### PR TITLE
Add transaction history search

### DIFF
--- a/frontend/src/pages/TransactionHistory.test.tsx
+++ b/frontend/src/pages/TransactionHistory.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 import TransactionHistory from "./TransactionHistory";
@@ -56,6 +56,7 @@ describe("TransactionHistory", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -208,6 +209,57 @@ describe("TransactionHistory", () => {
     expect(options).toContain("All");
     expect(options).toContain("Deposit");
     expect(options).toContain("Withdrawal");
+  });
+
+  it("filters transactions with a debounced client-side search input", async () => {
+    mockGetTransactions.mockResolvedValue([
+      makeTransaction({ id: "1", asset: "USDC", type: "deposit" }),
+      makeTransaction({
+        id: "2",
+        asset: "EURC",
+        type: "withdrawal",
+        transactionHash: "eurcdef1234567890abcdef1234567890abcdef12",
+      }),
+    ]);
+
+    renderPage(WALLET);
+
+    await waitFor(() => expect(screen.getByText("USDC")).toBeInTheDocument());
+    vi.useFakeTimers();
+
+    const searchInput = screen.getByRole("searchbox", {
+      name: /Search transactions/i,
+    });
+    expect(searchInput).toBeInTheDocument();
+
+    fireEvent.change(searchInput, { target: { value: "EURC" } });
+
+    act(() => {
+      vi.advanceTimersByTime(299);
+    });
+
+    expect(mockGetTransactions).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("USDC")).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+
+    await waitFor(() =>
+      expect(screen.queryByText("USDC")).not.toBeInTheDocument(),
+    );
+    expect(screen.getByText("EURC")).toBeInTheDocument();
+    expect(mockGetTransactions).toHaveBeenCalledTimes(1);
+
+    fireEvent.change(searchInput, { target: { value: "" } });
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    await waitFor(() => expect(screen.getByText("USDC")).toBeInTheDocument());
+    expect(screen.getByText("EURC")).toBeInTheDocument();
+    expect(mockGetTransactions).toHaveBeenCalledTimes(1);
   });
 
   // Req 5.3 — applying filter resets page to 1

--- a/frontend/src/pages/TransactionHistory.tsx
+++ b/frontend/src/pages/TransactionHistory.tsx
@@ -84,11 +84,12 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<ApiError | ValidationError | null>(null);
 
-  const { state, setSort, setPage, setPageSize } = useDataTableState({
+  const { state, setSearch, setSort, setPage, setPageSize } = useDataTableState({
     defaultSortBy: "date",
     defaultSortDirection: "desc",
     defaultPageSize: 10,
   });
+  const [searchInput, setSearchInput] = useState(state.search);
 
   const [searchParams, setSearchParams] = useSearchParams();
   const txType = (searchParams.get("txType") ?? "all") as TxTypeFilter;
@@ -99,6 +100,22 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({
     nextParams.set("page", "1");
     setSearchParams(nextParams, { replace: true });
   };
+
+  useEffect(() => {
+    setSearchInput(state.search);
+  }, [state.search]);
+
+  useEffect(() => {
+    if (searchInput === state.search) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setSearch(searchInput);
+    }, 300);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [searchInput, setSearch, state.search]);
 
   useEffect(() => {
     if (!walletAddress) {
@@ -218,6 +235,21 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({
               </div>
 
               <div className="portfolio-toolbar-controls">
+                <label className="input-group" style={{ minWidth: "220px" }}>
+                  <span className="text-body-sm">Search transactions</span>
+                  <div className="input-wrapper">
+                    <input
+                      aria-label="Search transactions"
+                      className="input-field"
+                      type="search"
+                      placeholder="Search asset, hash, type..."
+                      value={searchInput}
+                      onChange={(event) => setSearchInput(event.target.value)}
+                      style={{ fontSize: "var(--text-base)", fontFamily: "var(--font-sans)" }}
+                    />
+                  </div>
+                </label>
+
                 <label className="input-group" style={{ minWidth: "160px" }}>
                   <span className="text-body-sm">Type</span>
                   <div className="input-wrapper">


### PR DESCRIPTION
Closes #290

---

Implemented and pushed issue #290 for YieldVault-RWA.

What changed:

Added a free-text search input to frontend/src/pages/TransactionHistory.tsx.
Placed it in the existing portfolio-toolbar-controls toolbar area.
Search supports filtering by transaction type, asset, and transaction hash through the existing useClientDataTable search callback.
Added 300 ms debounce before updating table search state.
Uses useDataTableState.setSearch, so clearing/searching resets page to 1.
Added aria-label="Search transactions" for accessibility.
Kept filtering client-side only; typing does not trigger getTransactions.
Tests added:

Updated frontend/src/pages/TransactionHistory.test.tsx.
Added a regression test confirming:
Search input renders.
Search waits for debounce.
Rows filter client-side.
Clearing search shows all rows again.
No extra network fetch happens while typing.
Git:

Committed changes:
6fa4ca6 Add transaction history search
Pushed to:
origin/main