### PR TITLE
feat: add CHANGELOG.md and automated release workflow (#348)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,64 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Generate changelog and publish release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Generate the full CHANGELOG.md (all releases, written to file)
+      - name: Generate full CHANGELOG.md
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: cliff.toml
+          args: --verbose
+        env:
+          OUTPUT: CHANGELOG.md
+          GITHUB_REPO: ${{ github.repository }}
+
+      # Generate release-only notes for the GitHub Release body
+      - name: Generate release notes for this tag
+        id: cliff
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: cliff.toml
+          args: --latest --strip all
+        env:
+          OUTPUT: /tmp/release-notes.md
+          GITHUB_REPO: ${{ github.repository }}
+
+      # Commit the updated CHANGELOG.md back to the default branch
+      - name: Commit CHANGELOG.md
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          # Only commit if there are changes
+          if ! git diff --cached --quiet; then
+            git commit -m "chore(release): update CHANGELOG.md for ${{ github.ref_name }}"
+            git push origin HEAD:refs/heads/main
+          fi
+
+      # Create the GitHub Release with the generated notes
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.ref_name }}
+          tag_name: ${{ github.ref_name }}
+          body_path: /tmp/release-notes.md
+          draft: false
+          prerelease: ${{ contains(github.ref_name, '-') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to YieldVault-RWA are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+<!-- next-release -->
+
+## [Unreleased]
+
+### Features
+- CORS configuration for cross-origin API access
+- Structured logging, graceful shutdown, caching, and API key authentication
+- Network badge showing testnet vs mainnet status in the frontend
+
+### Bug Fixes
+- Vault performance dynamic date filter
+
+### Chores
+- Resolve merge conflict in Skeleton and dateUtils imports

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,57 @@
+[changelog]
+header = """
+# Changelog
+
+All notable changes to YieldVault-RWA are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+"""
+body = """
+{% if version %}\
+## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+## [Unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in commits %}\
+- {% if commit.breaking %}**BREAKING** {% endif %}{{ commit.message | upper_first }} ([`{{ commit.id | truncate(length=7, end="") }}`]({{ commit.id }}))\
+{% if commit.body %}\
+
+  {{ commit.body | indent(prefix="  ", first=true) }}
+{% else %}
+
+{% endif %}\
+{% endfor %}\
+{% endfor %}\
+"""
+footer = ""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+protect_breaking_commits = false
+filter_commits = false
+tag_pattern = "v[0-9].*"
+skip_tags = ""
+ignore_tags = ""
+topo_order = false
+sort_commits = "oldest"
+
+commit_parsers = [
+  { message = "^feat", group = "Features" },
+  { message = "^fix", group = "Bug Fixes" },
+  { message = "^docs", group = "Documentation" },
+  { message = "^perf", group = "Performance" },
+  { message = "^refactor", group = "Refactoring" },
+  { message = "^style", group = "Styling" },
+  { message = "^test", group = "Testing" },
+  { message = "^chore\\(release\\)", skip = true },
+  { message = "^chore", group = "Chores" },
+  { message = "^ci", group = "CI/CD" },
+  { message = "^revert", group = "Reverts" },
+  { body = ".*security", group = "Security" },
+]


### PR DESCRIPTION
 Closes #348 — adds a standardised changelog and fully automated release       
  pipeline triggered by version tags.
                                                                                
  - **`cliff.toml`** — git-cliff configuration: parses Conventional Commits     
    and groups them into labelled sections (Features, Bug Fixes, Docs,
    Performance, Refactoring, Testing, Chores, CI/CD, Security, Reverts).       
    `chore(release)` commits are silently skipped so the auto-commit that
    updates `CHANGELOG.md` doesn't appear in the next release's notes.          
                                                                                
  - **`CHANGELOG.md`** — initial changelog seeded with recent unreleased        
    work. After this PR merges, the file is managed entirely by the workflow.   
                                                                                
  - **`.github/workflows/release.yml`** — fires on any `v*.*.*` tag push:       
    1. Checks out full git history (`fetch-depth: 0`) so cliff can walk all     
  commits.                                                                      
    2. Regenerates the complete `CHANGELOG.md` and commits it back to `main`.
    3. Generates isolated notes for the tagged release (`--latest --strip all`).
    4. Creates a GitHub Release via `softprops/action-gh-release`, using the    
       generated notes as the body. Tags containing a hyphen (e.g.              
  `v1.0.0-rc.1`)                                                                
       are automatically flagged as pre-release.                                
                                                                                
  ## How to cut a release                                   

  ```bash                                                                       
  git tag v1.0.0
  git push origin v1.0.0                                                        
                                                            
  The workflow handles everything from there.                                   
  
  Test plan                                                                     
                                                            
  - Push a test tag (v0.0.1-test) to a fork and verify:                         
    - CHANGELOG.md is committed to main with grouped sections
    - A GitHub Release is created with the tag's notes in the body              
    - The release is marked as pre-release (due to the -test suffix)
  - Push a stable tag (v1.0.0) and verify the release is not marked pre-release 
  - Confirm chore(release): update CHANGELOG.md … commits do not appear in      
  subsequent release notes                      