### PR TITLE
feat: add Playwright E2E tests and CI workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,58 @@
+name: E2E Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  e2e:
+    name: Playwright E2E
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium --with-deps
+
+      - name: Build app
+        run: npm run build
+
+      - name: Run E2E tests
+        run: npm run test:e2e
+        env:
+          CI: true
+
+      # Upload the HTML report so it's browsable in the Actions UI
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend/playwright-report/
+          retention-days: 30
+
+      # Upload screenshots and videos captured on test failure
+      - name: Upload failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-failure-artifacts
+          path: frontend/test-results/
+          retention-days: 14

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -22,3 +22,7 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Playwright
+test-results/
+playwright-report/

--- a/frontend/e2e/dashboard-load.spec.ts
+++ b/frontend/e2e/dashboard-load.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * Flow 1: Dashboard Load
+ *
+ * Validates that the home page renders vault stats correctly from the API,
+ * navigation works, and the unauthenticated state is handled properly.
+ */
+import { test, expect } from './fixtures';
+
+test.describe('Dashboard load', () => {
+  test('renders vault stats from the API on home page load', async ({ appPage: page }) => {
+    await page.goto('/');
+
+    // Hero section
+    await expect(page.getByText('Institutional Yields,')).toBeVisible();
+    await expect(page.getByText('Decentralized Access.')).toBeVisible();
+
+    // Vault panel heading
+    await expect(page.getByText('Global RWA Yield Fund')).toBeVisible();
+
+    // APY from mock data (8.45%)
+    await expect(page.getByText('8.45%')).toBeVisible();
+
+    // TVL from mock data ($12,450,800)
+    await expect(page.getByText('$12,450,800')).toBeVisible();
+
+    // Strategy name from mock data
+    await expect(page.getByText('Franklin BENJI Connector')).toBeVisible();
+
+    // Underlying asset
+    await expect(page.getByText('Sovereign Debt', { exact: true })).toBeVisible();
+  });
+
+  test('shows wallet-not-connected overlay on the deposit panel', async ({ appPage: page }) => {
+    await page.goto('/');
+
+    await expect(page.getByText('Wallet Not Connected')).toBeVisible();
+    await expect(
+      page.getByText('Please connect your Freighter wallet to deposit USDC and earn RWA yields.'),
+    ).toBeVisible();
+
+    // Connect button in navbar must be present
+    await expect(page.getByRole('button', { name: /Connect Freighter/i })).toBeVisible();
+  });
+
+  test('navbar links navigate to the correct routes', async ({ appPage: page }) => {
+    await page.goto('/');
+
+    // Navigate to Analytics
+    await page.getByRole('link', { name: 'Analytics' }).click();
+    await expect(page).toHaveURL('/analytics');
+    await expect(page.getByText('Project Analytics')).toBeVisible();
+
+    // Navigate to Portfolio
+    await page.getByRole('link', { name: 'Portfolio' }).click();
+    await expect(page).toHaveURL('/portfolio');
+    await expect(page.getByRole('heading', { name: 'Your Portfolio' })).toBeVisible();
+
+    // Navigate back to Vaults (home)
+    await page.getByRole('link', { name: 'Vaults' }).click();
+    await expect(page).toHaveURL('/');
+    await expect(page.getByText('Global RWA Yield Fund')).toBeVisible();
+  });
+
+  test('analytics page shows live vault metrics', async ({ appPage: page }) => {
+    await page.goto('/analytics');
+
+    await expect(page.getByText('Project Analytics')).toBeVisible();
+
+    // TVL card
+    await expect(page.getByText('Total Value Locked')).toBeVisible();
+    await expect(page.getByText('$12,450,800')).toBeVisible();
+
+    // Participant count from mock data (1,248)
+    await expect(page.getByText('1,248')).toBeVisible();
+
+    // Strategy stability from mock data (99.9%)
+    await expect(page.getByText('99.9%')).toBeVisible();
+  });
+
+  test('unknown routes redirect to home', async ({ appPage: page }) => {
+    await page.goto('/does-not-exist');
+    await expect(page).toHaveURL('/');
+    await expect(page.getByText('Global RWA Yield Fund')).toBeVisible();
+  });
+});

--- a/frontend/e2e/deposit-withdraw.spec.ts
+++ b/frontend/e2e/deposit-withdraw.spec.ts
@@ -1,0 +1,125 @@
+﻿/**
+ * Flow 2: Deposit & Withdraw Transaction
+ */
+import { test, expect, interceptApiRoutes, stubFreighterConnected } from './fixtures';
+
+const MOCK_ADDRESS = 'GABC1TEST2STELLAR3ADDRESS4FAKE5XYZ6ABCDEFGHIJKLMNOPQRSTU';
+const SHORT_ADDR = `${MOCK_ADDRESS.substring(0, 5)}...${MOCK_ADDRESS.substring(MOCK_ADDRESS.length - 4)}`;
+
+// Tests that verify unauthenticated UI  no Freighter stub injected
+test.describe('Deposit panel  no wallet', () => {
+  test.beforeEach(async ({ page }) => {
+    await interceptApiRoutes(page);
+  });
+
+  test('deposit panel shows wallet-not-connected overlay', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByText('Wallet Not Connected')).toBeVisible();
+    await expect(page.getByRole('button', { name: /Approve & Deposit/i })).toBeVisible();
+  });
+
+  test('submit button is disabled when amount is empty or zero', async ({ page }) => {
+    await page.goto('/');
+    const submitBtn = page.getByRole('button', { name: /Approve & Deposit/i });
+    await expect(submitBtn).toBeDisabled();
+    await page.getByPlaceholder('0.00').fill('0');
+    await expect(submitBtn).toBeDisabled();
+  });
+
+  test('strategy info panel shows exchange rate and network fee', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByText('1 yvUSDC = 1.084 USDC')).toBeVisible();
+    await expect(page.getByText('~0.00001 XLM')).toBeVisible();
+    await expect(page.getByText('BENJI Strategy')).toBeVisible();
+  });
+});
+
+// Tests that require a connected wallet via Freighter stub
+test.describe('Deposit & Withdraw  connected wallet', () => {
+  test.beforeEach(async ({ page }) => {
+    await interceptApiRoutes(page);
+    await stubFreighterConnected(page, MOCK_ADDRESS);
+  });
+
+  test('auto-connects wallet on mount when Freighter is already allowed', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByText(SHORT_ADDR)).toBeVisible({ timeout: 5000 });
+  });
+
+  test('deposit overlay is removed after wallet connects', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByText(SHORT_ADDR)).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('Wallet Not Connected')).not.toBeVisible();
+  });
+
+  test('deposit tab is active by default and can switch to withdraw', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByText(SHORT_ADDR)).toBeVisible({ timeout: 5000 });
+
+    const depositTab = page.getByRole('button', { name: 'Deposit', exact: true });
+    const withdrawTab = page.getByRole('button', { name: 'Withdraw', exact: true });
+
+    await expect(page.getByText('Amount to deposit')).toBeVisible();
+    await withdrawTab.click();
+    await expect(page.getByText('Amount to withdraw')).toBeVisible();
+    await depositTab.click();
+    await expect(page.getByText('Amount to deposit')).toBeVisible();
+  });
+
+  test('MAX button fills the amount input with the current balance', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByText(SHORT_ADDR)).toBeVisible({ timeout: 5000 });
+    await page.getByRole('button', { name: 'MAX' }).click();
+    const value = await page.getByPlaceholder('0.00').inputValue();
+    expect(value).toBeTruthy();
+  });
+
+  test('performs a deposit and updates the balance', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByText(SHORT_ADDR)).toBeVisible({ timeout: 5000 });
+
+    const amountInput = page.getByPlaceholder('0.00');
+    const submitBtn = page.getByRole('button', { name: /Approve & Deposit/i });
+
+    await amountInput.fill('100');
+    await expect(submitBtn).toBeEnabled();
+    await submitBtn.click();
+
+    await expect(page.getByRole('button', { name: /Processing Transaction/i })).toBeVisible();
+    // Initial balance 1250.50 + 100 = 1350.50
+    await expect(page.getByText('1350.50')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole('button', { name: /Approve & Deposit/i })).toBeVisible();
+  });
+
+  test('performs a withdrawal and updates the balance', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByText(SHORT_ADDR)).toBeVisible({ timeout: 5000 });
+
+    await page.getByRole('button', { name: 'Withdraw', exact: true }).click();
+    await expect(page.getByText('Amount to withdraw')).toBeVisible();
+
+    await page.getByPlaceholder('0.00').fill('50');
+    const submitBtn = page.getByRole('button', { name: /Withdraw Funds/i });
+    await expect(submitBtn).toBeEnabled();
+    await submitBtn.click();
+
+    await expect(page.getByRole('button', { name: /Processing Transaction/i })).toBeVisible();
+    // 1250.50 - 50 = 1200.50
+    await expect(page.getByText('1200.50')).toBeVisible({ timeout: 5000 });
+  });
+
+  test('disconnect button clears wallet state and shows connect button', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByText(SHORT_ADDR)).toBeVisible({ timeout: 5000 });
+
+    // Disable the stub so the auto-connect effect does not re-fire after disconnect
+    await page.evaluate(() => {
+      (window as unknown as { __freighterStub: { connected: boolean } }).__freighterStub.connected = false;
+    });
+
+    await page.getByRole('button', { name: /Disconnect Wallet/i }).click();
+
+    await expect(page.getByRole('button', { name: /Connect Freighter/i })).toBeVisible({ timeout: 3000 });
+    await expect(page.getByText('Wallet Not Connected')).toBeVisible();
+  });
+});

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -1,0 +1,203 @@
+import { test as base, type Page } from '@playwright/test';
+
+// Inline fixture data — avoids JSON import attribute requirements across Node versions
+const vaultSummary = {
+  tvl: 12450800,
+  apy: 8.45,
+  participantCount: 1248,
+  monthlyGrowthPct: 12.5,
+  strategyStabilityPct: 99.9,
+  assetLabel: 'Sovereign Debt',
+  exchangeRate: 1.084,
+  networkFeeEstimate: '~0.00001 XLM',
+  updatedAt: '2026-03-25T10:00:00.000Z',
+  strategy: {
+    id: 'stellar-benji',
+    name: 'Franklin BENJI Connector',
+    issuer: 'Franklin Templeton',
+    network: 'Stellar',
+    rpcUrl: 'https://soroban-testnet.stellar.org',
+    status: 'active',
+    description:
+      'Connector strategy that routes vault yield updates from BENJI-issued tokenized money market exposure on Stellar.',
+  },
+};
+
+const portfolioHoldings = [
+  {
+    id: 'hold-1',
+    asset: 'USDC Treasury Pool',
+    vaultName: 'Stellar RWA Yield Fund',
+    symbol: 'yvUSDC',
+    shares: 1250.5,
+    apy: 8.45,
+    valueUsd: 1250.5,
+    unrealizedGainUsd: 42.15,
+    issuer: 'Franklin Templeton',
+    status: 'active',
+  },
+  {
+    id: 'hold-2',
+    asset: 'Government Bond Basket',
+    vaultName: 'Sovereign Income Sleeve',
+    symbol: 'yvBOND',
+    shares: 840.12,
+    apy: 7.2,
+    valueUsd: 894.41,
+    unrealizedGainUsd: 25.22,
+    issuer: 'WisdomTree',
+    status: 'active',
+  },
+  {
+    id: 'hold-3',
+    asset: 'Short Duration Credit',
+    vaultName: 'Liquidity Ladder',
+    symbol: 'yvCASH',
+    shares: 500.33,
+    apy: 6.85,
+    valueUsd: 512.9,
+    unrealizedGainUsd: 11.48,
+    issuer: 'Circle Reserve',
+    status: 'pending',
+  },
+  {
+    id: 'hold-4',
+    asset: 'Tokenized T-Bills',
+    vaultName: 'USD Treasury Express',
+    symbol: 'yvUSTB',
+    shares: 1380,
+    apy: 5.95,
+    valueUsd: 1404.32,
+    unrealizedGainUsd: 19.77,
+    issuer: 'OpenEden',
+    status: 'active',
+  },
+  {
+    id: 'hold-5',
+    asset: 'Yield Bearing Cash',
+    vaultName: 'Prime Reserve Strategy',
+    symbol: 'yvPRIME',
+    shares: 320.42,
+    apy: 7.9,
+    valueUsd: 337.08,
+    unrealizedGainUsd: 9.66,
+    issuer: 'Hashnote',
+    status: 'active',
+  },
+  {
+    id: 'hold-6',
+    asset: 'EM Debt Blend',
+    vaultName: 'Global Carry Vault',
+    symbol: 'yvEMD',
+    shares: 214.1,
+    apy: 9.1,
+    valueUsd: 228.55,
+    unrealizedGainUsd: 14.07,
+    issuer: 'Templeton',
+    status: 'pending',
+  },
+];
+
+/**
+ * Intercept mock API routes so tests are fully deterministic.
+ */
+export async function interceptApiRoutes(page: Page) {
+  await page.route('**/mock-api/vault-summary.json', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(vaultSummary),
+    }),
+  );
+  await page.route('**/mock-api/portfolio-holdings.json', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(portfolioHoldings),
+    }),
+  );
+}
+
+/**
+ * Stub the Freighter browser extension message protocol.
+ *
+ * @stellar/freighter-api communicates with the extension via window.postMessage
+ * using the source key "FREIGHTER_EXTERNAL_MSG_REQUEST". The extension responds
+ * with "FREIGHTER_EXTERNAL_MSG_RESPONSE". We intercept those messages and reply
+ * with the appropriate shape so the app believes a wallet is connected.
+ *
+ * The stub is stateful: call page.evaluate(() => window.__freighterStub.disconnect())
+ * to make subsequent isAllowed() calls return false, simulating a real disconnect.
+ *
+ * This must be injected via addInitScript so it runs before the app bundle.
+ */
+export async function stubFreighterConnected(page: Page, address: string) {
+  await page.addInitScript((addr) => {
+    // Stateful stub — tests can call window.__freighterStub.disconnect()
+    const stub = { connected: true };
+    (window as unknown as Record<string, unknown>).__freighterStub = stub;
+
+    window.addEventListener('message', (event) => {
+      if (
+        event.source !== window ||
+        !event.data ||
+        event.data.source !== 'FREIGHTER_EXTERNAL_MSG_REQUEST'
+      ) {
+        return;
+      }
+
+      const { messageId, type } = event.data as { messageId: number; type: string };
+
+      let response: Record<string, unknown> = {
+        source: 'FREIGHTER_EXTERNAL_MSG_RESPONSE',
+        messagedId: messageId, // note: the library uses "messagedId" (typo in source)
+      };
+
+      switch (type) {
+        case 'REQUEST_ALLOWED_STATUS':
+        case 'SET_ALLOWED_STATUS':
+          response = { ...response, isAllowed: stub.connected };
+          break;
+        case 'REQUEST_PUBLIC_KEY':
+          response = { ...response, publicKey: stub.connected ? addr : '' };
+          break;
+        case 'REQUEST_ACCESS':
+          response = { ...response, publicKey: stub.connected ? addr : '' };
+          break;
+        case 'REQUEST_CONNECTION_STATUS':
+          response = { ...response, isConnected: stub.connected };
+          break;
+        case 'REQUEST_NETWORK_DETAILS':
+          response = {
+            ...response,
+            networkDetails: {
+              network: 'TESTNET',
+              networkName: 'Test SDF Network',
+              networkUrl: 'https://horizon-testnet.stellar.org',
+              networkPassphrase: 'Test SDF Network ; September 2015',
+              sorobanRpcUrl: 'https://soroban-testnet.stellar.org',
+            },
+          };
+          break;
+        default:
+          return;
+      }
+
+      window.postMessage(response, window.location.origin);
+    });
+  }, address);
+}
+
+type Fixtures = {
+  /** Page with API routes intercepted — no wallet connected */
+  appPage: Page;
+};
+
+export const test = base.extend<Fixtures>({
+  appPage: async ({ page }, use) => {
+    await interceptApiRoutes(page);
+    await use(page);
+  },
+});
+
+export { expect } from '@playwright/test';

--- a/frontend/e2e/portfolio.spec.ts
+++ b/frontend/e2e/portfolio.spec.ts
@@ -1,0 +1,96 @@
+﻿/**
+ * Flow 3: Portfolio Page
+ */
+import { test, expect, interceptApiRoutes, stubFreighterConnected } from './fixtures';
+
+const MOCK_ADDRESS = 'GABC1TEST2STELLAR3ADDRESS4FAKE5XYZ6ABCDEFGHIJKLMNOPQRSTU';
+const SHORT_ADDR = `${MOCK_ADDRESS.substring(0, 5)}...${MOCK_ADDRESS.substring(MOCK_ADDRESS.length - 4)}`;
+
+test.describe('Portfolio page  unauthenticated', () => {
+  test('shows connect-wallet prompt when no wallet is connected', async ({ page }) => {
+    await interceptApiRoutes(page);
+    await page.goto('/portfolio');
+    await expect(page.getByRole('heading', { name: 'Your Portfolio' })).toBeVisible();
+    await expect(page.getByText('Please connect your wallet to view your portfolio.')).toBeVisible();
+    await expect(page.getByRole('table')).not.toBeVisible();
+  });
+});
+
+test.describe('Portfolio page  authenticated', () => {
+  test.beforeEach(async ({ page }) => {
+    await interceptApiRoutes(page);
+    await stubFreighterConnected(page, MOCK_ADDRESS);
+  });
+
+  test('loads and displays portfolio holdings after wallet connects', async ({ page }) => {
+    await page.goto('/portfolio');
+    await expect(page.getByText(SHORT_ADDR)).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('Total Assets')).toBeVisible();
+    await expect(page.getByRole('table', { name: 'Portfolio holdings' })).toBeVisible();
+    // Highest value holding from mock data (sorted by valueUsd desc)
+    await expect(page.getByText('Tokenized T-Bills')).toBeVisible();
+  });
+
+  test('displays correct total portfolio value', async ({ page }) => {
+    await page.goto('/portfolio');
+    await expect(page.getByText(SHORT_ADDR)).toBeVisible({ timeout: 5000 });
+    // Sum: 1250.5 + 894.41 + 512.9 + 1404.32 + 337.08 + 228.55 = $4,627.76
+    await expect(page.getByText('$4,627.76')).toBeVisible({ timeout: 5000 });
+  });
+
+  test('search filter narrows holdings results', async ({ page }) => {
+    await page.goto('/portfolio');
+    await expect(page.getByText(SHORT_ADDR)).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole('table', { name: 'Portfolio holdings' })).toBeVisible();
+
+    const searchInput = page.getByPlaceholder('Search asset, vault, issuer...');
+    await searchInput.fill('Franklin');
+
+    await expect(page.getByText('USDC Treasury Pool')).toBeVisible();
+    await expect(page.getByText('Tokenized T-Bills')).not.toBeVisible();
+    await expect(page.getByText('1 holdings found')).toBeVisible();
+  });
+
+  test('clearing search restores all holdings', async ({ page }) => {
+    await page.goto('/portfolio');
+    await expect(page.getByText(SHORT_ADDR)).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole('table', { name: 'Portfolio holdings' })).toBeVisible();
+
+    const searchInput = page.getByPlaceholder('Search asset, vault, issuer...');
+    await searchInput.fill('Franklin');
+    await expect(page.getByText('1 holdings found')).toBeVisible();
+    await searchInput.clear();
+    await expect(page.getByText('6 holdings found')).toBeVisible();
+  });
+
+  test('rows-per-page selector changes visible row count', async ({ page }) => {
+    await page.goto('/portfolio');
+    await expect(page.getByText(SHORT_ADDR)).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole('table', { name: 'Portfolio holdings' })).toBeVisible();
+
+    // Default page size 4 => 4 data rows + 1 header = 5 rows total
+    const rows = page.getByRole('row');
+    await expect(rows).toHaveCount(5);
+
+    await page.getByRole('combobox', { name: 'Rows per page' }).selectOption('6');
+    // 6 data rows + 1 header = 7
+    await expect(rows).toHaveCount(7);
+  });
+
+  test('column sort changes row order', async ({ page }) => {
+    await page.goto('/portfolio');
+    await expect(page.getByText(SHORT_ADDR)).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole('table', { name: 'Portfolio holdings' })).toBeVisible();
+
+    // Default sort: valueUsd desc  Tokenized T-Bills ($1,404.32) is first
+    const firstDataRow = page.getByRole('row').nth(1);
+    await expect(firstDataRow.getByRole('cell').first()).toContainText('Tokenized T-Bills');
+
+    // First click on APY sorts asc (lowest first: Tokenized T-Bills 5.95%)
+    // Second click sorts desc (highest first: EM Debt Blend 9.1%)
+    const apyHeader = page.getByRole('columnheader', { name: 'APY' });
+    await apyHeader.click(); // asc
+    await apyHeader.click(); // desc
+    await expect(page.getByRole('row').nth(1).getByRole('cell').first()).toContainText('EM Debt Blend');
+  });
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
+        "@playwright/test": "^1.58.2",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -1308,6 +1309,22 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -4399,6 +4416,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,11 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest",
+    "test:run": "vitest --run",
     "test:ui": "vitest --ui",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:debug": "playwright test --debug",
     "docs:api": "typedoc --entryPointStrategy expand --out ../docs/api/frontend src"
   },
   "dependencies": {
@@ -22,6 +26,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
+    "@playwright/test": "^1.58.2",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  outputDir: './test-results',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI
+    ? [['html', { outputFolder: 'playwright-report' }], ['github']]
+    : [['html', { outputFolder: 'playwright-report', open: 'never' }]],
+  use: {
+    baseURL: 'http://localhost:4173',
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    // In CI the build step runs separately; here we only start the preview server.
+    command: 'npm run preview',
+    url: 'http://localhost:4173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+});

--- a/frontend/tsconfig.e2e.json
+++ b/frontend/tsconfig.e2e.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["node"],
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["e2e/**/*.ts", "playwright.config.ts"]
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -2,6 +2,7 @@
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.e2e.json" }
   ]
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: './src/tests/setup.ts',
     css: true,
+    exclude: ['**/node_modules/**', '**/e2e/**'],
   },
 })
 


### PR DESCRIPTION
closes #97 

- Add 22 E2E tests across 3 critical flows:
  - Dashboard load: vault stats, nav routing, analytics metrics
  - Deposit/Withdraw: wallet connect stub, deposit/withdraw balance updates, disconnect
  - Portfolio: auth gate, holdings table, search, sort, pagination

- Stub @stellar/freighter-api via postMessage protocol interception (addInitScript) so no real browser extension is needed in CI

- Intercept mock API routes via page.route() for deterministic data

- Add .github/workflows/e2e.yml: builds app, runs Playwright on Chromium, uploads HTML report always + screenshots/videos on failure

- Add playwright.config.ts with retain-on-failure traces/screenshots/videos
- Add tsconfig.e2e.json for e2e/ TypeScript config
- Exclude e2e/ from Vitest discovery to prevent test runner conflicts