### PR TITLE
feat: implemented sharable link with prefilled deposit amout

### DIFF
--- a/frontend/src/components/VaultDashboard.tsx
+++ b/frontend/src/components/VaultDashboard.tsx
@@ -1,21 +1,27 @@
 import React, { useEffect, useState } from "react";
-import { Activity, AlertCircle, ShieldCheck, TrendingUp, Wallet as WalletIcon, Loader2, Info } from "./icons";
+import { useSearchParams } from "react-router-dom";
+import { 
+  Activity, 
+  AlertCircle, 
+  ShieldCheck, 
+  TrendingUp, 
+  Wallet as WalletIcon, 
+  Loader2, 
+  Info,
+  Share2
+} from "./icons";
 import Skeleton from "./Skeleton";
 import { useVault } from "../context/VaultContext";
 import ApiStatusBanner from "./ApiStatusBanner";
 import VaultPerformanceChart from "./VaultPerformanceChart";
 import { useToast } from "../context/ToastContext";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "./Tabs";
-import { FormField } from "../forms";
-import WithdrawalConfirmationModal from "./WithdrawalConfirmationModal";
 import { FormField, SubmitButton } from "../forms";
+import WithdrawalConfirmationModal from "./WithdrawalConfirmationModal";
 import { useDepositMutation, useWithdrawMutation } from "../hooks/useVaultMutations";
 import TransactionStatus, { type ActionStatus } from "./TransactionStatus";
 import CopyButton from "./CopyButton";
-import {
-  useDepositMutation,
-  useWithdrawMutation,
-} from "../hooks/useVaultMutations";
+import { copyTextToClipboard } from "../lib/clipboard";
 
 interface VaultDashboardProps {
   walletAddress: string | null;
@@ -144,6 +150,19 @@ const VaultDashboard: React.FC<VaultDashboardProps> = ({
 
   const depositMutation = useDepositMutation();
   const withdrawMutation = useWithdrawMutation();
+
+  const [searchParams] = useSearchParams();
+
+  useEffect(() => {
+    const amountParam = searchParams.get("amount");
+    if (amountParam) {
+      const val = Number(amountParam);
+      if (!Number.isNaN(val) && val > 0) {
+        setAmount(val.toString());
+        setActiveTab("deposit");
+      }
+    }
+  }, [searchParams]);
 
   useEffect(() => {
     const handleTrigger = () => {
@@ -547,7 +566,41 @@ const VaultDashboard: React.FC<VaultDashboardProps> = ({
                     />
 
                     <div className="flex justify-between items-center" style={{ margin: "16px 0 24px" }}>
-                      <span style={{ color: "var(--text-secondary)", fontSize: "0.85rem" }}>Asset: USDC</span>
+                      <div className="flex items-center gap-sm">
+                        <span style={{ color: "var(--text-secondary)", fontSize: "0.85rem" }}>Asset: USDC</span>
+                        {tab === "deposit" && (
+                          <>
+                            <div style={{ width: "1px", height: "14px", background: "var(--border-glass)", margin: "0 4px" }} />
+                            <button
+                              type="button"
+                              className="btn-link flex items-center gap-xs"
+                              style={{ fontSize: "0.75rem", color: "var(--accent-cyan)", padding: 0 }}
+                              onClick={async () => {
+                                const baseUrl = window.location.origin + window.location.pathname;
+                                const shareUrl = amount && !isNaN(Number(amount)) && Number(amount) > 0
+                                  ? `${baseUrl}?amount=${amount}`
+                                  : baseUrl;
+                                
+                                try {
+                                  await copyTextToClipboard(shareUrl);
+                                  toast.success({
+                                    title: "Link copied",
+                                    description: "Shareable vault link is ready to paste."
+                                  });
+                                } catch (err) {
+                                  toast.error({
+                                    title: "Copy failed",
+                                    description: "Could not copy link to clipboard."
+                                  });
+                                }
+                              }}
+                            >
+                              <Share2 size={12} />
+                              Share Link
+                            </button>
+                          </>
+                        )}
+                      </div>
                       <button
                         type="button"
                         className="btn-max"

--- a/frontend/src/components/icons.ts
+++ b/frontend/src/components/icons.ts
@@ -20,4 +20,6 @@ export {
   DollarSign,
   Percent,
   Briefcase,
+  Share2,
+  Link,
 } from "lucide-react";

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -594,6 +594,29 @@ button {
   border-color: rgba(255, 255, 255, 0.2);
 }
 
+.btn-link {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--accent-cyan);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  transition: opacity 0.2s, color 0.2s;
+  min-height: auto;
+  min-width: auto;
+}
+
+.btn-link:hover {
+  opacity: 0.8;
+  text-decoration: underline;
+}
+
+.btn-link:active {
+  transform: scale(0.98);
+}
+
 /* Animations */
 @keyframes puiseGlow {
   0% { box-shadow: 0 0 20px rgba(0, 240, 255, 0.1); }


### PR DESCRIPTION
# Pull Request Template
Closes #237 
Closes #242 

## 📋 Description
<!-- Provide a brief description of the changes in this PR -->

## 🔗 Type of Change
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🔒 Security improvement

---

## 🔒 SECURITY REVIEW (⭐ MANDATORY FOR SMART CONTRACT CHANGES)

**For all smart contract code changes, complete the following checklist.**

See [`docs/SECURITY_CHECKLIST.md`](/docs/SECURITY_CHECKLIST.md) for detailed guidance.

### Required: Security Checklist Sign-Off
- [ ] **I have reviewed this PR against the Internal Security Checklist** (`docs/SECURITY_CHECKLIST.md`)
  - [ ] Reentrancy: Verified Checks-Effects-Interactions (CEI) pattern
  - [ ] Access Control: Confirmed all sensitive functions are protected (`onlyOwner`, `onlyRole()`, etc.)
  - [ ] Input Validation: Validated all parameters have appropriate bounds checks
  - [ ] Unchecked Returns: All external calls have return value checks (`require(success, ...)`)
  - [ ] Gas Limits: No unbounded loops or potential DOS vectors
  
  **If any checkbox cannot be verified, explain below:**
  ```
  [Explanation here]
  ```

### Slither Static Analysis Results
- [ ] Ran Slither locally: `slither . --config-file slither.config.json`
  - **Result**: ✅ No High/Medium findings OR 🟡 Documented false positives (see below)
  
- [ ] GitHub Actions Slither workflow passed:
  - 🟢 All High/Medium findings fixed OR
  - 🟡 All false positives documented with FP references
  
  **If this PR has security findings, document them below:**

### Handling Security Findings

#### Option A: Fixed in This PR ✅
- [ ] Vulnerability identified and resolved
- [ ] Test case added to verify fix
- [ ] Explain fix below:
  ```
  [Explanation of fix]
  ```

#### Option B: False Positive 🟡
- [ ] Identified as false positive (tool limitation or misleading check)
- [ ] Added entry to `contracts/.false-positives.md` with:
  - Detector rule name
  - Technical reasoning (3+ sentences why it's safe)
  - Evidence (code snippet, test case, or reference)
- [ ] Reference number (e.g., FP-001):
  ```
  [FP number and explanation]
  ```
- [ ] Inline suppression added to code:
  ```solidity
  // slither-disable-next-line <detector-name>
  // Reason: [one-line reason]
  ```

#### Option C: Accepted Risk ⚠️
- [ ] Acknowledged as low-priority style issue (naming conventions, etc.)
- [ ] Added to Slither exclusions
- [ ] Explain below:
  ```
  [Explanation]
  ```

---

## 📝 Testing

### Functional Testing
- [ ] Unit tests added/updated for changes
- [ ] Integration tests passing
- [ ] Manual testing completed and documented below:
  ```
  [Testing steps or scenarios]
  ```

### Security Testing
- For state-changing functions:
  - [ ] Reentrancy test (if applicable): Verify re-entry is blocked
  - [ ] Access control test: Verify unauthorized access is rejected
  - [ ] Boundary test: Verify edge cases are handled
  
- For external integrations:
  - [ ] Return value verification test
  - [ ] Failure scenario test

### Test Coverage
- [ ] All new code paths have test coverage
- [ ] Security-critical paths have comprehensive test cases
- [ ] Coverage report: `[Link or reference]`

---

## 🚀 Deployment Notes

<!-- Any deployment considerations, migration steps, or special instructions -->

### Mainnet Readiness
- [ ] This code is ready for production deployment
- [ ] All critical tests pass
- [ ] Security review approved
- [ ] No temporary debug code
- [ ] No TODO comments

### Breaking Changes
If this PR introduces breaking changes:
- [ ] Migration guide provided
- [ ] Deprecation period defined: `[timeframe]`
- [ ] Legacy code deprecated with warnings

---

## 📊 Automated Scan Results

<!-- GitHub Actions will update this section -->

### Slither Analysis
- ✓ Status: [Pending workflow execution]
- 🔴 High/Medium findings: [Number] ([View in Security tab](../../security/code-scanning))
- 🟡 Low/Informational findings: [Number]
- 🟢 No issues detected: [If applicable]

### Related Documentation
- [Security Checklist](docs/SECURITY_CHECKLIST.md) — Use for code review
- [False Positive Process](docs/FALSE_POSITIVE_HANDLING.md) — For non-vulnerabilities
- [Slither Configuration](slither.config.json) — Current scanner settings

---

## ✅ Reviewer Checklist

**For code reviewers** (use this to guide your security-focused review):

- [ ] PR author completed security checklist ✓
- [ ] All findings documented and categorized (fixed/false positive/excluded)
- [ ] Inline security comments are clear and justified
- [ ] Tests cover security-critical code paths
- [ ] No external calls bypass return value checks
- [ ] Access control is properly enforced
- [ ] State updates follow CEI pattern
- [ ] Input validation is comprehensive
- [ ] Follow-up actions (if any) tracked in issues

---

## 📞 Questions or Issues?

- 🤔 Confused about security checklist? → See [`docs/SECURITY_CHECKLIST.md`](/docs/SECURITY_CHECKLIST.md)
- 🔍 Marking finding as false positive? → Follow [`docs/FALSE_POSITIVE_HANDLING.md`](/docs/FALSE_POSITIVE_HANDLING.md)
- 🆘 Need security review help? → Tag `@security-team` in comments

---

## 📋 Pre-Submit Checklist

Before marking PR as ready for review:

- [ ] Description is clear and concise
- [ ] All security checklist items checked (✅ or explanation provided)
- [ ] All tests passing locally: `npm test`
- [ ] Linter passing: `npm run lint`
- [ ] Slither passing locally OR findings documented: `slither . --config-file slither.config.json`
- [ ] Code follows project style guide
- [ ] No merge conflicts
- [ ] Commits are clean and well-documented
- [ ] Branch is up-to-date with main/develop

---

**✅ Ready for Review?** Ensure all items above are checked before requesting review.

