### PR TITLE
Feature: Add paginated transaction history filters

### DIFF
--- a/backend/src/__tests__/transactions.test.ts
+++ b/backend/src/__tests__/transactions.test.ts
@@ -1,0 +1,78 @@
+import request from 'supertest';
+import app from '../index';
+
+describe('GET /api/v1/transactions', () => {
+  it('returns total count with cursor-based pagination and no duplicate results across pages', async () => {
+    const firstPage = await request(app).get('/api/v1/transactions?limit=10');
+
+    expect(firstPage.status).toBe(200);
+    expect(firstPage.body.pagination.total).toBeGreaterThan(10);
+    expect(firstPage.body.pagination.nextCursor).toBeDefined();
+    expect(firstPage.body.data).toHaveLength(10);
+
+    const secondPage = await request(app).get(
+      `/api/v1/transactions?limit=10&cursor=${firstPage.body.pagination.nextCursor}`
+    );
+
+    expect(secondPage.status).toBe(200);
+    expect(secondPage.body.pagination.total).toBe(firstPage.body.pagination.total);
+
+    const firstPageIds = firstPage.body.data.map((transaction: { id: string }) => transaction.id);
+    const secondPageIds = secondPage.body.data.map((transaction: { id: string }) => transaction.id);
+    const duplicateIds = firstPageIds.filter((id: string) => secondPageIds.includes(id));
+
+    expect(duplicateIds).toEqual([]);
+  });
+
+  it('filters transactions by type accurately', async () => {
+    const response = await request(app).get('/api/v1/transactions?limit=100&type=deposit');
+
+    expect(response.status).toBe(200);
+    expect(response.body.pagination.total).toBe(response.body.data.length);
+    response.body.data.forEach((transaction: { type: string }) => {
+      expect(transaction.type).toBe('deposit');
+    });
+  });
+
+  it('filters transactions by status accurately', async () => {
+    const response = await request(app).get('/api/v1/transactions?limit=100&status=completed');
+
+    expect(response.status).toBe(200);
+    expect(response.body.pagination.total).toBe(response.body.data.length);
+    response.body.data.forEach((transaction: { status: string }) => {
+      expect(transaction.status).toBe('completed');
+    });
+  });
+
+  it('filters transactions by inclusive date range accurately', async () => {
+    const fullResponse = await request(app).get(
+      '/api/v1/transactions?limit=100&sortBy=timestamp&sortOrder=desc'
+    );
+
+    expect(fullResponse.status).toBe(200);
+    expect(fullResponse.body.data.length).toBeGreaterThan(20);
+
+    const from = fullResponse.body.data[20].timestamp;
+    const to = fullResponse.body.data[10].timestamp;
+    const expectedIds = fullResponse.body.data
+      .filter(
+        (transaction: { timestamp: string }) =>
+          transaction.timestamp >= from && transaction.timestamp <= to
+      )
+      .map((transaction: { id: string }) => transaction.id)
+      .sort();
+
+    const rangedResponse = await request(app).get(
+      `/api/v1/transactions?limit=100&from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`
+    );
+
+    expect(rangedResponse.status).toBe(200);
+    expect(rangedResponse.body.pagination.total).toBe(expectedIds.length);
+
+    const actualIds = rangedResponse.body.data
+      .map((transaction: { id: string }) => transaction.id)
+      .sort();
+
+    expect(actualIds).toEqual(expectedIds);
+  });
+});

--- a/backend/src/listEndpoints.ts
+++ b/backend/src/listEndpoints.ts
@@ -1,7 +1,7 @@
 /**
  * @file listEndpoints.ts
  * List endpoints with pagination and filtering support.
- * 
+ *
  * Provides consistent list endpoints for:
  * - Transactions
  * - Portfolio holdings
@@ -12,6 +12,7 @@ import { Router, Request, Response } from 'express';
 import {
   parsePaginationQuery,
   paginateWithCursor,
+  paginateWithOffset,
   sortItems,
   sendPaginatedResponse,
   encodeCursor,
@@ -40,6 +41,7 @@ const router = Router();
 interface Transaction {
   id: string;
   type: 'deposit' | 'withdrawal';
+  status: 'pending' | 'completed' | 'failed';
   amount: string;
   asset: string;
   timestamp: string;
@@ -103,6 +105,7 @@ interface VaultHistoryPoint {
 const MOCK_TRANSACTIONS: Transaction[] = Array.from({ length: 100 }, (_, i) => ({
   id: `tx-${i + 1}`,
   type: i % 2 === 0 ? 'deposit' : 'withdrawal',
+  status: i % 11 === 0 ? 'failed' : i % 3 === 0 ? 'pending' : 'completed',
   amount: (Math.random() * 1000).toFixed(2),
   asset: ['XLM', 'USDC', 'yUSDC', 'RWA'][i % 4],
   timestamp: new Date(Date.now() - i * 3600000).toISOString(),
@@ -159,17 +162,62 @@ const VAULT_HISTORY_PAGINATION_CONFIG: Partial<PaginationConfig> = {
  */
 function filterTransactions(
   transactions: Transaction[],
-  filters: { type?: string; walletAddress?: string }
+  filters: { type?: string; status?: string; walletAddress?: string; from?: string; to?: string }
 ): Transaction[] {
+  const from = parseDateFilter(filters.from, 'start');
+  const to = parseDateFilter(filters.to, 'end');
+
   return transactions.filter((tx) => {
     if (filters.type && filters.type !== 'all' && tx.type !== filters.type) {
+      return false;
+    }
+    if (filters.status && filters.status !== 'all' && tx.status !== filters.status) {
       return false;
     }
     if (filters.walletAddress && tx.walletAddress !== filters.walletAddress) {
       return false;
     }
+    if (!isTransactionInDateRange(tx.timestamp, from, to)) {
+      return false;
+    }
     return true;
   });
+}
+
+function parseDateFilter(value: string | undefined, boundary: 'start' | 'end'): number | null {
+  if (!value) {
+    return null;
+  }
+
+  const hasTimeComponent = value.includes('T');
+  const normalizedValue = hasTimeComponent
+    ? value
+    : boundary === 'start'
+      ? `${value}T00:00:00.000Z`
+      : `${value}T23:59:59.999Z`;
+  const timestamp = Date.parse(normalizedValue);
+
+  return Number.isNaN(timestamp) ? null : timestamp;
+}
+
+function isTransactionInDateRange(
+  timestamp: string,
+  from: number | null,
+  to: number | null
+): boolean {
+  const transactionTime = Date.parse(timestamp);
+
+  if (Number.isNaN(transactionTime)) {
+    return false;
+  }
+  if (from !== null && transactionTime < from) {
+    return false;
+  }
+  if (to !== null && transactionTime > to) {
+    return false;
+  }
+
+  return true;
 }
 
 /**
@@ -231,6 +279,15 @@ function filterVaultHistory(
  *         name: type
  *         schema: { type: string, enum: [deposit, withdrawal, all] }
  *       - in: query
+ *         name: status
+ *         schema: { type: string, enum: [pending, completed, failed, all] }
+ *       - in: query
+ *         name: from
+ *         schema: { type: string, format: date-time }
+ *       - in: query
+ *         name: to
+ *         schema: { type: string, format: date-time }
+ *       - in: query
  *         name: walletAddress
  *         schema: { type: string }
  *     responses:
@@ -253,6 +310,9 @@ router.get('/transactions', (req: Request, res: Response) => {
     const pagination = parsePaginationQuery(req, TRANSACTION_PAGINATION_CONFIG);
     const filters = {
       type: req.query.type as string | undefined,
+      status: req.query.status as string | undefined,
+      from: req.query.from as string | undefined,
+      to: req.query.to as string | undefined,
       walletAddress: req.query.walletAddress as string | undefined,
     };
 
@@ -264,14 +324,11 @@ router.get('/transactions', (req: Request, res: Response) => {
       filtered = sortItems(filtered, pagination.sortBy, pagination.sortOrder || 'desc');
     }
 
-    // Paginate with cursor
-    const { data, pagination: paginationMeta } = paginateWithCursor(
-      filtered,
-      pagination,
-      (tx) => encodeCursor(tx.id)
-    );
+    const paginated = pagination.page
+      ? paginateWithOffset(filtered, pagination)
+      : paginateWithCursor(filtered, pagination, (tx) => encodeCursor(tx.id));
 
-    sendPaginatedResponse(res, data, paginationMeta);
+    sendPaginatedResponse(res, paginated.data, paginated.pagination);
   } catch (error) {
     console.error('Error fetching transactions:', error);
     res.status(500).json({
@@ -375,10 +432,8 @@ router.get('/vault/history', (req: Request, res: Response) => {
     }
 
     // Paginate with cursor
-    const { data, pagination: paginationMeta } = paginateWithCursor(
-      filtered,
-      pagination,
-      (point) => encodeCursor(point.date)
+    const { data, pagination: paginationMeta } = paginateWithCursor(filtered, pagination, (point) =>
+      encodeCursor(point.date)
     );
 
     sendPaginatedResponse(res, data, paginationMeta);

--- a/backend/src/pagination.ts
+++ b/backend/src/pagination.ts
@@ -1,7 +1,7 @@
 /**
  * @file pagination.ts
  * Pagination utilities and types for consistent list endpoint behavior.
- * 
+ *
  * Provides:
  * - Cursor-based pagination for stable ordering
  * - Offset-based pagination for simple use cases
@@ -92,7 +92,7 @@ export const DEFAULT_PAGINATION_CONFIG: PaginationConfig = {
 
 /**
  * Parse and validate pagination query parameters from request.
- * 
+ *
  * @param req - Express request object
  * @param config - Pagination configuration
  * @returns Parsed and validated pagination query
@@ -149,7 +149,7 @@ export function parsePaginationQuery(
 
 /**
  * Apply cursor-based pagination to an array of items.
- * 
+ *
  * @param items - Array of items to paginate
  * @param query - Pagination query parameters
  * @param getCursor - Function to extract cursor from an item
@@ -162,13 +162,28 @@ export function paginateWithCursor<T>(
 ): { data: T[]; pagination: PaginationMeta } {
   const limit = query.limit || DEFAULT_PAGINATION_CONFIG.defaultLimit;
   let startIndex = 0;
+  let invalidCursor = false;
 
   // Find starting position based on cursor
   if (query.cursor) {
     const cursorIndex = items.findIndex((item) => getCursor(item) === query.cursor);
     if (cursorIndex !== -1) {
       startIndex = cursorIndex + 1;
+    } else {
+      invalidCursor = true;
     }
+  }
+
+  if (invalidCursor) {
+    return {
+      data: [],
+      pagination: {
+        count: 0,
+        total: items.length,
+        hasNextPage: false,
+        hasPrevPage: false,
+      },
+    };
   }
 
   // Extract page items
@@ -179,6 +194,7 @@ export function paginateWithCursor<T>(
   // Build pagination metadata
   const pagination: PaginationMeta = {
     count: data.length,
+    total: items.length,
     hasNextPage: hasMore,
     hasPrevPage: startIndex > 0,
   };
@@ -200,7 +216,7 @@ export function paginateWithCursor<T>(
 
 /**
  * Apply offset-based pagination to an array of items.
- * 
+ *
  * @param items - Array of items to paginate
  * @param query - Pagination query parameters
  * @returns Paginated result with metadata
@@ -231,7 +247,7 @@ export function paginateWithOffset<T>(
 
 /**
  * Sort items by a specified field.
- * 
+ *
  * @param items - Array of items to sort
  * @param sortBy - Field name to sort by
  * @param sortOrder - Sort direction
@@ -272,7 +288,7 @@ export function sortItems<T extends Record<string, unknown>>(
 
 /**
  * Create a standardized paginated response.
- * 
+ *
  * @param data - Array of data items
  * @param pagination - Pagination metadata
  * @returns Formatted paginated response
@@ -290,7 +306,7 @@ export function createPaginatedResponse<T>(
 
 /**
  * Send a paginated JSON response.
- * 
+ *
  * @param res - Express response object
  * @param data - Array of data items
  * @param pagination - Pagination metadata
@@ -309,13 +325,16 @@ export function sendPaginatedResponse<T>(
 
 /**
  * Middleware to parse and attach pagination query to request.
- * 
+ *
  * @param config - Pagination configuration
  * @returns Express middleware function
  */
 export function paginationMiddleware(config: Partial<PaginationConfig> = {}) {
   return (req: Request, _res: Response, next: NextFunction) => {
-    (req as Request & { pagination: PaginationQuery }).pagination = parsePaginationQuery(req, config);
+    (req as Request & { pagination: PaginationQuery }).pagination = parsePaginationQuery(
+      req,
+      config
+    );
     next();
   };
 }
@@ -324,7 +343,7 @@ export function paginationMiddleware(config: Partial<PaginationConfig> = {}) {
 
 /**
  * Encode a cursor value to a URL-safe base64 string.
- * 
+ *
  * @param value - Value to encode
  * @returns Encoded cursor string
  */
@@ -334,11 +353,10 @@ export function encodeCursor(value: string): string {
 
 /**
  * Decode a cursor value from a URL-safe base64 string.
- * 
+ *
  * @param cursor - Encoded cursor string
  * @returns Decoded cursor value
  */
 export function decodeCursor(cursor: string): string {
   return Buffer.from(cursor, 'base64url').toString('utf-8');
 }
-


### PR DESCRIPTION
### Goal
Allow users to retrieve full transaction history with server-side pagination and filtering. Closes #305.

### Changes
- Added server-side transaction filtering for `type`, `status`, `from`, and `to` on the transactions list endpoint.
- Updated cursor pagination metadata to return `total` counts alongside paginated transaction results.
- Made invalid cursors return an empty page predictably instead of falling back to the first page.
- Added focused backend tests covering cursor pagination, total counts, and transaction filtering accuracy.

### Testing
- Verified the updated transaction endpoint implementation is type-clean in the touched files.
- Added focused Jest coverage in `backend/src/__tests__/transactions.test.ts` for pagination and filtering behavior.
- Attempted to run the narrow backend test suite for the new transactions coverage, but execution is currently blocked by an unrelated existing compile error in `backend/src/tracing.ts`.