### PR TITLE
Add shared api client and reusable data table

### DIFF
--- a/frontend/public/mock-api/portfolio-holdings.json
+++ b/frontend/public/mock-api/portfolio-holdings.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "hold-1",
+    "asset": "USDC Treasury Pool",
+    "vaultName": "Stellar RWA Yield Fund",
+    "symbol": "yvUSDC",
+    "shares": 1250.5,
+    "apy": 8.45,
+    "valueUsd": 1250.5,
+    "unrealizedGainUsd": 42.15,
+    "issuer": "Franklin Templeton",
+    "status": "active"
+  },
+  {
+    "id": "hold-2",
+    "asset": "Government Bond Basket",
+    "vaultName": "Sovereign Income Sleeve",
+    "symbol": "yvBOND",
+    "shares": 840.12,
+    "apy": 7.2,
+    "valueUsd": 894.41,
+    "unrealizedGainUsd": 25.22,
+    "issuer": "WisdomTree",
+    "status": "active"
+  },
+  {
+    "id": "hold-3",
+    "asset": "Short Duration Credit",
+    "vaultName": "Liquidity Ladder",
+    "symbol": "yvCASH",
+    "shares": 500.33,
+    "apy": 6.85,
+    "valueUsd": 512.9,
+    "unrealizedGainUsd": 11.48,
+    "issuer": "Circle Reserve",
+    "status": "pending"
+  },
+  {
+    "id": "hold-4",
+    "asset": "Tokenized T-Bills",
+    "vaultName": "USD Treasury Express",
+    "symbol": "yvUSTB",
+    "shares": 1380,
+    "apy": 5.95,
+    "valueUsd": 1404.32,
+    "unrealizedGainUsd": 19.77,
+    "issuer": "OpenEden",
+    "status": "active"
+  },
+  {
+    "id": "hold-5",
+    "asset": "Yield Bearing Cash",
+    "vaultName": "Prime Reserve Strategy",
+    "symbol": "yvPRIME",
+    "shares": 320.42,
+    "apy": 7.9,
+    "valueUsd": 337.08,
+    "unrealizedGainUsd": 9.66,
+    "issuer": "Hashnote",
+    "status": "active"
+  },
+  {
+    "id": "hold-6",
+    "asset": "EM Debt Blend",
+    "vaultName": "Global Carry Vault",
+    "symbol": "yvEMD",
+    "shares": 214.1,
+    "apy": 9.1,
+    "valueUsd": 228.55,
+    "unrealizedGainUsd": 14.07,
+    "issuer": "Templeton",
+    "status": "pending"
+  }
+]

--- a/frontend/public/mock-api/vault-summary.json
+++ b/frontend/public/mock-api/vault-summary.json
@@ -1,0 +1,20 @@
+{
+  "tvl": 12450800,
+  "apy": 8.45,
+  "participantCount": 1248,
+  "monthlyGrowthPct": 12.5,
+  "strategyStabilityPct": 99.9,
+  "assetLabel": "Sovereign Debt",
+  "exchangeRate": 1.084,
+  "networkFeeEstimate": "~0.00001 XLM",
+  "updatedAt": "2026-03-25T10:00:00.000Z",
+  "strategy": {
+    "id": "stellar-benji",
+    "name": "Franklin BENJI Connector",
+    "issuer": "Franklin Templeton",
+    "network": "Stellar",
+    "rpcUrl": "https://soroban-testnet.stellar.org",
+    "status": "active",
+    "description": "Connector strategy that routes vault yield updates from BENJI-issued tokenized money market exposure on Stellar."
+  }
+}

--- a/frontend/src/components/ApiStatusBanner.tsx
+++ b/frontend/src/components/ApiStatusBanner.tsx
@@ -1,0 +1,27 @@
+import type { ApiError } from "../lib/api";
+
+interface ApiStatusBannerProps {
+  error: ApiError;
+}
+
+const ApiStatusBanner: React.FC<ApiStatusBannerProps> = ({ error }) => {
+  return (
+    <div
+      role="alert"
+      className="glass-panel"
+      style={{
+        padding: "16px 18px",
+        marginBottom: "20px",
+        background: "rgba(255, 107, 107, 0.12)",
+        border: "1px solid rgba(255, 107, 107, 0.25)",
+      }}
+    >
+      <div style={{ fontWeight: 600, marginBottom: "4px" }}>Data unavailable</div>
+      <div style={{ color: "var(--text-secondary)", fontSize: "0.9rem" }}>
+        {error.userMessage}
+      </div>
+    </div>
+  );
+};
+
+export default ApiStatusBanner;

--- a/frontend/src/components/DataTable.tsx
+++ b/frontend/src/components/DataTable.tsx
@@ -1,0 +1,187 @@
+import type { KeyboardEvent, ReactNode } from "react";
+
+export type TableSortDirection = "asc" | "desc";
+
+export interface DataTableColumn<T> {
+  id: string;
+  header: string;
+  accessor?: (row: T) => ReactNode;
+  cell?: (row: T) => ReactNode;
+  sortable?: boolean;
+  width?: string;
+  align?: "left" | "center" | "right";
+}
+
+interface PaginationState {
+  page: number;
+  pageSize: number;
+  totalItems: number;
+  totalPages: number;
+}
+
+interface DataTableProps<T> {
+  columns: DataTableColumn<T>[];
+  rows: T[];
+  rowKey: (row: T) => string;
+  caption: string;
+  emptyMessage: string;
+  sortBy?: string;
+  sortDirection?: TableSortDirection;
+  onSortChange?: (columnId: string) => void;
+  pagination?: PaginationState;
+  onPageChange?: (page: number) => void;
+  renderRowDetails?: (row: T) => ReactNode;
+}
+
+function getCellAlignment(align: DataTableColumn<unknown>["align"]) {
+  if (align === "center") {
+    return "center";
+  }
+
+  if (align === "right") {
+    return "right";
+  }
+
+  return "left";
+}
+
+export function DataTable<T>({
+  columns,
+  rows,
+  rowKey,
+  caption,
+  emptyMessage,
+  sortBy,
+  sortDirection = "asc",
+  onSortChange,
+  pagination,
+  onPageChange,
+  renderRowDetails,
+}: DataTableProps<T>) {
+  const handleHeaderKeyDown = (
+    event: KeyboardEvent<HTMLButtonElement>,
+    columnId: string,
+  ) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      onSortChange?.(columnId);
+    }
+  };
+
+  return (
+    <div className="data-table-shell glass-panel">
+      <div className="data-table-scroll">
+        <table className="data-table">
+          <caption className="sr-only">{caption}</caption>
+          <thead>
+            <tr>
+              {columns.map((column) => {
+                const isSorted = sortBy === column.id;
+                const ariaSort = !column.sortable
+                  ? "none"
+                  : isSorted
+                    ? sortDirection === "asc"
+                      ? "ascending"
+                      : "descending"
+                    : "none";
+
+                return (
+                  <th
+                    key={column.id}
+                    scope="col"
+                    aria-sort={ariaSort}
+                    style={{
+                      width: column.width,
+                      textAlign: getCellAlignment(column.align),
+                    }}
+                  >
+                    {column.sortable ? (
+                      <button
+                        type="button"
+                        className="data-table-sort"
+                        onClick={() => onSortChange?.(column.id)}
+                        onKeyDown={(event) =>
+                          handleHeaderKeyDown(event, column.id)
+                        }
+                        aria-label={`Sort by ${column.header}`}
+                      >
+                        <span>{column.header}</span>
+                        <span className="data-table-sort-indicator" aria-hidden="true">
+                          {isSorted ? (sortDirection === "asc" ? "↑" : "↓") : "↕"}
+                        </span>
+                      </button>
+                    ) : (
+                      <span>{column.header}</span>
+                    )}
+                  </th>
+                );
+              })}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.length === 0 ? (
+              <tr>
+                <td colSpan={columns.length} className="data-table-empty">
+                  {emptyMessage}
+                </td>
+              </tr>
+            ) : (
+              rows.map((row) => (
+                <tr key={rowKey(row)} tabIndex={0} className="data-table-row">
+                  {columns.map((column, columnIndex) => {
+                    const content = column.cell
+                      ? column.cell(row)
+                      : column.accessor?.(row);
+
+                    return (
+                      <td
+                        key={column.id}
+                        data-label={column.header}
+                        style={{
+                          textAlign: getCellAlignment(column.align),
+                        }}
+                      >
+                        {content}
+                        {renderRowDetails && columnIndex === 0 && (
+                          <div className="data-table-mobile-detail">
+                            {renderRowDetails(row)}
+                          </div>
+                        )}
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {pagination && pagination.totalPages > 1 && (
+        <div className="data-table-pagination">
+          <div className="data-table-pagination-summary">
+            Page {pagination.page} of {pagination.totalPages}
+          </div>
+          <div className="data-table-pagination-actions">
+            <button
+              type="button"
+              className="btn btn-outline"
+              onClick={() => onPageChange?.(pagination.page - 1)}
+              disabled={pagination.page <= 1}
+            >
+              Previous
+            </button>
+            <button
+              type="button"
+              className="btn btn-outline"
+              onClick={() => onPageChange?.(pagination.page + 1)}
+              disabled={pagination.page >= pagination.totalPages}
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/VaultDashboard.test.tsx
+++ b/frontend/src/components/VaultDashboard.test.tsx
@@ -1,76 +1,137 @@
-import { render, screen, fireEvent, act } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import VaultDashboard from './VaultDashboard';
-import { VaultProvider } from '../context/VaultContext';
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import VaultDashboard from "./VaultDashboard";
+import { VaultProvider } from "../context/VaultContext";
 
-// Mock timer for setTimeout in handleTransaction
-vi.useFakeTimers();
+const mockSummary = {
+  tvl: 12450800,
+  apy: 8.45,
+  participantCount: 1248,
+  monthlyGrowthPct: 12.5,
+  strategyStabilityPct: 99.9,
+  assetLabel: "Sovereign Debt",
+  exchangeRate: 1.084,
+  networkFeeEstimate: "~0.00001 XLM",
+  updatedAt: "2026-03-25T10:00:00.000Z",
+  strategy: {
+    id: "stellar-benji",
+    name: "Franklin BENJI Connector",
+    issuer: "Franklin Templeton",
+    network: "Stellar",
+    rpcUrl: "https://soroban-testnet.stellar.org",
+    status: "active" as const,
+    description:
+      "Connector strategy that routes vault yield updates from BENJI-issued tokenized money market exposure on Stellar.",
+  },
+};
 
-describe('VaultDashboard', () => {
-    beforeEach(() => {
-        vi.clearAllMocks();
+function renderDashboard(walletAddress: string | null) {
+  return render(
+    <VaultProvider>
+      <VaultDashboard walletAddress={walletAddress} />
+    </VaultProvider>,
+  );
+}
+
+describe("VaultDashboard", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify(mockSummary), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders the connect overlay when wallet is not connected", async () => {
+    renderDashboard(null);
+
+    expect(screen.getByText(/Wallet Not Connected/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Please connect your Freighter wallet/i),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText(/Franklin BENJI Connector/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the dashboard when wallet is connected", async () => {
+    renderDashboard("GABC123");
+
+    expect(screen.queryByText(/Wallet Not Connected/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/Global RWA Yield Fund/i)).toBeInTheDocument();
+    expect(screen.getByText(/Current APY/i)).toBeInTheDocument();
+
+    expect(await screen.findByText(/Sovereign Debt/i)).toBeInTheDocument();
+  });
+
+  it("allows switching between deposit and withdraw tabs", async () => {
+    renderDashboard("GABC123");
+
+    expect(await screen.findByText(/Approve & Deposit/i)).toBeInTheDocument();
+
+    const depositTab = screen.getByText("Deposit");
+    const withdrawTab = screen.getByText("Withdraw");
+
+    fireEvent.click(withdrawTab);
+    expect(screen.getByText(/Amount to withdraw/i)).toBeInTheDocument();
+
+    fireEvent.click(depositTab);
+    expect(screen.getByText(/Amount to deposit/i)).toBeInTheDocument();
+  });
+
+  it("updates the amount input and processes a deposit", async () => {
+    renderDashboard("GABC123");
+
+    expect(await screen.findByText(/Approve & Deposit/i)).toBeInTheDocument();
+
+    vi.useFakeTimers();
+
+    const input = screen.getByPlaceholderText("0.00");
+    fireEvent.change(input, { target: { value: "100" } });
+    expect(input).toHaveValue(100);
+
+    const button = screen.getByText("Approve & Deposit");
+    fireEvent.click(button);
+
+    expect(
+      screen.getByText(/Processing Transaction.../i),
+    ).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
     });
 
-    it('renders the connect overlay when wallet is not connected', () => {
-        render(
-            <VaultProvider>
-                <VaultDashboard walletAddress={null} />
-            </VaultProvider>
-        );
-        expect(screen.getByText(/Wallet Not Connected/i)).toBeInTheDocument();
-        expect(screen.getByText(/Please connect your Freighter wallet/i)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Processing Transaction.../i),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("1350.50")).toBeInTheDocument();
+  });
+
+  it("shows a normalized API error message when data loading fails", async () => {
+    vi.useRealTimers();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new TypeError("Failed to fetch")),
+    );
+
+    renderDashboard("GABC123");
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("Data unavailable");
     });
-
-    it('renders the dashboard when wallet is connected', () => {
-        render(
-            <VaultProvider>
-                <VaultDashboard walletAddress="GABC123" />
-            </VaultProvider>
-        );
-        expect(screen.queryByText(/Wallet Not Connected/i)).not.toBeInTheDocument();
-        expect(screen.getByText(/Global RWA Yield Fund/i)).toBeInTheDocument();
-        expect(screen.getByText(/Current APY/i)).toBeInTheDocument();
-    });
-
-    it('allows switching between deposit and withdraw tabs', () => {
-        render(
-            <VaultProvider>
-                <VaultDashboard walletAddress="GABC123" />
-            </VaultProvider>
-        );
-        
-        const depositTab = screen.getByText('Deposit');
-        const withdrawTab = screen.getByText('Withdraw');
-
-        fireEvent.click(withdrawTab);
-        expect(screen.getByText(/Amount to withdraw/i)).toBeInTheDocument();
-
-        fireEvent.click(depositTab);
-        expect(screen.getByText(/Amount to deposit/i)).toBeInTheDocument();
-    });
-
-    it('updates the amount input and processes a deposit', async () => {
-        render(
-            <VaultProvider>
-                <VaultDashboard walletAddress="GABC123" />
-            </VaultProvider>
-        );
-        
-        const input = screen.getByPlaceholderText('0.00');
-        fireEvent.change(input, { target: { value: '100' } });
-        expect(input).toHaveValue(100);
-
-        const button = screen.getByText('Approve & Deposit');
-        fireEvent.click(button);
-
-        expect(screen.getByText(/Processing Transaction.../i)).toBeInTheDocument();
-
-        // Fast-forward time
-        act(() => {
-            vi.advanceTimersByTime(2000);
-        });
-
-        expect(screen.queryByText(/Processing Transaction.../i)).not.toBeInTheDocument();
-        expect(screen.getByText('1350.50')).toBeInTheDocument(); // 1250.50 + 100
-    });
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "We could not reach the server. Check your connection and try again.",
+    );
+  });
 });

--- a/frontend/src/components/VaultDashboard.tsx
+++ b/frontend/src/components/VaultDashboard.tsx
@@ -1,22 +1,23 @@
-import { useState } from 'react';
-import { TrendingUp, ShieldCheck, Wallet as WalletIcon, Activity } from 'lucide-react';
-import { benjiStrategy } from '../lib/strategy';
-import { hasCustomRpcConfig, networkConfig } from '../config/network';
-import { useVault } from '../context/VaultContext';
+import { useState } from "react";
+import { TrendingUp, ShieldCheck, Wallet as WalletIcon, Activity } from "lucide-react";
+import { hasCustomRpcConfig, networkConfig } from "../config/network";
+import { useVault } from "../context/VaultContext";
+import ApiStatusBanner from "./ApiStatusBanner";
 
 interface VaultDashboardProps {
-    walletAddress: string | null;
+  walletAddress: string | null;
 }
 
 const VaultDashboard: React.FC<VaultDashboardProps> = ({ walletAddress }) => {
-    const { formattedTvl, formattedApy } = useVault();
-    const [activeTab, setActiveTab] = useState<'deposit' | 'withdraw'>('deposit');
-    const [amount, setAmount] = useState('');
+    const { formattedTvl, formattedApy, summary, error, isLoading } = useVault();
+    const [activeTab, setActiveTab] = useState<"deposit" | "withdraw">("deposit");
+    const [amount, setAmount] = useState("");
     const [isProcessing, setIsProcessing] = useState(false);
-    const [fakeBalance, setFakeBalance] = useState(1250.50);
+    const [fakeBalance, setFakeBalance] = useState(1250.5);
 
     const yieldRate = formattedApy;
     const tvl = formattedTvl;
+    const strategy = summary.strategy;
 
     const handleTransaction = () => {
         if (!walletAddress || !amount || isNaN(Number(amount))) return;
@@ -25,9 +26,9 @@ const VaultDashboard: React.FC<VaultDashboardProps> = ({ walletAddress }) => {
         // Simulate transaction delay
         setTimeout(() => {
             const value = Number(amount);
-            if (activeTab === 'deposit') setFakeBalance(prev => prev + value);
-            if (activeTab === 'withdraw') setFakeBalance(prev => Math.max(0, prev - value));
-            setAmount('');
+            if (activeTab === "deposit") setFakeBalance(prev => prev + value);
+            if (activeTab === "withdraw") setFakeBalance(prev => Math.max(0, prev - value));
+            setAmount("");
             setIsProcessing(false);
         }, 2000);
     };
@@ -38,6 +39,8 @@ const VaultDashboard: React.FC<VaultDashboardProps> = ({ walletAddress }) => {
             <div style={{ flex: '1 1 500px' }} className="flex flex-col gap-lg">
 
                 <div className="glass-panel" style={{ padding: '32px' }}>
+                    {error && <ApiStatusBanner error={error} />}
+
                     <div className="flex justify-between items-center" style={{ marginBottom: '24px' }}>
                         <div>
                             <h2 style={{ fontSize: '1.5rem', marginBottom: '4px' }}>Global RWA Yield Fund</h2>
@@ -60,8 +63,8 @@ const VaultDashboard: React.FC<VaultDashboardProps> = ({ walletAddress }) => {
                             <div style={{ color: 'var(--text-secondary)', fontSize: '0.85rem', marginBottom: '4px', display: 'flex', alignItems: 'center', gap: '6px' }}>
                                 Total Value Locked
                                 <span className="flex items-center gap-xs" style={{ color: 'var(--accent-cyan)', fontSize: '0.7rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em' }}>
-                                    <Activity size={10} className="animate-pulse" />
-                                    Live
+                                    <Activity size={10} className={isLoading ? "animate-pulse" : undefined} />
+                                    {isLoading ? "Syncing" : "Live"}
                                 </span>
                             </div>
                             <div style={{ fontSize: '1.25rem', fontFamily: 'var(--font-display)', fontWeight: 600 }}>{tvl}</div>
@@ -70,7 +73,7 @@ const VaultDashboard: React.FC<VaultDashboardProps> = ({ walletAddress }) => {
                             <div style={{ color: 'var(--text-secondary)', fontSize: '0.85rem', marginBottom: '4px' }}>Underlying Asset</div>
                             <div className="flex items-center gap-sm">
                                 <ShieldCheck size={16} color="var(--accent-cyan)" />
-                                <span style={{ fontSize: '1.1rem', fontWeight: 500 }}>Sovereign Debt</span>
+                                <span style={{ fontSize: '1.1rem', fontWeight: 500 }}>{summary.assetLabel}</span>
                             </div>
                         </div>
                     </div>
@@ -85,7 +88,7 @@ const VaultDashboard: React.FC<VaultDashboardProps> = ({ walletAddress }) => {
                             Yields are algorithmically harvested and auto-compounded daily into the vault token price.
                         </p>
                         <div style={{ marginTop: '12px', color: 'var(--text-secondary)', fontSize: '0.82rem' }}>
-                            Strategy: <span style={{ color: 'var(--text-primary)' }}>{benjiStrategy.name}</span> ({benjiStrategy.issuer})
+                            Strategy: <span style={{ color: 'var(--text-primary)' }}>{strategy.name}</span> ({strategy.issuer})
                         </div>
                         <div style={{ marginTop: '8px', color: 'var(--text-secondary)', fontSize: '0.78rem' }}>
                             RPC: {hasCustomRpcConfig ? 'Custom' : 'Default'} - {networkConfig.rpcUrl}
@@ -204,19 +207,21 @@ const VaultDashboard: React.FC<VaultDashboardProps> = ({ walletAddress }) => {
                     </div>
 
                     <div className="glass-panel" style={{ padding: '16px', background: 'var(--bg-muted)', marginBottom: '24px' }}>
-                        <div className="flex justify-between items-center" style={{ marginBottom: '8px' }}>
-                            <span style={{ color: 'var(--text-secondary)', fontSize: '0.9rem' }}>Exchange Rate</span>
-                            <span style={{ fontSize: '0.9rem', fontWeight: 500 }}>1 yvUSDC = 1.084 USDC</span>
-                        </div>
                         <div className="flex justify-between items-center">
-                            <span style={{ color: 'var(--text-secondary)', fontSize: '0.9rem' }}>Network Fee</span>
-                            <span style={{ fontSize: '0.9rem', fontWeight: 500 }}>~0.00001 XLM</span>
-                        </div>
-                        <div className="flex justify-between items-center" style={{ marginTop: '8px' }}>
                             <span style={{ color: 'var(--text-secondary)', fontSize: '0.9rem' }}>BENJI Strategy</span>
                             <span style={{ fontSize: '0.9rem', fontWeight: 500 }}>
-                                {benjiStrategy.status === 'active' ? 'Active' : 'Inactive'}
+                                {strategy.status === 'active' ? 'Active' : 'Inactive'}
                             </span>
+                        </div>
+                        <div className="flex justify-between items-center" style={{ marginTop: '8px' }}>
+                            <span style={{ color: 'var(--text-secondary)', fontSize: '0.9rem' }}>Exchange Rate</span>
+                            <span style={{ fontSize: '0.9rem', fontWeight: 500 }}>
+                                1 yvUSDC = {summary.exchangeRate.toFixed(3)} USDC
+                            </span>
+                        </div>
+                        <div className="flex justify-between items-center" style={{ marginTop: '8px' }}>
+                            <span style={{ color: 'var(--text-secondary)', fontSize: '0.9rem' }}>Network Fee</span>
+                            <span style={{ fontSize: '0.9rem', fontWeight: 500 }}>{summary.networkFeeEstimate}</span>
                         </div>
                     </div>
 

--- a/frontend/src/components/WalletConnect.test.tsx
+++ b/frontend/src/components/WalletConnect.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { ComponentProps } from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import WalletConnect from './WalletConnect';
 import * as freighter from '@stellar/freighter-api';
@@ -14,9 +15,11 @@ vi.mock('@stellar/freighter-api', () => ({
 // Mock framer-motion to avoid animation issues in tests
 vi.mock('framer-motion', () => ({
     motion: {
-        div: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+        div: ({ children, ...props }: ComponentProps<'div'>) => <div {...props}>{children}</div>,
     },
 }));
+
+const mockedFreighter = vi.mocked(freighter);
 
 describe('WalletConnect', () => {
     const mockOnConnect = vi.fn();
@@ -27,7 +30,7 @@ describe('WalletConnect', () => {
     });
 
     it('renders the connect button when no wallet is connected', async () => {
-        (freighter.isAllowed as any).mockResolvedValue(false);
+        mockedFreighter.isAllowed.mockResolvedValue({ isAllowed: false });
         render(
             <WalletConnect 
                 walletAddress={null} 
@@ -40,9 +43,11 @@ describe('WalletConnect', () => {
     });
 
     it('calls onConnect when manually connected via button', async () => {
-        (freighter.isAllowed as any).mockResolvedValueOnce(false).mockResolvedValueOnce(true);
-        (freighter.setAllowed as any).mockResolvedValue(true);
-        (freighter.getAddress as any).mockResolvedValue({ address: 'GABC123' });
+        mockedFreighter.isAllowed
+            .mockResolvedValueOnce({ isAllowed: false })
+            .mockResolvedValueOnce({ isAllowed: true });
+        mockedFreighter.setAllowed.mockResolvedValue({ isAllowed: true });
+        mockedFreighter.getAddress.mockResolvedValue({ address: 'GABC123' });
 
         render(
             <WalletConnect 

--- a/frontend/src/components/WalletConnect.tsx
+++ b/frontend/src/components/WalletConnect.tsx
@@ -17,7 +17,8 @@ const WalletConnect: React.FC<WalletConnectProps> = ({ walletAddress, onConnect,
     useEffect(() => {
         const checkConnection = async () => {
             try {
-                if (await isAllowed()) {
+                const allowed = await isAllowed();
+                if (allowed.isAllowed) {
                     const userInfo = await getAddress();
                     if (userInfo.address) {
                         onConnect(userInfo.address);
@@ -35,7 +36,8 @@ const WalletConnect: React.FC<WalletConnectProps> = ({ walletAddress, onConnect,
         setError(null);
         try {
             await setAllowed();
-            if (await isAllowed()) {
+            const allowed = await isAllowed();
+            if (allowed.isAllowed) {
                 const userInfo = await getAddress();
                 if (userInfo.address) {
                     onConnect(userInfo.address);

--- a/frontend/src/context/ThemeContext.tsx
+++ b/frontend/src/context/ThemeContext.tsx
@@ -32,6 +32,7 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     );
 };
 
+// eslint-disable-next-line react-refresh/only-export-components
 export const useTheme = () => {
     const context = useContext(ThemeContext);
     if (!context) {

--- a/frontend/src/context/VaultContext.tsx
+++ b/frontend/src/context/VaultContext.tsx
@@ -1,65 +1,134 @@
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+import type { ApiError } from "../lib/api";
+import { normalizeApiError, subscribeToApiTelemetry } from "../lib/api";
+import { getVaultSummary, type VaultSummary } from "../lib/vaultApi";
+import { networkConfig } from "../config/network";
 
 interface VaultContextType {
-    tvl: number;
-    apy: number;
-    formattedTvl: string;
-    formattedApy: string;
-    lastUpdate: Date;
+  summary: VaultSummary;
+  tvl: number;
+  apy: number;
+  formattedTvl: string;
+  formattedApy: string;
+  lastUpdate: Date;
+  isLoading: boolean;
+  error: ApiError | null;
+  refresh: () => Promise<void>;
 }
+
+const DEFAULT_SUMMARY: VaultSummary = {
+  tvl: 12450800,
+  apy: 8.45,
+  participantCount: 1248,
+  monthlyGrowthPct: 12.5,
+  strategyStabilityPct: 99.9,
+  assetLabel: "Sovereign Debt",
+  exchangeRate: 1.084,
+  networkFeeEstimate: "~0.00001 XLM",
+  updatedAt: "2026-03-25T10:00:00.000Z",
+  strategy: {
+    id: "stellar-benji",
+    name: "Franklin BENJI Connector",
+    issuer: "Franklin Templeton",
+    network: "Stellar",
+    rpcUrl: networkConfig.rpcUrl,
+    status: "active",
+    description:
+      "Connector strategy that routes vault yield updates from BENJI-issued tokenized money market exposure on Stellar.",
+  },
+};
 
 const VaultContext = createContext<VaultContextType | undefined>(undefined);
 
-const BASE_TVL = 12450800;
-const BASE_APY = 8.45;
+export const VaultProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [summary, setSummary] = useState(DEFAULT_SUMMARY);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<ApiError | null>(null);
+  const [lastUpdate, setLastUpdate] = useState(
+    new Date(DEFAULT_SUMMARY.updatedAt),
+  );
 
-export const VaultProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-    const [tvl, setTvl] = useState(BASE_TVL);
-    const [apy, setApy] = useState(BASE_APY);
-    const [lastUpdate, setLastUpdate] = useState(new Date());
+  const refresh = useCallback(async () => {
+    setIsLoading(true);
 
-    useEffect(() => {
-        const interval = setInterval(() => {
-            // Simulate TVL fluctuation (between -500 and +1000)
-            const fluctuation = (Math.random() * 1500) - 500;
-            setTvl(prev => {
-                const next = prev + fluctuation;
-                // Keep it within a reasonable range of BASE_TVL
-                if (next < BASE_TVL * 0.95 || next > BASE_TVL * 1.05) return prev;
-                return next;
-            });
+    try {
+      const nextSummary = await getVaultSummary();
+      setSummary({
+        ...nextSummary,
+        strategy: {
+          ...nextSummary.strategy,
+          rpcUrl: networkConfig.rpcUrl,
+        },
+      });
+      setLastUpdate(new Date(nextSummary.updatedAt));
+      setError(null);
+    } catch (unknownError) {
+      setError(normalizeApiError(unknownError));
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
 
-            // Simulate minor APY fluctuation (+/- 0.01)
-            setApy(prev => {
-                const next = prev + (Math.random() * 0.02 - 0.01);
-                return Math.max(5, Math.min(15, next));
-            });
+  useEffect(() => {
+    void refresh();
 
-            setLastUpdate(new Date());
-        }, 5000); // Update every 5 seconds
+    const interval = window.setInterval(() => {
+      void refresh();
+    }, 30000);
 
-        return () => clearInterval(interval);
-    }, []);
+    return () => window.clearInterval(interval);
+  }, [refresh]);
 
-    const formattedTvl = new Intl.NumberFormat('en-US', {
-        style: 'currency',
-        currency: 'USD',
-        maximumFractionDigits: 0
-    }).format(tvl);
+  useEffect(() => {
+    const unsubscribe = subscribeToApiTelemetry((event) => {
+      if (event.type === "error") {
+        console.error("[api]", event.error);
+      }
+    });
 
-    const formattedApy = `${apy.toFixed(2)}%`;
+    return unsubscribe;
+  }, []);
 
-    return (
-        <VaultContext.Provider value={{ tvl, apy, formattedTvl, formattedApy, lastUpdate }}>
-            {children}
-        </VaultContext.Provider>
-    );
+  const formattedTvl = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  }).format(summary.tvl);
+
+  const formattedApy = `${summary.apy.toFixed(2)}%`;
+
+  return (
+    <VaultContext.Provider
+      value={{
+        summary,
+        tvl: summary.tvl,
+        apy: summary.apy,
+        formattedTvl,
+        formattedApy,
+        lastUpdate,
+        isLoading,
+        error,
+        refresh,
+      }}
+    >
+      {children}
+    </VaultContext.Provider>
+  );
 };
 
+// eslint-disable-next-line react-refresh/only-export-components
 export const useVault = () => {
-    const context = useContext(VaultContext);
-    if (!context) {
-        throw new Error('useVault must be used within a VaultProvider');
-    }
-    return context;
+  const context = useContext(VaultContext);
+  if (!context) {
+    throw new Error("useVault must be used within a VaultProvider");
+  }
+  return context;
 };

--- a/frontend/src/hooks/useClientDataTable.ts
+++ b/frontend/src/hooks/useClientDataTable.ts
@@ -1,0 +1,57 @@
+import { useMemo } from "react";
+import type { DataTableState } from "./useDataTableState";
+
+export interface ClientTableConfig<T> {
+  rows: T[];
+  state: DataTableState;
+  getSearchValue: (row: T) => string;
+  getSortValue: (row: T, columnId: string) => string | number;
+}
+
+export function useClientDataTable<T>({
+  rows,
+  state,
+  getSearchValue,
+  getSortValue,
+}: ClientTableConfig<T>) {
+  const filteredRows = useMemo(() => {
+    const search = state.search.trim().toLowerCase();
+    if (!search) {
+      return rows;
+    }
+
+    return rows.filter((row) =>
+      getSearchValue(row).toLowerCase().includes(search),
+    );
+  }, [getSearchValue, rows, state.search]);
+
+  const sortedRows = useMemo(() => {
+    return [...filteredRows].sort((left, right) => {
+      const leftValue = getSortValue(left, state.sortBy);
+      const rightValue = getSortValue(right, state.sortBy);
+
+      if (leftValue === rightValue) {
+        return 0;
+      }
+
+      if (leftValue > rightValue) {
+        return state.sortDirection === "asc" ? 1 : -1;
+      }
+
+      return state.sortDirection === "asc" ? -1 : 1;
+    });
+  }, [filteredRows, getSortValue, state.sortBy, state.sortDirection]);
+
+  const totalItems = sortedRows.length;
+  const totalPages = Math.max(1, Math.ceil(totalItems / state.pageSize));
+  const safePage = Math.min(state.page, totalPages);
+  const startIndex = (safePage - 1) * state.pageSize;
+  const paginatedRows = sortedRows.slice(startIndex, startIndex + state.pageSize);
+
+  return {
+    rows: paginatedRows,
+    totalItems,
+    totalPages,
+    page: safePage,
+  };
+}

--- a/frontend/src/hooks/useDataTableState.ts
+++ b/frontend/src/hooks/useDataTableState.ts
@@ -1,0 +1,76 @@
+import { useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
+import type { TableSortDirection } from "../components/DataTable";
+
+export interface DataTableState {
+  search: string;
+  sortBy: string;
+  sortDirection: TableSortDirection;
+  page: number;
+  pageSize: number;
+}
+
+interface UseDataTableStateOptions {
+  defaultSearch?: string;
+  defaultSortBy: string;
+  defaultSortDirection?: TableSortDirection;
+  defaultPage?: number;
+  defaultPageSize?: number;
+}
+
+export function useDataTableState(options: UseDataTableStateOptions) {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const state = useMemo<DataTableState>(() => {
+    const pageValue = Number(searchParams.get("page") ?? options.defaultPage ?? 1);
+    const pageSizeValue = Number(
+      searchParams.get("pageSize") ?? options.defaultPageSize ?? 5,
+    );
+    const sortDirection = searchParams.get("direction");
+
+    return {
+      search: searchParams.get("search") ?? options.defaultSearch ?? "",
+      sortBy: searchParams.get("sortBy") ?? options.defaultSortBy,
+      sortDirection:
+        sortDirection === "asc" || sortDirection === "desc"
+          ? sortDirection
+          : options.defaultSortDirection ?? "asc",
+      page: Number.isFinite(pageValue) && pageValue > 0 ? pageValue : 1,
+      pageSize:
+        Number.isFinite(pageSizeValue) && pageSizeValue > 0
+          ? pageSizeValue
+          : options.defaultPageSize ?? 5,
+    };
+  }, [options.defaultPage, options.defaultPageSize, options.defaultSearch, options.defaultSortBy, options.defaultSortDirection, searchParams]);
+
+  const updateState = (nextState: Partial<DataTableState>) => {
+    const mergedState = {
+      ...state,
+      ...nextState,
+    };
+
+    const nextParams = new URLSearchParams(searchParams);
+
+    nextParams.set("search", mergedState.search);
+    nextParams.set("sortBy", mergedState.sortBy);
+    nextParams.set("direction", mergedState.sortDirection);
+    nextParams.set("page", String(mergedState.page));
+    nextParams.set("pageSize", String(mergedState.pageSize));
+
+    setSearchParams(nextParams, { replace: true });
+  };
+
+  return {
+    state,
+    setSearch: (search: string) => updateState({ search, page: 1 }),
+    setSort: (sortBy: string) =>
+      updateState({
+        sortBy,
+        sortDirection:
+          state.sortBy === sortBy && state.sortDirection === "asc" ? "desc" : "asc",
+        page: 1,
+      }),
+    setPage: (page: number) => updateState({ page }),
+    setPageSize: (pageSize: number) => updateState({ pageSize, page: 1 }),
+  };
+}

--- a/frontend/src/hooks/useServerDataTable.ts
+++ b/frontend/src/hooks/useServerDataTable.ts
@@ -1,0 +1,21 @@
+import { useMemo } from "react";
+import type { DataTableState } from "./useDataTableState";
+
+interface ServerDataTableOptions {
+  state: DataTableState;
+}
+
+export function useServerDataTable({ state }: ServerDataTableOptions) {
+  return useMemo(
+    () => ({
+      query: {
+        search: state.search,
+        sortBy: state.sortBy,
+        direction: state.sortDirection,
+        page: state.page,
+        pageSize: state.pageSize,
+      },
+    }),
+    [state.page, state.pageSize, state.search, state.sortBy, state.sortDirection],
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -279,3 +279,192 @@ button {
   font-weight: 600;
   font-size: 0.9rem;
 }
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.portfolio-toolbar {
+  display: flex;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+}
+
+.portfolio-toolbar-controls {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  align-items: flex-end;
+}
+
+.portfolio-select {
+  width: 100%;
+  background: transparent;
+  border: none;
+  color: var(--text-primary);
+  padding: 12px 0;
+  outline: none;
+  font-size: 1rem;
+}
+
+.data-table-shell {
+  overflow: hidden;
+}
+
+.data-table-scroll {
+  overflow-x: auto;
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.data-table th,
+.data-table td {
+  padding: 16px 18px;
+  border-bottom: 1px solid var(--border-glass);
+  vertical-align: top;
+}
+
+.data-table th {
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.data-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.data-table-row {
+  outline: none;
+}
+
+.data-table-row:focus {
+  background: var(--bg-surface-hover);
+}
+
+.data-table-sort {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+}
+
+.data-table-sort:focus-visible,
+.data-table-pagination-actions .btn:focus-visible,
+.portfolio-select:focus-visible,
+.input-field:focus-visible {
+  outline: 2px solid var(--accent-cyan);
+  outline-offset: 2px;
+}
+
+.data-table-sort-indicator {
+  color: var(--accent-cyan);
+  font-size: 0.95rem;
+}
+
+.data-table-empty {
+  text-align: center;
+  color: var(--text-secondary);
+}
+
+.data-table-pagination {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: center;
+  padding: 16px 18px 18px;
+  border-top: 1px solid var(--border-glass);
+  flex-wrap: wrap;
+}
+
+.data-table-pagination-summary {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.data-table-pagination-actions {
+  display: flex;
+  gap: 12px;
+}
+
+.data-table-pagination-actions .btn[disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.data-table-mobile-detail {
+  display: none;
+}
+
+.portfolio-row-meta {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+  color: var(--text-secondary);
+  font-size: 0.82rem;
+}
+
+@media (max-width: 768px) {
+  .data-table-scroll {
+    overflow-x: visible;
+  }
+
+  .data-table thead {
+    display: none;
+  }
+
+  .data-table,
+  .data-table tbody,
+  .data-table tr,
+  .data-table td {
+    display: block;
+    width: 100%;
+  }
+
+  .data-table-row {
+    padding: 16px 18px;
+    border-bottom: 1px solid var(--border-glass);
+  }
+
+  .data-table-row:last-child {
+    border-bottom: none;
+  }
+
+  .data-table td {
+    border-bottom: none;
+    padding: 8px 0;
+    text-align: left !important;
+  }
+
+  .data-table td::before {
+    content: attr(data-label);
+    display: block;
+    color: var(--text-secondary);
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 4px;
+  }
+
+  .data-table-mobile-detail {
+    display: block;
+  }
+}

--- a/frontend/src/lib/api/client.test.ts
+++ b/frontend/src/lib/api/client.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ApiError,
+  createApiClient,
+  subscribeToApiTelemetry,
+  type ApiTelemetryEvent,
+} from ".";
+
+describe("ApiClient", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("retries transient GET failures with backoff and emits telemetry", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ message: "temporarily unavailable" }), {
+          status: 503,
+          statusText: "Service Unavailable",
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const events: ApiTelemetryEvent[] = [];
+    const unsubscribe = subscribeToApiTelemetry((event) => {
+      events.push(event);
+    });
+
+    const client = createApiClient({ baseUrl: "http://localhost" });
+    const request = client.get<{ ok: boolean }>("/health");
+
+    await vi.runAllTimersAsync();
+
+    await expect(request).resolves.toEqual({ ok: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(events.some((event) => event.type === "retry")).toBe(true);
+
+    unsubscribe();
+  });
+
+  it("does not retry non-idempotent requests", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: "bad gateway" }), {
+        status: 502,
+        statusText: "Bad Gateway",
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = createApiClient({ baseUrl: "http://localhost" });
+
+    await expect(
+      client.post("/orders", { body: { amount: 1 } }),
+    ).rejects.toBeInstanceOf(ApiError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("normalizes terminal HTTP errors", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ error: "bad request" }), {
+          status: 400,
+          statusText: "Bad Request",
+          headers: { "content-type": "application/json", "x-trace-id": "trace-123" },
+        }),
+      ),
+    );
+
+    const client = createApiClient({ baseUrl: "http://localhost" });
+
+    await expect(client.get("/vault")).rejects.toMatchObject({
+      code: "HTTP_ERROR",
+      status: 400,
+      traceId: "trace-123",
+      userMessage:
+        "We could not complete that request. Please review your input and try again.",
+    });
+  });
+});

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -1,0 +1,306 @@
+import { ApiError, normalizeApiError, type NormalizeApiErrorOptions } from "./error";
+import { emitApiTelemetry } from "./telemetry";
+
+type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+
+export interface RetryOptions {
+  attempts?: number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+}
+
+export interface ApiRequestOptions extends Omit<RequestInit, "body" | "method"> {
+  method?: HttpMethod;
+  query?: Record<string, string | number | boolean | null | undefined>;
+  body?: BodyInit | object | null;
+  headers?: HeadersInit;
+  retry?: RetryOptions | false;
+}
+
+export interface ApiRequestContext
+  extends Omit<ApiRequestOptions, "body" | "method"> {
+  method: HttpMethod;
+  body?: BodyInit | null;
+  url: string;
+}
+
+export interface ApiResponseContext<T> {
+  request: ApiRequestContext;
+  response: Response;
+  data: T;
+}
+
+interface ApiClientConfig {
+  baseUrl?: string;
+  headers?: HeadersInit;
+}
+
+type RequestInterceptor = (
+  request: ApiRequestContext,
+) => ApiRequestContext | Promise<ApiRequestContext>;
+
+type ResponseInterceptor = <T>(
+  context: ApiResponseContext<T>,
+) => ApiResponseContext<T> | Promise<ApiResponseContext<T>>;
+
+type ErrorInterceptor = (
+  error: ApiError,
+  request: ApiRequestContext,
+) => ApiError | Promise<ApiError>;
+
+const DEFAULT_RETRY_OPTIONS: Required<RetryOptions> = {
+  attempts: 3,
+  baseDelayMs: 250,
+  maxDelayMs: 2000,
+};
+
+async function parseResponseData<T>(response: Response): Promise<T> {
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  const contentType = response.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    return (await response.json()) as T;
+  }
+
+  return (await response.text()) as T;
+}
+
+function buildUrl(baseUrl: string | undefined, path: string, query?: ApiRequestOptions["query"]) {
+  const url = new URL(path, baseUrl ?? window.location.origin);
+
+  if (query) {
+    Object.entries(query).forEach(([key, value]) => {
+      if (value === undefined || value === null) {
+        return;
+      }
+
+      url.searchParams.set(key, String(value));
+    });
+  }
+
+  return url.toString();
+}
+
+function isJsonBody(body: ApiRequestOptions["body"]): body is object {
+  return !!body && typeof body === "object" && !(body instanceof FormData) && !(body instanceof URLSearchParams) && !(body instanceof Blob);
+}
+
+function createRequestContext(
+  baseConfig: ApiClientConfig,
+  path: string,
+  options: ApiRequestOptions = {},
+): ApiRequestContext {
+  const method = options.method ?? "GET";
+  const headers = new Headers(baseConfig.headers);
+
+  new Headers(options.headers).forEach((value, key) => {
+    headers.set(key, value);
+  });
+
+  let body: BodyInit | null | undefined = null;
+  if (options.body === undefined || options.body === null) {
+    body = null;
+  } else if (isJsonBody(options.body)) {
+    headers.set("content-type", "application/json");
+    body = JSON.stringify(options.body);
+  } else {
+    body = options.body;
+  }
+
+  return {
+    ...options,
+    method,
+    headers,
+    body,
+    url: buildUrl(baseConfig.baseUrl, path, options.query),
+  };
+}
+
+function getRetryOptions(request: ApiRequestContext): Required<RetryOptions> | null {
+  if (request.retry === false) {
+    return null;
+  }
+
+  return {
+    attempts: request.retry?.attempts ?? DEFAULT_RETRY_OPTIONS.attempts,
+    baseDelayMs: request.retry?.baseDelayMs ?? DEFAULT_RETRY_OPTIONS.baseDelayMs,
+    maxDelayMs: request.retry?.maxDelayMs ?? DEFAULT_RETRY_OPTIONS.maxDelayMs,
+  };
+}
+
+function shouldRetry(request: ApiRequestContext, error: ApiError, attempt: number) {
+  const retryOptions = getRetryOptions(request);
+  if (!retryOptions) {
+    return false;
+  }
+
+  const isSafeMethod = request.method === "GET" || request.method === "DELETE";
+  if (!isSafeMethod) {
+    return false;
+  }
+
+  return error.retryable && attempt < retryOptions.attempts;
+}
+
+function getRetryDelay(request: ApiRequestContext, attempt: number) {
+  const retryOptions = getRetryOptions(request) ?? DEFAULT_RETRY_OPTIONS;
+  const exponentialDelay = retryOptions.baseDelayMs * 2 ** (attempt - 1);
+  const jitter = Math.round(Math.random() * 100);
+  return Math.min(exponentialDelay + jitter, retryOptions.maxDelayMs);
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => window.setTimeout(resolve, ms));
+}
+
+async function buildApiError(
+  error: unknown,
+  request: ApiRequestContext,
+  options: NormalizeApiErrorOptions = {},
+) {
+  return normalizeApiError(error, {
+    ...options,
+    method: request.method,
+    url: request.url,
+  });
+}
+
+export class ApiClient {
+  private readonly baseConfig: ApiClientConfig;
+  private readonly requestInterceptors: RequestInterceptor[] = [];
+  private readonly responseInterceptors: ResponseInterceptor[] = [];
+  private readonly errorInterceptors: ErrorInterceptor[] = [];
+
+  constructor(config: ApiClientConfig = {}) {
+    this.baseConfig = config;
+  }
+
+  useRequest(interceptor: RequestInterceptor) {
+    this.requestInterceptors.push(interceptor);
+    return () => {
+      const index = this.requestInterceptors.indexOf(interceptor);
+      this.requestInterceptors.splice(index, 1);
+    };
+  }
+
+  useResponse(interceptor: ResponseInterceptor) {
+    this.responseInterceptors.push(interceptor);
+    return () => {
+      const index = this.responseInterceptors.indexOf(interceptor);
+      this.responseInterceptors.splice(index, 1);
+    };
+  }
+
+  useError(interceptor: ErrorInterceptor) {
+    this.errorInterceptors.push(interceptor);
+    return () => {
+      const index = this.errorInterceptors.indexOf(interceptor);
+      this.errorInterceptors.splice(index, 1);
+    };
+  }
+
+  async request<T>(path: string, options: ApiRequestOptions = {}): Promise<T> {
+    let request = createRequestContext(this.baseConfig, path, options);
+
+    for (const interceptor of this.requestInterceptors) {
+      request = await interceptor(request);
+    }
+
+    let attempt = 0;
+
+    while (true) {
+      attempt += 1;
+      const startedAt = performance.now();
+
+      emitApiTelemetry({
+        type: "request",
+        method: request.method,
+        url: request.url,
+        attempt,
+      });
+
+      try {
+        const response = await fetch(request.url, request);
+        const durationMs = Math.round(performance.now() - startedAt);
+
+        if (!response.ok) {
+          const details = await parseResponseData<unknown>(response).catch(() => undefined);
+          throw await buildApiError(undefined, request, {
+            status: response.status,
+            statusText: response.statusText,
+            details,
+            traceId: response.headers.get("x-trace-id") ?? undefined,
+          });
+        }
+
+        let context: ApiResponseContext<T> = {
+          request,
+          response,
+          data: await parseResponseData<T>(response),
+        };
+
+        for (const interceptor of this.responseInterceptors) {
+          context = await interceptor(context);
+        }
+
+        emitApiTelemetry({
+          type: "success",
+          method: request.method,
+          url: request.url,
+          attempt,
+          durationMs,
+          status: response.status,
+        });
+
+        return context.data;
+      } catch (unknownError) {
+        let apiError = await buildApiError(unknownError, request);
+
+        for (const interceptor of this.errorInterceptors) {
+          apiError = await interceptor(apiError, request);
+        }
+
+        const durationMs = Math.round(performance.now() - startedAt);
+
+        if (shouldRetry(request, apiError, attempt)) {
+          const delayMs = getRetryDelay(request, attempt);
+          emitApiTelemetry({
+            type: "retry",
+            method: request.method,
+            url: request.url,
+            attempt,
+            delayMs,
+            reason: apiError.code,
+          });
+          await sleep(delayMs);
+          continue;
+        }
+
+        emitApiTelemetry({
+          type: "error",
+          method: request.method,
+          url: request.url,
+          attempt,
+          durationMs,
+          error: apiError,
+        });
+
+        throw apiError;
+      }
+    }
+  }
+
+  get<T>(path: string, options: Omit<ApiRequestOptions, "method"> = {}) {
+    return this.request<T>(path, { ...options, method: "GET" });
+  }
+
+  post<T>(path: string, options: Omit<ApiRequestOptions, "method"> = {}) {
+    return this.request<T>(path, { ...options, method: "POST" });
+  }
+}
+
+export function createApiClient(config: ApiClientConfig = {}) {
+  return new ApiClient(config);
+}

--- a/frontend/src/lib/api/error.ts
+++ b/frontend/src/lib/api/error.ts
@@ -1,0 +1,158 @@
+export type ApiErrorCode =
+  | "NETWORK_ERROR"
+  | "TIMEOUT"
+  | "ABORTED"
+  | "HTTP_ERROR"
+  | "INVALID_RESPONSE"
+  | "UNKNOWN_ERROR";
+
+export interface ApiErrorMetadata {
+  code: ApiErrorCode;
+  message: string;
+  userMessage: string;
+  retryable: boolean;
+  status?: number;
+  statusText?: string;
+  url?: string;
+  method?: string;
+  traceId?: string;
+  details?: unknown;
+  cause?: unknown;
+}
+
+export class ApiError extends Error {
+  readonly code: ApiErrorCode;
+  readonly userMessage: string;
+  readonly retryable: boolean;
+  readonly status?: number;
+  readonly statusText?: string;
+  readonly url?: string;
+  readonly method?: string;
+  readonly traceId?: string;
+  readonly details?: unknown;
+  override readonly cause?: unknown;
+
+  constructor(metadata: ApiErrorMetadata) {
+    super(metadata.message);
+    this.name = "ApiError";
+    this.code = metadata.code;
+    this.userMessage = metadata.userMessage;
+    this.retryable = metadata.retryable;
+    this.status = metadata.status;
+    this.statusText = metadata.statusText;
+    this.url = metadata.url;
+    this.method = metadata.method;
+    this.traceId = metadata.traceId;
+    this.details = metadata.details;
+    this.cause = metadata.cause;
+  }
+}
+
+export interface NormalizeApiErrorOptions {
+  status?: number;
+  statusText?: string;
+  url?: string;
+  method?: string;
+  details?: unknown;
+  traceId?: string;
+}
+
+const DEFAULT_USER_MESSAGE =
+  "Something went wrong while loading data. Please try again.";
+
+const RETRYABLE_STATUS_CODES = new Set([408, 425, 429, 500, 502, 503, 504]);
+
+export function isApiError(error: unknown): error is ApiError {
+  return error instanceof ApiError;
+}
+
+export function isRetryableStatus(status?: number): boolean {
+  return typeof status === "number" && RETRYABLE_STATUS_CODES.has(status);
+}
+
+export function normalizeApiError(
+  error: unknown,
+  options: NormalizeApiErrorOptions = {},
+): ApiError {
+  if (isApiError(error)) {
+    return error;
+  }
+
+  const baseMetadata = {
+    url: options.url,
+    method: options.method,
+    details: options.details,
+    traceId: options.traceId,
+  };
+
+  if (error instanceof DOMException && error.name === "AbortError") {
+    return new ApiError({
+      ...baseMetadata,
+      code: "ABORTED",
+      message: "The request was aborted.",
+      userMessage: "The request was cancelled. Please try again.",
+      retryable: false,
+      cause: error,
+    });
+  }
+
+  if (error instanceof TypeError) {
+    return new ApiError({
+      ...baseMetadata,
+      code: "NETWORK_ERROR",
+      message: error.message || "Network request failed.",
+      userMessage:
+        "We could not reach the server. Check your connection and try again.",
+      retryable: true,
+      cause: error,
+    });
+  }
+
+  if (error instanceof SyntaxError) {
+    return new ApiError({
+      ...baseMetadata,
+      code: "INVALID_RESPONSE",
+      message: error.message,
+      userMessage:
+        "We received an unexpected response from the server. Please try again.",
+      retryable: false,
+      cause: error,
+    });
+  }
+
+  if (options.status) {
+    return new ApiError({
+      ...baseMetadata,
+      code: "HTTP_ERROR",
+      message: `Request failed with status ${options.status}.`,
+      userMessage:
+        options.status >= 500
+          ? "The service is temporarily unavailable. Please try again shortly."
+          : "We could not complete that request. Please review your input and try again.",
+      retryable: isRetryableStatus(options.status),
+      status: options.status,
+      statusText: options.statusText,
+      cause: error,
+    });
+  }
+
+  if (error instanceof Error) {
+    return new ApiError({
+      ...baseMetadata,
+      code: "UNKNOWN_ERROR",
+      message: error.message,
+      userMessage: DEFAULT_USER_MESSAGE,
+      retryable: false,
+      cause: error,
+    });
+  }
+
+  return new ApiError({
+    ...baseMetadata,
+    code: "UNKNOWN_ERROR",
+    message: "An unknown API error occurred.",
+    userMessage: DEFAULT_USER_MESSAGE,
+    retryable: false,
+    cause: error,
+  });
+}

--- a/frontend/src/lib/api/index.ts
+++ b/frontend/src/lib/api/index.ts
@@ -1,0 +1,22 @@
+export {
+  ApiError,
+  isApiError,
+  isRetryableStatus,
+  normalizeApiError,
+  type ApiErrorCode,
+  type ApiErrorMetadata,
+} from "./error";
+export {
+  ApiClient,
+  createApiClient,
+  type ApiRequestContext,
+  type ApiRequestOptions,
+  type ApiResponseContext,
+  type RetryOptions,
+} from "./client";
+export {
+  emitApiTelemetry,
+  subscribeToApiTelemetry,
+  type ApiTelemetryEvent,
+} from "./telemetry";
+export { useApiTelemetry } from "./useApiTelemetry";

--- a/frontend/src/lib/api/telemetry.ts
+++ b/frontend/src/lib/api/telemetry.ts
@@ -1,0 +1,48 @@
+import type { ApiError } from "./error";
+
+export type ApiTelemetryEvent =
+  | {
+      type: "request";
+      method: string;
+      url: string;
+      attempt: number;
+    }
+  | {
+      type: "retry";
+      method: string;
+      url: string;
+      attempt: number;
+      delayMs: number;
+      reason: string;
+    }
+  | {
+      type: "success";
+      method: string;
+      url: string;
+      attempt: number;
+      durationMs: number;
+      status: number;
+    }
+  | {
+      type: "error";
+      method: string;
+      url: string;
+      attempt: number;
+      durationMs: number;
+      error: ApiError;
+    };
+
+type ApiTelemetryListener = (event: ApiTelemetryEvent) => void;
+
+const listeners = new Set<ApiTelemetryListener>();
+
+export function emitApiTelemetry(event: ApiTelemetryEvent) {
+  listeners.forEach((listener) => listener(event));
+}
+
+export function subscribeToApiTelemetry(listener: ApiTelemetryListener) {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}

--- a/frontend/src/lib/api/useApiTelemetry.ts
+++ b/frontend/src/lib/api/useApiTelemetry.ts
@@ -1,0 +1,11 @@
+import { useEffect } from "react";
+import {
+  subscribeToApiTelemetry,
+  type ApiTelemetryEvent,
+} from "./telemetry";
+
+export function useApiTelemetry(handler: (event: ApiTelemetryEvent) => void) {
+  useEffect(() => {
+    return subscribeToApiTelemetry(handler);
+  }, [handler]);
+}

--- a/frontend/src/lib/portfolioApi.ts
+++ b/frontend/src/lib/portfolioApi.ts
@@ -1,0 +1,25 @@
+import { createApiClient } from "./api";
+
+export interface PortfolioHolding {
+  id: string;
+  asset: string;
+  vaultName: string;
+  symbol: string;
+  shares: number;
+  apy: number;
+  valueUsd: number;
+  unrealizedGainUsd: number;
+  issuer: string;
+  status: "active" | "pending";
+}
+
+const apiClient = createApiClient({
+  baseUrl: import.meta.env.VITE_API_BASE_URL,
+  headers: {
+    Accept: "application/json",
+  },
+});
+
+export async function getPortfolioHoldings() {
+  return apiClient.get<PortfolioHolding[]>("/mock-api/portfolio-holdings.json");
+}

--- a/frontend/src/lib/vaultApi.ts
+++ b/frontend/src/lib/vaultApi.ts
@@ -1,0 +1,35 @@
+import { createApiClient } from "./api";
+
+export interface StrategyMetadata {
+  id: string;
+  name: string;
+  issuer: string;
+  network: string;
+  rpcUrl: string;
+  status: "active" | "inactive";
+  description: string;
+}
+
+export interface VaultSummary {
+  tvl: number;
+  apy: number;
+  participantCount: number;
+  monthlyGrowthPct: number;
+  strategyStabilityPct: number;
+  assetLabel: string;
+  exchangeRate: number;
+  networkFeeEstimate: string;
+  updatedAt: string;
+  strategy: StrategyMetadata;
+}
+
+const apiClient = createApiClient({
+  baseUrl: import.meta.env.VITE_API_BASE_URL,
+  headers: {
+    Accept: "application/json",
+  },
+});
+
+export async function getVaultSummary() {
+  return apiClient.get<VaultSummary>("/mock-api/vault-summary.json");
+}

--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -1,12 +1,15 @@
-import React from 'react';
-import { useVault } from '../context/VaultContext';
-import { Activity } from 'lucide-react';
+import React from "react";
+import { Activity } from "lucide-react";
+import ApiStatusBanner from "../components/ApiStatusBanner";
+import { useVault } from "../context/VaultContext";
 
 const Analytics: React.FC = () => {
-    const { formattedTvl } = useVault();
+    const { formattedTvl, summary, error, isLoading } = useVault();
 
     return (
         <div className="glass-panel" style={{ padding: '32px' }}>
+            {error && <ApiStatusBanner error={error} />}
+
             <header style={{ textAlign: 'center', marginBottom: '48px' }}>
                 <h1 style={{ fontSize: '2.5rem', marginBottom: '16px' }}>
                     <span className="text-gradient">Project Analytics</span>
@@ -21,21 +24,21 @@ const Analytics: React.FC = () => {
                     <div style={{ fontSize: '0.9rem', color: 'var(--text-secondary)', display: 'flex', justifyContent: 'space-between' }}>
                         Total Value Locked
                         <span style={{ color: 'var(--accent-cyan)', fontSize: '0.7rem', fontWeight: 600, display: 'flex', alignItems: 'center', gap: '4px' }}>
-                            <Activity size={10} className="animate-pulse" />
-                            LIVE
+                            <Activity size={10} className={isLoading ? "animate-pulse" : undefined} />
+                            {isLoading ? "SYNCING" : "LIVE"}
                         </span>
                     </div>
                     <div style={{ fontSize: '1.8rem', fontWeight: 600 }}>{formattedTvl}</div>
-                    <div style={{ fontSize: '0.8rem', color: 'var(--accent-cyan)', marginTop: '8px' }}>+12.5% this month</div>
+                    <div style={{ fontSize: '0.8rem', color: 'var(--accent-cyan)', marginTop: '8px' }}>+{summary.monthlyGrowthPct}% this month</div>
                 </div>
                 <div className="glass-panel" style={{ flex: '1 1 300px', padding: '24px', background: 'var(--bg-muted)' }}>
                     <div style={{ fontSize: '0.9rem', color: 'var(--text-secondary)' }}>Vault Participants</div>
-                    <div style={{ fontSize: '1.8rem', fontWeight: 600 }}>1,248</div>
+                    <div style={{ fontSize: '1.8rem', fontWeight: 600 }}>{summary.participantCount.toLocaleString('en-US')}</div>
                     <div style={{ fontSize: '0.8rem', color: 'var(--accent-cyan)', marginTop: '8px' }}>+82 new users</div>
                 </div>
                 <div className="glass-panel" style={{ flex: '1 1 300px', padding: '24px', background: 'var(--bg-muted)' }}>
                     <div style={{ fontSize: '0.9rem', color: 'var(--text-secondary)' }}>Strategy Stability</div>
-                    <div style={{ fontSize: '1.8rem', fontWeight: 600 }}>99.9%</div>
+                    <div style={{ fontSize: '1.8rem', fontWeight: 600 }}>{summary.strategyStabilityPct}%</div>
                     <div style={{ fontSize: '0.8rem', color: 'var(--accent-cyan)', marginTop: '8px' }}>Tracking Sovereign Bonds</div>
                 </div>
             </div>

--- a/frontend/src/pages/Portfolio.test.tsx
+++ b/frontend/src/pages/Portfolio.test.tsx
@@ -1,0 +1,179 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import Portfolio from "./Portfolio";
+
+const mockHoldings = [
+  {
+    id: "hold-1",
+    asset: "USDC Treasury Pool",
+    vaultName: "Stellar RWA Yield Fund",
+    symbol: "yvUSDC",
+    shares: 1250.5,
+    apy: 8.45,
+    valueUsd: 1250.5,
+    unrealizedGainUsd: 42.15,
+    issuer: "Franklin Templeton",
+    status: "active",
+  },
+  {
+    id: "hold-2",
+    asset: "Government Bond Basket",
+    vaultName: "Sovereign Income Sleeve",
+    symbol: "yvBOND",
+    shares: 840.12,
+    apy: 7.2,
+    valueUsd: 894.41,
+    unrealizedGainUsd: 25.22,
+    issuer: "WisdomTree",
+    status: "active",
+  },
+  {
+    id: "hold-3",
+    asset: "Short Duration Credit",
+    vaultName: "Liquidity Ladder",
+    symbol: "yvCASH",
+    shares: 500.33,
+    apy: 6.85,
+    valueUsd: 512.9,
+    unrealizedGainUsd: 11.48,
+    issuer: "Circle Reserve",
+    status: "pending",
+  },
+  {
+    id: "hold-4",
+    asset: "Tokenized T-Bills",
+    vaultName: "USD Treasury Express",
+    symbol: "yvUSTB",
+    shares: 1380,
+    apy: 5.95,
+    valueUsd: 1404.32,
+    unrealizedGainUsd: 19.77,
+    issuer: "OpenEden",
+    status: "active",
+  },
+  {
+    id: "hold-5",
+    asset: "Yield Bearing Cash",
+    vaultName: "Prime Reserve Strategy",
+    symbol: "yvPRIME",
+    shares: 320.42,
+    apy: 7.9,
+    valueUsd: 337.08,
+    unrealizedGainUsd: 9.66,
+    issuer: "Hashnote",
+    status: "active",
+  },
+  {
+    id: "hold-6",
+    asset: "EM Debt Blend",
+    vaultName: "Global Carry Vault",
+    symbol: "yvEMD",
+    shares: 214.1,
+    apy: 9.1,
+    valueUsd: 228.55,
+    unrealizedGainUsd: 14.07,
+    issuer: "Templeton",
+    status: "pending",
+  },
+];
+
+function LocationDisplay() {
+  const location = useLocation();
+  return <div data-testid="location-display">{location.pathname}{location.search}</div>;
+}
+
+function renderPortfolio(
+  initialEntry = "/portfolio",
+  walletAddress: string | null = "GABC123",
+) {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route
+          path="/portfolio"
+          element={
+            <>
+              <Portfolio walletAddress={walletAddress} />
+              <LocationDisplay />
+            </>
+          }
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("Portfolio", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify(mockHoldings), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shows the wallet prompt when disconnected", () => {
+    renderPortfolio("/portfolio", null);
+
+    expect(
+      screen.getByText(/Please connect your wallet to view your portfolio/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders holdings in the reusable table", async () => {
+    renderPortfolio();
+
+    expect(await screen.findByText(/Tokenized T-Bills/i)).toBeInTheDocument();
+    expect(screen.getByRole("table")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Sort by Asset/i })).toBeInTheDocument();
+  });
+
+  it("persists filter state in the URL", async () => {
+    renderPortfolio();
+
+    const searchInput = await screen.findByPlaceholderText(
+      /Search asset, vault, issuer/i,
+    );
+    fireEvent.change(searchInput, { target: { value: "OpenEden" } });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Tokenized T-Bills/i)).toBeInTheDocument();
+      expect(screen.queryByText(/USDC Treasury Pool/i)).not.toBeInTheDocument();
+      expect(screen.getByTestId("location-display")).toHaveTextContent(
+        "search=OpenEden",
+      );
+    });
+  });
+
+  it("supports keyboard sorting and pagination state from the URL", async () => {
+    renderPortfolio("/portfolio?page=2&pageSize=4&sortBy=asset&direction=asc");
+
+    expect(await screen.findByText(/Yield Bearing Cash/i)).toBeInTheDocument();
+    expect(screen.getByText(/USDC Treasury Pool/i)).toBeInTheDocument();
+
+    const assetSort = screen.getByRole("button", { name: /Sort by Asset/i });
+    fireEvent.keyDown(assetSort, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("location-display")).toHaveTextContent(
+        "sortBy=asset",
+      );
+      expect(screen.getByTestId("location-display")).toHaveTextContent(
+        "direction=desc",
+      );
+      expect(screen.getByTestId("location-display")).toHaveTextContent("page=1");
+    });
+
+    const row = screen.getByText(/Yield Bearing Cash/i).closest("tr");
+    expect(row).toHaveAttribute("tabindex", "0");
+  });
+});

--- a/frontend/src/pages/Portfolio.tsx
+++ b/frontend/src/pages/Portfolio.tsx
@@ -1,52 +1,321 @@
-import React from 'react';
+import React, { useEffect, useState } from "react";
+import ApiStatusBanner from "../components/ApiStatusBanner";
+import {
+  DataTable,
+  type DataTableColumn,
+} from "../components/DataTable";
+import { normalizeApiError, type ApiError } from "../lib/api";
+import {
+  getPortfolioHoldings,
+  type PortfolioHolding,
+} from "../lib/portfolioApi";
+import { useClientDataTable } from "../hooks/useClientDataTable";
+import { useDataTableState } from "../hooks/useDataTableState";
+import { useServerDataTable } from "../hooks/useServerDataTable";
 
 interface PortfolioProps {
   walletAddress: string | null;
 }
 
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+});
+
+const numberFormatter = new Intl.NumberFormat("en-US", {
+  maximumFractionDigits: 2,
+});
+
+const columns: DataTableColumn<PortfolioHolding>[] = [
+  {
+    id: "asset",
+    header: "Asset",
+    sortable: true,
+    width: "28%",
+    cell: (row) => (
+      <div>
+        <div style={{ fontWeight: 600 }}>{row.asset}</div>
+        <div style={{ color: "var(--text-secondary)", fontSize: "0.82rem" }}>
+          {row.vaultName}
+        </div>
+      </div>
+    ),
+  },
+  {
+    id: "shares",
+    header: "Shares",
+    sortable: true,
+    align: "right",
+    cell: (row) => (
+      <div>
+        <div style={{ fontWeight: 600 }}>
+          {numberFormatter.format(row.shares)} {row.symbol}
+        </div>
+        <div style={{ color: "var(--text-secondary)", fontSize: "0.82rem" }}>
+          Issuer: {row.issuer}
+        </div>
+      </div>
+    ),
+  },
+  {
+    id: "apy",
+    header: "APY",
+    sortable: true,
+    align: "right",
+    cell: (row) => (
+      <span style={{ color: "var(--accent-cyan)", fontWeight: 600 }}>
+        {row.apy.toFixed(2)}%
+      </span>
+    ),
+  },
+  {
+    id: "valueUsd",
+    header: "Value",
+    sortable: true,
+    align: "right",
+    cell: (row) => <span>{currencyFormatter.format(row.valueUsd)}</span>,
+  },
+  {
+    id: "unrealizedGainUsd",
+    header: "Unrealized Gain",
+    sortable: true,
+    align: "right",
+    cell: (row) => (
+      <span
+        style={{
+          color:
+            row.unrealizedGainUsd >= 0
+              ? "var(--accent-cyan)"
+              : "var(--text-error)",
+          fontWeight: 600,
+        }}
+      >
+        {row.unrealizedGainUsd >= 0 ? "+" : ""}
+        {currencyFormatter.format(row.unrealizedGainUsd)}
+      </span>
+    ),
+  },
+];
+
 const Portfolio: React.FC<PortfolioProps> = ({ walletAddress }) => {
+  const [holdings, setHoldings] = useState<PortfolioHolding[]>([]);
+  const [error, setError] = useState<ApiError | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const { state, setSearch, setSort, setPage, setPageSize } = useDataTableState({
+    defaultSortBy: "valueUsd",
+    defaultSortDirection: "desc",
+    defaultPageSize: 4,
+  });
+
+  useServerDataTable({ state });
+
+  useEffect(() => {
+    if (!walletAddress) {
+      return;
+    }
+
+    let isMounted = true;
+
+    const loadHoldings = async () => {
+      setIsLoading(true);
+
+      try {
+        const response = await getPortfolioHoldings();
+        if (!isMounted) {
+          return;
+        }
+        setHoldings(response);
+        setError(null);
+      } catch (unknownError) {
+        if (!isMounted) {
+          return;
+        }
+        setError(normalizeApiError(unknownError));
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void loadHoldings();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [walletAddress]);
+
+  const { rows, page, totalItems, totalPages } = useClientDataTable({
+    rows: holdings,
+    state,
+    getSearchValue: (row) =>
+      `${row.asset} ${row.vaultName} ${row.symbol} ${row.issuer} ${row.status}`,
+    getSortValue: (row, columnId) => {
+      switch (columnId) {
+        case "asset":
+          return row.asset;
+        case "shares":
+          return row.shares;
+        case "apy":
+          return row.apy;
+        case "valueUsd":
+          return row.valueUsd;
+        case "unrealizedGainUsd":
+          return row.unrealizedGainUsd;
+        default:
+          return row.valueUsd;
+      }
+    },
+  });
+
+  const totalValue = holdings.reduce((sum, holding) => sum + holding.valueUsd, 0);
+  const totalGain = holdings.reduce(
+    (sum, holding) => sum + holding.unrealizedGainUsd,
+    0,
+  );
+
   return (
-    <div className="glass-panel" style={{ padding: '32px' }}>
-      <header style={{ textAlign: 'center', marginBottom: '48px' }}>
-        <h1 style={{ fontSize: '2.5rem', marginBottom: '16px' }}>
+    <div className="glass-panel" style={{ padding: "32px" }}>
+      <header style={{ textAlign: "center", marginBottom: "48px" }}>
+        <h1 style={{ fontSize: "2.5rem", marginBottom: "16px" }}>
           Your <span className="text-gradient">Portfolio</span>
         </h1>
-        <p style={{ color: 'var(--text-secondary)', fontSize: '1.1rem' }}>
+        <p style={{ color: "var(--text-secondary)", fontSize: "1.1rem" }}>
           Overview of your deposited real-world assets.
         </p>
       </header>
 
       {!walletAddress ? (
-        <div style={{ textAlign: 'center', padding: '48px' }}>
-          <p style={{ color: 'var(--text-secondary)' }}>Please connect your wallet to view your portfolio.</p>
+        <div style={{ textAlign: "center", padding: "48px" }}>
+          <p style={{ color: "var(--text-secondary)" }}>
+            Please connect your wallet to view your portfolio.
+          </p>
         </div>
       ) : (
         <div className="flex flex-col gap-lg">
-          <div className="glass-panel" style={{ padding: '24px', background: 'var(--bg-muted)' }}>
-            <div className="flex justify-between items-center">
-              <div>
-                <div style={{ fontSize: '0.9rem', color: 'var(--text-secondary)' }}>Total Assets</div>
-                <div style={{ fontSize: '1.8rem', fontWeight: 600 }}>$1,250.50</div>
+          {error && <ApiStatusBanner error={error} />}
+
+          <div
+            className="portfolio-summary-grid"
+            style={{ display: "grid", gap: "24px", gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))" }}
+          >
+            <div
+              className="glass-panel"
+              style={{ padding: "24px", background: "var(--bg-muted)" }}
+            >
+              <div style={{ fontSize: "0.9rem", color: "var(--text-secondary)" }}>
+                Total Assets
               </div>
-              <div style={{ textAlign: 'right' }}>
-                <div style={{ fontSize: '0.9rem', color: 'var(--text-secondary)' }}>Unrealized Gain</div>
-                <div style={{ fontSize: '1.2rem', color: 'var(--accent-cyan)', fontWeight: 600 }}>+$42.15</div>
+              <div style={{ fontSize: "1.8rem", fontWeight: 600 }}>
+                {currencyFormatter.format(totalValue)}
+              </div>
+            </div>
+            <div
+              className="glass-panel"
+              style={{ padding: "24px", background: "var(--bg-muted)" }}
+            >
+              <div style={{ fontSize: "0.9rem", color: "var(--text-secondary)" }}>
+                Unrealized Gain
+              </div>
+              <div
+                style={{
+                  fontSize: "1.2rem",
+                  color: "var(--accent-cyan)",
+                  fontWeight: 600,
+                }}
+              >
+                +{currencyFormatter.format(totalGain)}
               </div>
             </div>
           </div>
-          
-          <div className="glass-panel" style={{ padding: '24px', background: 'var(--bg-muted)' }}>
-            <h3 style={{ marginBottom: '16px' }}>Stellar RWA Yield Fund</h3>
-            <div className="flex justify-between items-center">
+
+          <section
+            className="glass-panel"
+            style={{ padding: "24px", background: "var(--bg-muted)" }}
+            aria-label="Portfolio holdings"
+          >
+            <div className="portfolio-toolbar">
               <div>
-                <span className="tag cyan">USDC</span>
+                <h3 style={{ marginBottom: "6px" }}>Holdings</h3>
+                <p style={{ color: "var(--text-secondary)", fontSize: "0.92rem" }}>
+                  Sort, search, and page through all current vault positions.
+                </p>
               </div>
-              <div style={{ textAlign: 'right' }}>
-                <div style={{ fontWeight: 600 }}>1,250.50 yvUSDC</div>
-                <div style={{ fontSize: '0.8rem', color: 'var(--text-secondary)' }}>APY 8.45%</div>
+
+              <div className="portfolio-toolbar-controls">
+                <label className="input-group" style={{ minWidth: "220px" }}>
+                  <span>Filter holdings</span>
+                  <div className="input-wrapper">
+                    <input
+                      className="input-field"
+                      type="search"
+                      placeholder="Search asset, vault, issuer..."
+                      value={state.search}
+                      onChange={(event) => setSearch(event.target.value)}
+                      style={{ fontSize: "1rem", fontFamily: "var(--font-sans)" }}
+                    />
+                  </div>
+                </label>
+
+                <label className="input-group" style={{ minWidth: "120px" }}>
+                  <span>Rows</span>
+                  <div className="input-wrapper">
+                    <select
+                      aria-label="Rows per page"
+                      value={state.pageSize}
+                      onChange={(event) => setPageSize(Number(event.target.value))}
+                      className="portfolio-select"
+                    >
+                      <option value={4}>4</option>
+                      <option value={6}>6</option>
+                      <option value={8}>8</option>
+                    </select>
+                  </div>
+                </label>
               </div>
             </div>
-          </div>
+
+            <div
+              style={{
+                color: "var(--text-secondary)",
+                fontSize: "0.86rem",
+                marginBottom: "16px",
+              }}
+            >
+              {isLoading ? "Loading holdings..." : `${totalItems} holdings found`}
+            </div>
+
+            <DataTable
+              caption="Portfolio holdings"
+              columns={columns}
+              rows={rows}
+              rowKey={(row) => row.id}
+              emptyMessage={
+                isLoading
+                  ? "Loading holdings..."
+                  : "No holdings matched the current filters."
+              }
+              sortBy={state.sortBy}
+              sortDirection={state.sortDirection}
+              onSortChange={setSort}
+              pagination={{
+                page,
+                pageSize: state.pageSize,
+                totalItems,
+                totalPages,
+              }}
+              onPageChange={setPage}
+              renderRowDetails={(row) => (
+                <div className="portfolio-row-meta">
+                  <span className={`tag ${row.status === "active" ? "cyan" : ""}`}>
+                    {row.status}
+                  </span>
+                  <span>{row.symbol}</span>
+                </div>
+              )}
+            />
+          </section>
         </div>
       )}
     </div>


### PR DESCRIPTION
PR description:

closes #91 
closes #94

```
## Summary

This PR improves the frontend foundation in two areas:

1. Introduces a centralized API client with typed error handling, retry/backoff support, and telemetry hooks.
2. Adds a reusable data table system with sorting, filtering, pagination, responsive behavior, and keyboard navigation.

## Changes

### Shared API client
- Added a shared fetch-based API client wrapper
- Normalized API errors with a typed `ApiError` model
- Added retry/backoff behavior for transient failures
- Exposed API telemetry subscription and hook support
- Migrated vault summary loading to use the shared client
- Standardized user-facing API error messaging in the UI

### Reusable data table
- Added a composable `DataTable` component with column configuration
- Added shared hooks for table state, client-side table processing, and future server-side table query integration
- Migrated the portfolio holdings view to the new table
- Persisted sorting, filtering, and pagination state in the URL
- Added responsive mobile behavior for narrow screens
- Ensured keyboard-friendly sorting and row focus behavior

## Files of note

- `frontend/src/lib/api/*`
- `frontend/src/lib/vaultApi.ts`
- `frontend/src/context/VaultContext.tsx`
- `frontend/src/components/ApiStatusBanner.tsx`
- `frontend/src/components/DataTable.tsx`
- `frontend/src/hooks/useDataTableState.ts`
- `frontend/src/hooks/useClientDataTable.ts`
- `frontend/src/hooks/useServerDataTable.ts`
- `frontend/src/lib/portfolioApi.ts`
- `frontend/src/pages/Portfolio.tsx`

## Validation

Ran locally:
- `npm test -- --run`
- `npm run lint`
- `npm run build`

## Notes

- Portfolio holdings and vault data currently use local mock API JSON endpoints to exercise the shared client and reusable table flow without requiring a backend dependency.
- The server-side table hook is included so future list views can adopt the same table state contract with API-backed sorting/filtering/pagination.
```