### PR TITLE
fix: derive Stellar Explorer link network from networkConfig instead of hardcoding testnet

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -129,6 +129,7 @@
       "version": "7.29.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -457,6 +458,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -501,6 +503,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -2066,6 +2069,7 @@
       "version": "10.4.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2274,6 +2278,7 @@
       "version": "24.12.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2282,6 +2287,7 @@
       "version": "19.2.14",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2290,6 +2296,7 @@
       "version": "19.2.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2344,6 +2351,7 @@
       "version": "8.56.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -2593,6 +2601,7 @@
       "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.5",
@@ -2722,6 +2731,7 @@
       "integrity": "sha512-3Z9HNFiV0IF1fk0JPiK+7kE1GcaIPefQQIBYur6PM5yFIq6agys3uqP/0t966e1wXfmjbRCHDe7qW236Xjwnag==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.1.5",
         "fflate": "^0.8.2",
@@ -2757,6 +2767,7 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2971,6 +2982,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3889,6 +3901,7 @@
       "version": "9.39.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5568,6 +5581,7 @@
     "node_modules/react": {
       "version": "19.2.4",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5575,6 +5589,7 @@
     "node_modules/react-dom": {
       "version": "19.2.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5586,13 +5601,15 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -5699,7 +5716,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -5736,6 +5754,7 @@
       "version": "4.59.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -6251,6 +6270,7 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6375,6 +6395,7 @@
       "version": "7.3.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -6465,6 +6486,7 @@
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.5",
         "@vitest/mocker": "4.1.5",
@@ -6777,6 +6799,7 @@
     "node_modules/zod": {
       "version": "4.3.6",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/config/network.ts
+++ b/frontend/src/config/network.ts
@@ -5,6 +5,7 @@ export interface NetworkConfig {
   rpcUrl: string;
   networkPassphrase: string;
   contractId: string;
+  isTestnet: boolean;
 }
 
 export const networkConfig: NetworkConfig = {
@@ -12,6 +13,9 @@ export const networkConfig: NetworkConfig = {
   networkPassphrase:
     import.meta.env.VITE_STELLAR_NETWORK_PASSPHRASE || TESTNET_PASSPHRASE,
   contractId: import.meta.env.VITE_VAULT_CONTRACT_ID || "",
+  isTestnet:
+    (import.meta.env.VITE_STELLAR_NETWORK_PASSPHRASE || TESTNET_PASSPHRASE) ===
+    TESTNET_PASSPHRASE,
 };
 
 export const hasCustomRpcConfig = Boolean(import.meta.env.VITE_SOROBAN_RPC_URL);

--- a/frontend/src/pages/TransactionHistory.test.tsx
+++ b/frontend/src/pages/TransactionHistory.test.tsx
@@ -5,6 +5,18 @@ import TransactionHistory from "./TransactionHistory";
 import * as transactionApi from "../lib/transactionApi";
 import type { Transaction } from "../lib/transactionApi";
 
+// Hoisted so it can be referenced inside vi.mock factories
+const mockNetworkConfig = vi.hoisted(() => ({
+  isTestnet: true,
+  rpcUrl: "https://soroban-testnet.stellar.org",
+  networkPassphrase: "Test SDF Network ; September 2015",
+  contractId: "",
+}));
+
+vi.mock("../config/network", () => ({
+  networkConfig: mockNetworkConfig,
+}));
+
 // Mock the transactionApi module
 vi.mock("../lib/transactionApi", async (importOriginal) => {
   const actual = await importOriginal<typeof transactionApi>();
@@ -53,6 +65,7 @@ describe("TransactionHistory", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.spyOn(console, "error").mockImplementation(() => undefined);
+    mockNetworkConfig.isTestnet = true;
   });
 
   afterEach(() => {
@@ -298,5 +311,65 @@ describe("TransactionHistory", () => {
         screen.getByText("No transactions matched the current filter."),
       ).toBeInTheDocument(),
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stellar Explorer link — network-aware URL (issue #294)
+// ---------------------------------------------------------------------------
+
+const VALID_HASH = "a".repeat(64);
+
+describe("TransactionHistory — Stellar Explorer link network", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    mockNetworkConfig.isTestnet = true;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("generates a testnet explorer URL when networkConfig.isTestnet is true", async () => {
+    mockNetworkConfig.isTestnet = true;
+    mockGetTransactions.mockResolvedValue([
+      makeTransaction({ transactionHash: VALID_HASH }),
+    ]);
+
+    renderPage(WALLET);
+
+    const link = await screen.findByTitle(VALID_HASH);
+    expect(link).toHaveAttribute(
+      "href",
+      `https://stellar.expert/explorer/testnet/tx/${VALID_HASH}`,
+    );
+  });
+
+  it("generates a mainnet explorer URL when networkConfig.isTestnet is false", async () => {
+    mockNetworkConfig.isTestnet = false;
+    mockGetTransactions.mockResolvedValue([
+      makeTransaction({ transactionHash: VALID_HASH }),
+    ]);
+
+    renderPage(WALLET);
+
+    const link = await screen.findByTitle(VALID_HASH);
+    expect(link).toHaveAttribute(
+      "href",
+      `https://stellar.expert/explorer/public/tx/${VALID_HASH}`,
+    );
+  });
+
+  it("renders the explorer link with correct security attributes", async () => {
+    mockGetTransactions.mockResolvedValue([
+      makeTransaction({ transactionHash: VALID_HASH }),
+    ]);
+
+    renderPage(WALLET);
+
+    const link = await screen.findByTitle(VALID_HASH);
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
   });
 });

--- a/frontend/src/pages/TransactionHistory.tsx
+++ b/frontend/src/pages/TransactionHistory.tsx
@@ -20,6 +20,7 @@ import {
 import { useClientDataTable } from "../hooks/useClientDataTable";
 import { useDataTableState } from "../hooks/useDataTableState";
 import { getStellarExplorerUrl } from "../lib/security";
+import { networkConfig } from "../config/network";
 
 interface TransactionHistoryProps {
   walletAddress: string | null;
@@ -65,7 +66,7 @@ const columns: DataTableColumn<Transaction>[] = [
     sortable: false,
     cell: (row) => (
       <a
-        href={getStellarExplorerUrl(row.transactionHash, "testnet")}
+        href={getStellarExplorerUrl(row.transactionHash, networkConfig.isTestnet ? "testnet" : "mainnet")}
         target="_blank"
         rel="noopener noreferrer"
         style={{ color: "var(--accent-cyan)", textDecoration: "none" }}


### PR DESCRIPTION
## Summary                                                                                                              

  - **Added `isTestnet` to `NetworkConfig`** in `config/network.ts` — derived from comparing the active `networkPassphrase` to the known testnet passphrase constant, so it is always consistent with the RPC URL default                                                                     
  - **Fixed hardcoded `"testnet"` in `TransactionHistory.tsx` line 68** — the Stellar Explorer `href` now reads `networkConfig.isTestnet ? "testnet" : "mainnet"` rather than the literal string `"testnet"`                                                                                     
  - **Added 3 tests to `TransactionHistory.test.tsx`** covering the network-aware URL behavior: testnet URL when `isTestnet` is true, mainnet URL when `isTestnet` is false, and correct `target`/`rel` security attributes on the link                                                       
                
Closes #294 