### PR TITLE
- Add dark mode support with theme persistence

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,19 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>frontend</title>
+    <title>YieldVault</title>
+    <!-- Prevent flash of unstyled content: apply saved theme before first paint -->
+    <script>
+      (function () {
+        try {
+          var saved = localStorage.getItem('theme');
+          var theme = saved === 'light' || saved === 'dark'
+            ? saved
+            : window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          document.documentElement.setAttribute('data-theme', theme);
+        } catch (e) {}
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
Closes #221

---

#221 

## Summary
Implements dark/light theme switching with persistent user preference and 
no flash of unstyled content on page load.

## Changes
- Add inline script to `index.html` that reads `localStorage` before first 
  paint and sets `data-theme` on `<html>`, eliminating FOUC
- Verified `ThemeContext` initializes from `localStorage` with 
  `prefers-color-scheme` fallback
- Verified `ThemeToggle` is rendered in `Navbar` and accessible on all pages
- Verified CSS variables for both themes defined in `index.css` under 
  `:root` (dark) and `[data-theme='light']`
- Verified all pages and components use `var(--*)` tokens throughout
- Verified `ThemeProvider` wraps the entire app in `main.tsx`
- Verified i18n labels for toggle aria-labels in both `en` and `es` locales

## Acceptance Criteria
- [x] Theme toggle works across all pages
- [x] Preference persists across sessions
- [x] No flash of unstyled content on load
- [x] Soroban-compatible CSS variables applied for both themes
- [x] All pages and components respect the active theme
