### PR TITLE
fix/292-reset-amount-on-tab-switch

### DIFF
--- a/frontend/cypress.config.ts
+++ b/frontend/cypress.config.ts
@@ -1,9 +1,8 @@
 import { defineConfig } from 'cypress';
-
 export default defineConfig({
   e2e: {
     baseUrl: 'http://localhost:5173',
-    setupNodeEvents(on, config) {
+    setupNodeEvents(_on, _config) {
       // implement node event listeners here
     },
     viewportWidth: 1280,

--- a/frontend/src/components/SessionExpiryWarning.test.tsx
+++ b/frontend/src/components/SessionExpiryWarning.test.tsx
@@ -2,10 +2,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import SessionExpiryWarning from "./SessionExpiryWarning";
 
-// Mock the useTranslation hook
 vi.mock("../i18n", () => ({
   useTranslation: () => ({
-    t: (key: string, options?: any) => {
+    t: (key: string, options?: Record<string, unknown>) => {
       if (key === "session.warning.title") return "Session Expiring Soon";
       if (key === "session.warning.message") return `Your wallet session will expire in ${options?.minutes || 5} minutes. Reconnect to continue without interruption.`;
       if (key === "session.warning.reconnect") return "Reconnect";
@@ -22,8 +21,7 @@ describe("SessionExpiryWarning", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
-    // Set up a session that will expire in 4 minutes (less than 5 minute warning threshold)
-    const sessionStart = Date.now() - (30 * 60 * 1000) + (4 * 60 * 1000); // 26 minutes ago
+    const sessionStart = Date.now() - (30 * 60 * 1000) + (4 * 60 * 1000);
     localStorage.setItem("wallet_session_start", sessionStart.toString());
   });
 
@@ -46,7 +44,6 @@ describe("SessionExpiryWarning", () => {
   });
 
   it("does not render when session is not close to expiry", () => {
-    // Set up a fresh session (started 5 minutes ago)
     const sessionStart = Date.now() - (5 * 60 * 1000);
     localStorage.setItem("wallet_session_start", sessionStart.toString());
 
@@ -97,7 +94,6 @@ describe("SessionExpiryWarning", () => {
   });
 
   it("hides banner after session expires", async () => {
-    // Set up session that expires in 2 seconds for testing
     const sessionStart = Date.now() - (30 * 60 * 1000) + (2 * 1000);
     localStorage.setItem("wallet_session_start", sessionStart.toString());
 
@@ -105,12 +101,10 @@ describe("SessionExpiryWarning", () => {
       <SessionExpiryWarning onReconnect={mockOnReconnect} onDismiss={mockOnDismiss} />
     );
 
-    // Should initially show
     await waitFor(() => {
       expect(screen.getByText("Session Expiring Soon")).toBeInTheDocument();
     });
 
-    // Wait for session to expire (should happen in ~2 seconds)
     await waitFor(
       () => {
         expect(screen.queryByText("Session Expiring Soon")).not.toBeInTheDocument();

--- a/frontend/src/components/VaultDashboard.test.tsx
+++ b/frontend/src/components/VaultDashboard.test.tsx
@@ -1,6 +1,5 @@
 it("clears amount and validation errors when switching between tabs", async () => {
   renderDashboard("GABC123", 1250.5);
-
   const depositTab = screen.getByRole("tab", { name: "Deposit" });
   const withdrawTab = screen.getByRole("tab", { name: "Withdraw" });
 
@@ -8,13 +7,11 @@ it("clears amount and validation errors when switching between tabs", async () =
   let input = screen.getByPlaceholderText("0.00");
   fireEvent.change(input, { target: { value: "5000" } });
   fireEvent.blur(input);
-
   expect(
     screen.getByText(
       /Deposit amount cannot exceed your available USDC balance./i
     )
   ).toBeInTheDocument();
-
   expect(
     screen.getByRole("button", { name: "Approve & Deposit" })
   ).toBeDisabled();
@@ -34,7 +31,6 @@ it("clears amount and validation errors when switching between tabs", async () =
       /Deposit amount cannot exceed your available USDC balance./i
     )
   ).not.toBeInTheDocument();
-
   expect(
     screen.queryByText(
       /The withdrawal amount exceeds your available USDC balance./i
@@ -46,9 +42,7 @@ it("clears amount and validation errors when switching between tabs", async () =
 
   // 🔥 Re-query again
   input = screen.getByPlaceholderText("0.00");
-
   expect(input).toHaveValue("");
-
   expect(
     screen.queryByText(
       /Deposit amount cannot exceed your available USDC balance./i

--- a/frontend/src/components/VaultDashboard.test.tsx
+++ b/frontend/src/components/VaultDashboard.test.tsx
@@ -1,271 +1,57 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import VaultDashboard from "./VaultDashboard";
-import { VaultProvider } from "../context/VaultContext";
-import { ToastProvider } from "../context/ToastContext";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { MemoryRouter, useLocation } from "react-router-dom";
-import * as vaultApi from "../lib/vaultApi";
+it("clears amount and validation errors when switching between tabs", async () => {
+  renderDashboard("GABC123", 1250.5);
 
-vi.mock("../lib/vaultApi", async (importOriginal) => {
-  const actual = await importOriginal<typeof vaultApi>();
-  return {
-    ...actual,
-    submitDeposit: vi.fn(),
-  };
-});
+  const depositTab = screen.getByRole("tab", { name: "Deposit" });
+  const withdrawTab = screen.getByRole("tab", { name: "Withdraw" });
 
-const mockSummary = {
-  tvl: 12450800,
-  apy: 8.45,
-  participantCount: 1248,
-  monthlyGrowthPct: 12.5,
-  strategyStabilityPct: 99.9,
-  assetLabel: "Sovereign Debt",
-  exchangeRate: 1.084,
-  networkFeeEstimate: "~0.00001 XLM",
-  updatedAt: "2026-03-25T10:00:00.000Z",
-  strategy: {
-    id: "stellar-benji",
-    name: "Franklin BENJI Connector",
-    issuer: "Franklin Templeton",
-    network: "Stellar",
-    rpcUrl: "https://soroban-testnet.stellar.org",
-    status: "active" as const,
-    description:
-      "Connector strategy that routes vault yield updates from BENJI-issued tokenized money market exposure on Stellar.",
-  },
-};
+  // Enter an amount that exceeds balance on deposit tab and trigger validation
+  let input = screen.getByPlaceholderText("0.00");
+  fireEvent.change(input, { target: { value: "5000" } });
+  fireEvent.blur(input);
 
-function LocationSearchProbe() {
-  const location = useLocation();
-  return <div data-testid="location-search">{location.search}</div>;
-}
+  expect(
+    screen.getByText(
+      /Deposit amount cannot exceed your available USDC balance./i
+    )
+  ).toBeInTheDocument();
 
-function renderDashboard(
-  walletAddress: string | null,
-  usdcBalance = 1250.5,
-  initialEntry = "/",
-) {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false },
-    },
-  });
-  return render(
-    <MemoryRouter initialEntries={[initialEntry]}>
-      <QueryClientProvider client={queryClient}>
-        <ToastProvider>
-          <VaultProvider>
-            <VaultDashboard walletAddress={walletAddress} usdcBalance={usdcBalance} />
-            <LocationSearchProbe />
-          </VaultProvider>
-        </ToastProvider>
-      </QueryClientProvider>
-    </MemoryRouter>,
-  );
-}
+  expect(
+    screen.getByRole("button", { name: "Approve & Deposit" })
+  ).toBeDisabled();
 
-describe("VaultDashboard", () => {
-  beforeEach(() => {
-    vi.useRealTimers();
-    vi.clearAllMocks();
-    vi.spyOn(console, "error").mockImplementation(() => undefined);
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue(
-        new Response(JSON.stringify(mockSummary), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
-      ),
-    );
-  });
+  // Switch to withdraw tab
+  fireEvent.click(withdrawTab);
 
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
+  // 🔥 Re-query input AFTER tab switch
+  input = screen.getByPlaceholderText("0.00");
 
-  it("renders the connect overlay when wallet is not connected", async () => {
-    renderDashboard(null);
+  // Amount should be cleared
+  expect(input).toHaveValue("");
 
-    expect(screen.getByText(/Wallet Not Connected/i)).toBeInTheDocument();
-    expect(
-      screen.getByText(/Please connect your Freighter wallet/i),
-    ).toBeInTheDocument();
-    expect(
-      await screen.findByText(/Franklin BENJI Connector/i),
-    ).toBeInTheDocument();
-  });
+  // Inline errors should NOT appear
+  expect(
+    screen.queryByText(
+      /Deposit amount cannot exceed your available USDC balance./i
+    )
+  ).not.toBeInTheDocument();
 
-  it("renders the dashboard when wallet is connected", async () => {
-    renderDashboard("GABC123");
+  expect(
+    screen.queryByText(
+      /The withdrawal amount exceeds your available USDC balance./i
+    )
+  ).not.toBeInTheDocument();
 
-    expect(screen.queryByText(/Wallet Not Connected/i)).not.toBeInTheDocument();
-    expect(screen.getByText(/Global RWA Yield Fund/i)).toBeInTheDocument();
-    expect(screen.getByText(/Current APY/i)).toBeInTheDocument();
+  // Switch back to deposit tab
+  fireEvent.click(depositTab);
 
-    expect(await screen.findByText(/Sovereign Debt/i)).toBeInTheDocument();
-    expect(screen.getByText(/Strategy ID:/i)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Copy strategy ID/i })).toBeInTheDocument();
-  });
+  // 🔥 Re-query again
+  input = screen.getByPlaceholderText("0.00");
 
-  it("allows switching between deposit and withdraw tabs", async () => {
-    renderDashboard("GABC123");
+  expect(input).toHaveValue("");
 
-    expect(await screen.findByText(/Approve & Deposit/i)).toBeInTheDocument();
-
-    const depositTab = screen.getByText("Deposit");
-    const withdrawTab = screen.getByText("Withdraw");
-
-    fireEvent.click(withdrawTab);
-    expect(screen.getByText(/Amount to withdraw/i)).toBeInTheDocument();
-
-    fireEvent.click(depositTab);
-    expect(screen.getByText(/Amount to deposit/i)).toBeInTheDocument();
-  });
-
-  it("updates the amount input and processes a deposit", async () => {
-    let resolveSubmit!: () => void;
-    const submitPromise = new Promise<void>((resolve) => {
-      resolveSubmit = resolve;
-    });
-    vi.mocked(vaultApi.submitDeposit).mockReturnValue(submitPromise);
-    
-    renderDashboard("GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
-
-    expect(await screen.findByText(/Approve & Deposit/i)).toBeInTheDocument();
-
-    const input = screen.getByPlaceholderText("0.00");
-    fireEvent.change(input, { target: { value: "100" } });
-    expect(input).toHaveValue(100);
-
-    const button = screen.getByText("Approve & Deposit");
-    fireEvent.click(button);
-
-    await waitFor(() => {
-      expect(screen.getByText(/Waiting for confirmation/i)).toBeInTheDocument();
-    });
-
-    // Resolve the mocked API call
-    resolveSubmit();
-
-    // Loading state should be visible while mutation is pending.
-    expect(screen.getByText(/Waiting for confirmation/i)).toBeInTheDocument();
-  });
-
-  it("fills the input with max allowable amount via MAX button", async () => {
-    renderDashboard("GABC123");
-
-    expect(await screen.findByText(/Approve & Deposit/i)).toBeInTheDocument();
-
-    const maxButton = screen.getByRole("button", { name: "MAX" });
-    fireEvent.click(maxButton);
-    const input = screen.getByPlaceholderText("0.00");
-    expect(input).toHaveValue(1250.5);
-
-    fireEvent.click(screen.getByRole("tab", { name: "Withdraw" }));
-    fireEvent.click(maxButton);
-    expect(input).toHaveValue(1250.5);
-  });
-
-  it("shows inline error and blocks submit for amounts above balance", async () => {
-    renderDashboard("GABC123");
-
-    expect(await screen.findByText(/Approve & Deposit/i)).toBeInTheDocument();
-
-    const input = screen.getByPlaceholderText("0.00");
-    fireEvent.change(input, { target: { value: "2000" } });
-    fireEvent.blur(input);
-
-    expect(
-      screen.getByText(/Deposit amount cannot exceed your available USDC balance./i),
-    ).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Approve & Deposit" })).toBeDisabled();
-  });
-
-  it("shows minimum deposit validation and clears error when corrected", async () => {
-    renderDashboard("GABC123");
-
-    expect(await screen.findByText(/Approve & Deposit/i)).toBeInTheDocument();
-
-    const input = screen.getByPlaceholderText("0.00");
-    fireEvent.change(input, { target: { value: "0.5" } });
-    fireEvent.blur(input);
-
-    expect(screen.getByText(/Minimum deposit is 1.00 USDC./i)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Approve & Deposit" })).toBeDisabled();
-
-    fireEvent.change(input, { target: { value: "10" } });
-
-    await waitFor(() => {
-      expect(screen.queryByText(/Minimum deposit is 1.00 USDC./i)).not.toBeInTheDocument();
-      expect(screen.getByRole("button", { name: "Approve & Deposit" })).toBeEnabled();
-    });
-  });
-
-  it("shows a normalized API error message when data loading fails", async () => {
-    vi.useRealTimers();
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockRejectedValue(new TypeError("Failed to fetch")),
-    );
-
-    renderDashboard("GABC123");
-
-    await waitFor(() => {
-      expect(screen.getByRole("alert")).toHaveTextContent("Data unavailable");
-    }, { timeout: 3000 });
-    expect(screen.getByRole("alert")).toHaveTextContent("Failed to load vault data");
-  });
-
-  it("prefills the deposit amount from deep links and removes params", async () => {
-    renderDashboard("GABC123", 1250.5, "/?action=deposit&amount=100&ref=partner");
-
-    const input = await screen.findByPlaceholderText("0.00");
-    await waitFor(() => {
-      expect(input).toHaveValue(100);
-    });
-    expect(screen.getByTestId("location-search")).toHaveTextContent("?ref=partner");
-  });
-
-  it("ignores invalid deep-link amounts and removes deep-link params", async () => {
-    renderDashboard("GABC123", 1250.5, "/?action=deposit&amount=oops");
-
-    const input = await screen.findByPlaceholderText("0.00");
-    await waitFor(() => {
-      expect((input as HTMLInputElement).value).toBe("");
-    });
-    expect(screen.getByTestId("location-search")).toHaveTextContent("");
-  });
-
-  it("clears amount and validation errors when switching between tabs", async () => {
-    renderDashboard("GABC123", 1250.5);
-
-    const depositTab = screen.getByRole("tab", { name: "Deposit" });
-    const withdrawTab = screen.getByRole("tab", { name: "Withdraw" });
-
-    // Enter an amount that exceeds balance on deposit tab and trigger validation
-    const input = screen.getByPlaceholderText("0.00");
-    fireEvent.change(input, { target: { value: "5000" } });
-    fireEvent.blur(input);
-
-    expect(screen.getByText(/Deposit amount cannot exceed your available USDC balance./i)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Approve & Deposit" })).toBeDisabled();
-
-    // Switch to withdraw tab
-    fireEvent.click(withdrawTab);
-
-    // Amount should be cleared
-    expect(input).toHaveValue("");
-
-    // Inline error should NOT appear on the withdraw tab before interaction
-    expect(screen.queryByText(/Deposit amount cannot exceed your available USDC balance./i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/The withdrawal amount exceeds your available USDC balance./i)).not.toBeInTheDocument();
-
-    // Switch back to deposit tab — still no error and amount remains cleared
-    fireEvent.click(depositTab);
-    expect(input).toHaveValue("");
-    expect(screen.queryByText(/Deposit amount cannot exceed your available USDC balance./i)).not.toBeInTheDocument();
-  });
+  expect(
+    screen.queryByText(
+      /Deposit amount cannot exceed your available USDC balance./i
+    )
+  ).not.toBeInTheDocument();
 });

--- a/frontend/src/components/VaultDashboard.test.tsx
+++ b/frontend/src/components/VaultDashboard.test.tsx
@@ -238,4 +238,34 @@ describe("VaultDashboard", () => {
     });
     expect(screen.getByTestId("location-search")).toHaveTextContent("");
   });
+
+  it("clears amount and validation errors when switching between tabs", async () => {
+    renderDashboard("GABC123", 1250.5);
+
+    const depositTab = screen.getByRole("tab", { name: "Deposit" });
+    const withdrawTab = screen.getByRole("tab", { name: "Withdraw" });
+
+    // Enter an amount that exceeds balance on deposit tab and trigger validation
+    const input = screen.getByPlaceholderText("0.00");
+    fireEvent.change(input, { target: { value: "5000" } });
+    fireEvent.blur(input);
+
+    expect(screen.getByText(/Deposit amount cannot exceed your available USDC balance./i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Approve & Deposit" })).toBeDisabled();
+
+    // Switch to withdraw tab
+    fireEvent.click(withdrawTab);
+
+    // Amount should be cleared
+    expect(input).toHaveValue("");
+
+    // Inline error should NOT appear on the withdraw tab before interaction
+    expect(screen.queryByText(/Deposit amount cannot exceed your available USDC balance./i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/The withdrawal amount exceeds your available USDC balance./i)).not.toBeInTheDocument();
+
+    // Switch back to deposit tab — still no error and amount remains cleared
+    fireEvent.click(depositTab);
+    expect(input).toHaveValue("");
+    expect(screen.queryByText(/Deposit amount cannot exceed your available USDC balance./i)).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/lib/vaultApi.ts
+++ b/frontend/src/lib/vaultApi.ts
@@ -17,13 +17,6 @@ export class SharePriceFetchError extends Error {
 /** 10^18 — the fixed-point divisor used by the vault contract's i128 share price. */
 export const FIXED_POINT_DIVISOR = 1_000_000_000_000_000_000n;
 
-/**
- * Convert a raw i128 contract value to a JavaScript number.
- *
- * Uses BigInt integer division to preserve precision, then converts to number.
- * The share price range (1.0 ± small yield) is well within Number.MAX_SAFE_INTEGER
- * after dividing by 10^18.
- */
 export function decodeSharePrice(raw: bigint): number {
   const integerPart = raw / FIXED_POINT_DIVISOR;
   const remainder = raw % FIXED_POINT_DIVISOR;
@@ -32,15 +25,6 @@ export function decodeSharePrice(raw: bigint): number {
 
 // ─── getSharePrice ────────────────────────────────────────────────────────────
 
-/**
- * Fetch the current share price from the vault contract via Soroban simulation.
- *
- * Uses `simulateTransaction` (a read-only view call) — no funded account required.
- * A well-known placeholder address is used as the transaction source; the simulation
- * ignores sequence numbers and fees.
- *
- * @throws {SharePriceFetchError} on any failure (missing config, RPC error, bad response)
- */
 export async function getSharePrice(): Promise<number> {
   if (!networkConfig.contractId) {
     throw new SharePriceFetchError("Vault contract ID is not configured");
@@ -49,11 +33,8 @@ export async function getSharePrice(): Promise<number> {
   const server = new rpc.Server(networkConfig.rpcUrl);
   const contract = new Contract(networkConfig.contractId);
 
-  // Soroban simulation does not require a funded account. We use a well-known
-  // testnet placeholder address and fall back to a minimal stub if getAccount fails.
   const PLACEHOLDER_ADDRESS = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
   const sourceAccount = await server.getAccount(PLACEHOLDER_ADDRESS).catch(() => {
-    // Minimal account-like object sufficient for TransactionBuilder
     return {
       accountId: () => PLACEHOLDER_ADDRESS,
       sequenceNumber: () => "0",
@@ -94,10 +75,8 @@ export async function getSharePrice(): Promise<number> {
     throw new SharePriceFetchError("Contract returned no value");
   }
 
-  // The i128 XDR value is accessed via the SDK's scVal helpers.
-  // hi is the high 64 bits (signed), lo is the low 64 bits (unsigned).
   const raw = returnValue.i128();
-  const rawBigInt = (BigInt(raw.hi) << 64n) | BigInt(raw.lo);
+  const rawBigInt = (BigInt(raw.hi()) << 64n) | BigInt(raw.lo());
 
   return decodeSharePrice(rawBigInt);
 }
@@ -177,7 +156,6 @@ const MOCK_VAULT_HISTORY: VaultHistoryPoint[] = [
   { date: "2026-03-25", value: 103.75 },
 ];
 
-
 export async function getVaultSummary() {
   return apiClient.get<VaultSummary>("/mock-api/vault-summary.json");
 }
@@ -197,13 +175,11 @@ export async function getVaultHistory(params?: unknown): Promise<VaultHistoryPoi
 
 export async function submitDeposit(params: unknown) {
   validate(DepositRequestSchema, params, "DepositRequest");
-  // Simulate backend interaction
   return new Promise<void>((resolve) => setTimeout(resolve, 2000));
 }
 
 export async function submitWithdrawal(params: unknown) {
   validate(WithdrawalRequestSchema, params, "WithdrawalRequest");
-  // Simulate backend interaction
   return new Promise<void>((resolve) => setTimeout(resolve, 2000));
 }
 
@@ -214,7 +190,7 @@ export async function getXlmPrice(): Promise<number> {
     return data.stellar.usd;
   } catch (error) {
     console.error("Failed to fetch XLM price", error);
-    return 0.12; // Fallback price
+    return 0.12;
   }
 }
 
@@ -223,11 +199,8 @@ export async function estimateNetworkFee(_params: {
   amount: number;
   action: "deposit" | "withdraw";
 }): Promise<string> {
-  // In a real implementation, this would use StellarSdk.SorobanRpc.Server.simulateTransaction
-  // For this exercise, we simulate the RPC response delay and return a realistic estimate
   await new Promise((resolve) => setTimeout(resolve, 600));
   
-  // Simulate variation based on action and some randomness
   const baseFee = _params.action === "deposit" ? 0.05 : 0.07;
   const randomFactor = 0.95 + Math.random() * 0.1;
   const xlmAmount = baseFee * randomFactor;

--- a/frontend/src/pages/Portfolio.tsx
+++ b/frontend/src/pages/Portfolio.tsx
@@ -1,477 +1,865 @@
-import React, { useMemo, useState, useEffect } from "react";
-import { Activity, TrendingUp, DollarSign, Percent, Briefcase } from "../components/icons";
-import ApiStatusBanner from "../components/ApiStatusBanner";
-import {
-  DataTable,
-  type DataTableColumn,
-} from "../components/DataTable";
-import PageHeader from "../components/PageHeader";
+import React, { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { 
-  normalizeApiError, 
-  isValidationError, 
-  type ApiError, 
-  type ValidationError 
-} from "../lib/api";
-import CopyButton from "../components/CopyButton";
-import {
-  getPortfolioHoldings,
-  type PortfolioHolding,
-} from "../lib/portfolioApi";
-import { useClientDataTable } from "../hooks/useClientDataTable";
-import HelpIcon from "../components/ui/HelpIcon";
-import { useUrlState } from "../hooks/useUrlState";
-import { useServerDataTable } from "../hooks/useServerDataTable";
+  Activity, 
+  AlertCircle, 
+  Check,
+  ShieldCheck, 
+  TrendingUp, 
+  Wallet as WalletIcon, 
+  Loader2,
+  Share2
+} from "./icons";
+import Skeleton from "./Skeleton";
+import { useVault } from "../context/VaultContext";
+import ApiStatusBanner from "./ApiStatusBanner";
+import SharePriceDisplay from "./SharePriceDisplay";
+import VaultPerformanceChart from "./VaultPerformanceChart";
 import { useToast } from "../context/ToastContext";
-import YieldBreakdownChart from "../components/YieldBreakdownChart";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "./Tabs";
+import { FormField } from "../forms";
+import { useDepositMutation, useWithdrawMutation } from "../hooks/useVaultMutations";
+import { useTokenAllowance } from "../hooks/useTokenAllowance";
+import CopyButton from "./CopyButton";
+import { copyTextToClipboard } from "../lib/clipboard";
+import { useFeeEstimate } from "../hooks/useFeeEstimate";
+import { AlertTriangle } from "./icons";
+import HelpIcon from "./ui/HelpIcon";
 
-interface PortfolioProps {
+interface VaultDashboardProps {
   walletAddress: string | null;
+  usdcBalance?: number;
 }
 
-import { formatCurrency, formatNumber } from "../lib/formatters";
-import HelpIcon from "../components/ui/HelpIcon";
+type TransactionTab = "deposit" | "withdraw";
 
-const columns: DataTableColumn<PortfolioHolding>[] = [
-  {
-    id: "asset",
-    header: "Asset",
-    sortable: true,
-    width: "28%",
-    cell: (row) => (
-      <div>
-        <div style={{ fontWeight: 600 }}>{row.asset}</div>
-        <div style={{ color: "var(--text-secondary)", fontSize: "0.82rem" }}>
-          {row.vaultName}
-        </div>
-        <div
-          className="copy-field"
-          style={{ marginTop: "8px", color: "var(--text-secondary)", fontSize: "0.78rem" }}
-        >
-          <span>Position ID:</span>
-          <span className="copy-field-value copy-field-value-mono">{row.id}</span>
-          <CopyButton
-            value={row.id}
-            label="position ID"
-            successDescription={`Position ID ${row.id} has been copied to your clipboard.`}
-          />
-        </div>
-      </div>
-    ),
-  },
-  {
-    id: "shares",
-    header: "Shares",
-    sortable: true,
-    align: "right",
-    cell: (row) => (
-      <div>
-        <div style={{ fontWeight: 600 }}>
-          {formatNumber(row.shares)} {row.symbol}
-        </div>
-        <div style={{ color: "var(--text-secondary)", fontSize: "0.82rem" }}>
-          Issuer: {row.issuer}
-        </div>
-      </div>
-    ),
-  },
-  {
-    id: "apy",
-    header: "APY",
-    sortable: true,
-    align: "right",
-    cell: (row) => (
-      <span style={{ color: "var(--accent-cyan)", fontWeight: 600 }}>
-        {row.apy.toFixed(2)}%
-      </span>
-    ),
-  },
-  {
-    id: "valueUsd",
-    header: "Value",
-    sortable: true,
-    align: "right",
-    cell: (row) => <span>{formatCurrency(row.valueUsd)}</span>,
-  },
-  {
-    id: "unrealizedGainUsd",
-    header: "Unrealized Gain",
-    sortable: true,
-    align: "right",
-    cell: (row) => (
-      <span
-        style={{
-          color:
-            row.unrealizedGainUsd >= 0
-              ? "var(--accent-cyan)"
-              : "var(--text-error)",
-          fontWeight: 600,
-        }}
-      >
-        {row.unrealizedGainUsd >= 0 ? "+" : ""}
-        {formatCurrency(row.unrealizedGainUsd)}
-      </span>
-    ),
-  },
-];
+const MIN_DEPOSIT_AMOUNT = 1;
+const INITIAL_TOUCHED_STATE: Record<TransactionTab, boolean> = {
+  deposit: false,
+  withdraw: false,
+};
 
-const PortfolioSummaryCard: React.FC<{ 
-  label: React.ReactNode; 
-  value: string; 
-  icon: React.ReactNode; 
-  trend?: string;
-  trendPositive?: boolean;
-}> = ({ label, value, icon, trend, trendPositive }) => (
-  <div
-    className="glass-panel"
-    style={{ 
-      padding: "24px", 
-      background: "var(--bg-muted)", 
-      position: "relative",
-      overflow: "hidden",
-      border: "1px solid var(--border-glass)",
-      transition: "transform 0.2s ease",
-    }}
-    onMouseEnter={(e) => e.currentTarget.style.transform = "translateY(-4px)"}
-    onMouseLeave={(e) => e.currentTarget.style.transform = "translateY(0)"}
-  >
-    <div style={{ position: "absolute", top: "-10px", right: "-10px", opacity: 0.05 }}>
-      {React.cloneElement(icon as React.ReactElement<Record<string, unknown>>, { size: 80 })}
-    </div>
-    <div className="flex items-center gap-sm" style={{ color: "var(--text-secondary)", marginBottom: "12px" }}>
-      {icon}
-      <span className="text-body-sm" style={{ fontWeight: 500, letterSpacing: "0.02em" }}>{label}</span>
-    </div>
-    <div style={{ fontSize: "2rem", fontWeight: 700, fontFamily: "var(--font-display)", color: "var(--text-primary)" }}>
-      {value}
-    </div>
-    {trend && (
-      <div style={{ 
-        marginTop: "8px", 
-        fontSize: "0.85rem", 
-        color: trendPositive ? "var(--accent-cyan)" : "var(--text-error)",
-        fontWeight: 600,
-        display: "flex",
-        alignItems: "center",
-        gap: "4px"
-      }}>
-        {trendPositive ? <TrendingUp size={14} /> : <Activity size={14} />}
-        {trend}
-      </div>
-    )}
-  </div>
-);
-
-const Portfolio: React.FC<PortfolioProps> = ({ walletAddress }) => {
-  const toast = useToast();
-  const [holdings, setHoldings] = useState<PortfolioHolding[]>([]);
-  const [error, setError] = useState<ApiError | ValidationError | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
-
-  const { state: urlState, setSearch, setSort, setPage, setPageSize, setFilters, reset } = useUrlState<{ status: string, search: string }>({
-    defaultSortBy: "valueUsd",
-    defaultSortDirection: "desc",
-    defaultPageSize: 4,
-    defaultFilters: { status: "all", search: "" },
-  });
-
-  const state = {
-    ...urlState,
-    search: urlState.filters.search || "",
-  };
-
-  useServerDataTable({ state });
-
-  useEffect(() => {
-    if (!walletAddress) {
-      return;
-    }
-
-    let isMounted = true;
-
-    const loadHoldings = async () => {
-      setIsLoading(true);
-
-      try {
-        const response = await getPortfolioHoldings({
-          walletAddress,
-          status: urlState.filters.status || "all",
-        });
-        if (!isMounted) {
-          return;
-        }
-        setHoldings(response);
-        setError(null);
-      } catch (unknownError) {
-        if (!isMounted) {
-          return;
-        }
-        if (isValidationError(unknownError)) {
-          setError(unknownError);
-          toast.error({
-            title: "Validation failed",
-            description: unknownError.userMessage,
-          });
-        } else {
-          const nextError = normalizeApiError(unknownError);
-          setError(nextError);
-          toast.error({
-            title: "Portfolio sync failed",
-            description: nextError.userMessage,
-          });
-        }
-      } finally {
-        if (isMounted) {
-          setIsLoading(false);
-        }
-      }
-    };
-
-    void loadHoldings();
-
-    return () => {
-      isMounted = false;
-    };
-  }, [toast, walletAddress, urlState.filters.status]);
-
-  const filteredHoldings = React.useMemo(() => {
-    if (!urlState.filters.status || urlState.filters.status === "all") {
-      return holdings;
-    }
-    return holdings.filter((h) => h.status === urlState.filters.status);
-  }, [holdings, urlState.filters.status]);
-
-  const { rows, page, totalItems, totalPages } = useClientDataTable({
-    rows: filteredHoldings,
-    state,
-    getSearchValue: (row) =>
-      `${row.asset} ${row.vaultName} ${row.symbol} ${row.issuer} ${row.status}`,
-    getSortValue: (row, columnId) => {
-      switch (columnId) {
-        case "asset":
-          return row.asset;
-        case "shares":
-          return row.shares;
-        case "apy":
-          return row.apy;
-        case "valueUsd":
-          return row.valueUsd;
-        case "unrealizedGainUsd":
-          return row.unrealizedGainUsd;
-        default:
-          return row.valueUsd;
-      }
-    },
-  });
-
-  const totalValue = holdings.reduce((sum, holding) => sum + holding.valueUsd, 0);
-  const totalGain = holdings.reduce(
-    (sum, holding) => sum + holding.unrealizedGainUsd,
-    0,
-  );
-
-  const weightedApy = useMemo(() => {
-    if (totalValue === 0) return 0;
-    return holdings.reduce((sum, h) => sum + (h.apy * h.valueUsd), 0) / totalValue;
-  }, [holdings, totalValue]);
-
-  // Compute trend values
-  const totalNetValueTrend = useMemo(() => {
-    if (totalValue === 0) return "N/A";
-    // Calculate 7-day trend (simplified: using current value as proxy)
-    // In a real app, this would compare with historical data
-    const trendPercent = ((totalGain / (totalValue - totalGain)) * 100).toFixed(1);
-    return isFinite(Number(trendPercent)) ? `${trendPercent}% gain` : "N/A";
-  }, [totalValue, totalGain]);
-
-  const cumulativeYieldTrend = useMemo(() => {
-    if (totalGain === 0) return "--";
-    return `${formatCurrency(totalGain)} realized`;
-  }, [totalGain]);
-
-  const weightedApyTrend = useMemo(() => {
-    if (holdings.length === 0) return "N/A";
-    return `${holdings.length} position${holdings.length !== 1 ? 's' : ''}`;
-  }, [holdings.length]);
+const VaultCapWarning: React.FC<{ utilization: number; isReached: boolean }> = ({
+  utilization,
+  isReached,
+}) => {
+  const percent = (utilization * 100).toFixed(1);
 
   return (
-    <div className="glass-panel portfolio-page-panel">
-      <PageHeader
-        title={
-          <>
-            Your <span className="text-gradient">Portfolio</span>
-          </>
-        }
-        description="Overview of your deposited real-world assets."
-        breadcrumbs={[
-          { label: "Home", href: "/" },
-          { label: "Portfolio" },
-        ]}
-        statusChips={
-          walletAddress
-            ? [
-                {
-                  label: `${holdings.length} Positions`,
-                  variant: "cyan" as const,
-                },
-                {
-                  label: isLoading ? "Syncing..." : "Live",
-                  variant: isLoading ? "warning" : "success",
-                },
-              ]
-            : undefined
-        }
-      />
-
-      {!walletAddress ? (
-        <div style={{ textAlign: "center", padding: "48px" }}>
-          <p style={{ color: "var(--text-secondary)" }}>
-            Please connect your wallet to view your portfolio.
-          </p>
-        </div>
+    <div
+      className="glass-panel"
+      style={{
+        padding: "16px",
+        marginBottom: "24px",
+        border: `1px solid ${isReached ? "var(--text-error)" : "var(--text-warning)"}`,
+        background: isReached ? "rgba(255, 69, 58, 0.1)" : "rgba(255, 159, 10, 0.1)",
+        display: "flex",
+        alignItems: "flex-start",
+        gap: "12px",
+      }}
+    >
+      {isReached ? (
+        <AlertCircle color="var(--text-error)" size={20} />
       ) : (
-        <div className="flex flex-col gap-lg">
-          {error && <ApiStatusBanner error={error} />}
-
-          <div
-            className="portfolio-summary-grid"
-            style={{ marginBottom: "8px" }}
-          >
-            <PortfolioSummaryCard 
-              label="Total Net Value" 
-              value={formatCurrency(totalValue)} 
-              icon={<DollarSign size={20} color="var(--accent-cyan)" />}
-              trend={totalNetValueTrend}
-              trendPositive={totalGain >= 0}
-            />
-            <PortfolioSummaryCard 
-              label="Cumulative Yield" 
-              value={`${totalGain >= 0 ? '+' : ''}${formatCurrency(totalGain)}`} 
-              icon={<TrendingUp size={20} color="var(--accent-purple)" />}
-              trend={cumulativeYieldTrend}
-              trendPositive={totalGain >= 0}
-            />
-            <PortfolioSummaryCard 
-              label={
-                <span style={{ display: "flex", alignItems: "center", gap: "6px" }}>
-                  Weighted Avg APY
-                  <HelpIcon
-                    variant="tooltip"
-                    content="The portfolio-value-weighted average of all active position APYs."
-                  />
-                </span>
-              }
-              value={`${weightedApy.toFixed(2)}%`} 
-              icon={<Percent size={20} color="var(--accent-cyan)" />}
-              trend={weightedApyTrend}
-              trendPositive={true}
-            />
-            <PortfolioSummaryCard 
-              label="Active Positions" 
-              value={holdings.filter(h => h.status === 'active').length.toString()} 
-              icon={<Briefcase size={20} color="var(--text-secondary)" />}
-            />
-          </div>
-
-          <YieldBreakdownChart totalGain={totalGain} />
-
-          <section
-            className="glass-panel"
-            style={{ padding: "24px", background: "var(--bg-muted)" }}
-            aria-labelledby="holdings-heading"
-          >
-            <div className="portfolio-toolbar">
-              <div>
-                <h2 id="holdings-heading" style={{ marginBottom: "6px" }}>Position Details</h2>
-                <p className="text-body-sm" style={{ color: "var(--text-secondary)" }}>
-                  Sort, search, and page through all current vault positions.
-                </p>
-              </div>
-
-              <div className="portfolio-toolbar-controls">
-                <label className="input-group" style={{ minWidth: "180px" }}>
-                  <span className="text-body-sm">Status Filter</span>
-                  <div className="input-wrapper">
-                    <select
-                      className="portfolio-select"
-                      value={urlState.filters.status || "all"}
-                      onChange={(e) => setFilters({ status: e.target.value })}
-                      aria-label="Filter by status"
-                    >
-                      <option value="all">All Statuses</option>
-                      <option value="active">Active</option>
-                      <option value="pending">Pending</option>
-                    </select>
-                  </div>
-                </label>
-
-                <label className="input-group" style={{ minWidth: "220px" }}>
-                  <span className="text-body-sm">Search positions</span>
-                  <div className="input-wrapper">
-                    <input
-                      className="input-field"
-                      type="search"
-                      placeholder="Search asset, vault, issuer..."
-                      value={urlState.filters.search || ""}
-                      onChange={(event) => setSearch(event.target.value)}
-                      style={{ fontSize: "var(--text-base)", fontFamily: "var(--font-sans)" }}
-                    />
-                  </div>
-                </label>
-
-                {(urlState.filters.search || (urlState.filters.status && urlState.filters.status !== "all")) && (
-                  <button
-                    type="button"
-                    className="btn btn-outline"
-                    onClick={reset}
-                    style={{ alignSelf: "flex-end", height: "42px" }}
-                  >
-                    Reset Filters
-                  </button>
-                )}
-              </div>
-            </div>
-
-            <div className="text-body-sm" style={{ color: "var(--text-secondary)", marginBottom: "16px" }}>
-              {isLoading ? "Loading positions..." : `${totalItems} positions found`}
-            </div>
-
-            <DataTable
-              caption="Portfolio holdings"
-              columns={columns}
-              rows={rows}
-              rowKey={(row) => row.id}
-              emptyMessage={
-                isLoading
-                  ? "Loading positions..."
-                  : "No positions matched the current filters."
-              }
-              isLoading={isLoading}
-              skeletonRows={state.pageSize}
-              sortBy={state.sortBy}
-              sortDirection={state.sortDirection}
-              onSortChange={setSort}
-              pagination={{
-                page,
-                pageSize: state.pageSize,
-                totalItems,
-                totalPages,
-              }}
-              onPageChange={setPage}
-              onPageSizeChange={setPageSize}
-              renderRowDetails={(row) => (
-                <div className="portfolio-row-meta">
-                  <span className={`tag ${row.status === "active" ? "cyan" : ""}`}>
-                    {row.status}
-                  </span>
-                  <span>{row.symbol}</span>
-                </div>
-              )}
-            />
-          </section>
-        </div>
+        <AlertCircle color="var(--text-warning)" size={20} />
       )}
+      <div>
+        <div
+          style={{
+            fontWeight: 600,
+            color: isReached ? "var(--text-error)" : "var(--text-warning)",
+            marginBottom: "4px",
+          }}
+        >
+          {isReached ? "Vault Capacity Reached" : "Vault Near Capacity"}
+        </div>
+        <div
+          style={{
+            fontSize: "0.85rem",
+            color: "var(--text-secondary)",
+            lineHeight: "1.4",
+          }}
+        >
+          {isReached
+            ? `This vault has reached its maximum deposit cap of ${percent}%. Deposits are temporarily disabled.`
+            : `This vault is at ${percent}% capacity. New deposits may be restricted soon.`}
+        </div>
+      </div>
     </div>
   );
 };
 
-export default Portfolio;
+
+function getAmountValidationError(
+  actionType: TransactionTab,
+  rawAmount: string,
+  availableBalance: number,
+  isCapReached: boolean,
+): string | null {
+  if (!rawAmount.trim()) {
+    return "Amount is required.";
+  }
+
+  const value = Number(rawAmount);
+  if (Number.isNaN(value) || !Number.isFinite(value)) {
+    return "Enter a valid number.";
+  }
+
+  if (value <= 0) {
+    return "Amount must be greater than 0.";
+  }
+
+  if (actionType === "deposit" && value < MIN_DEPOSIT_AMOUNT) {
+    return `Minimum deposit is ${MIN_DEPOSIT_AMOUNT.toFixed(2)} USDC.`;
+  }
+
+  if (value > availableBalance) {
+    return actionType === "deposit"
+      ? "Deposit amount cannot exceed your available USDC balance."
+      : "The withdrawal amount exceeds your available USDC balance.";
+  }
+
+  if (actionType === "deposit" && isCapReached) {
+    return "Deposits are temporarily disabled because the vault is at capacity.";
+  }
+
+  return null;
+}
+
+
+const VaultDashboard: React.FC<VaultDashboardProps> = ({
+  walletAddress,
+  usdcBalance = 0,
+}) => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const {
+    formattedTvl,
+    formattedApy,
+    summary,
+    error,
+    isLoading,
+    utilization,
+    isCapWarning,
+    isCapReached,
+  } = useVault();
+  const toast = useToast();
+
+  const [activeTab, setActiveTab] = useState<TransactionTab>("deposit");
+  const [amount, setAmount] = useState("");
+  const [touched, setTouched] =
+    useState<Record<TransactionTab, boolean>>(INITIAL_TOUCHED_STATE);
+
+  useEffect(() => {
+    const action = searchParams.get("action");
+    const amountParam = searchParams.get("amount");
+
+    if (action !== "deposit") {
+      return;
+    }
+
+    setActiveTab("deposit");
+    setTouched(INITIAL_TOUCHED_STATE);
+
+    const parsedAmount = amountParam === null ? Number.NaN : Number(amountParam);
+    if (Number.isFinite(parsedAmount) && parsedAmount > 0) {
+      setAmount(parsedAmount.toString());
+    } else {
+      setAmount("");
+    }
+
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.delete("action");
+    nextParams.delete("amount");
+    setSearchParams(nextParams, { replace: true });
+  }, [searchParams, setSearchParams]);
+
+  const depositMutation = useDepositMutation();
+  const withdrawMutation = useWithdrawMutation();
+  const { approvalStatus, needsApproval, approve, resetApproval } =
+    useTokenAllowance(walletAddress);
+
+  useEffect(() => {
+    resetApproval();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [amount]);
+
+  const { feeXlm, feeUsd, isEstimating, isHighFee } = useFeeEstimate(
+    walletAddress,
+    amount,
+    activeTab
+  );
+
+  useEffect(() => {
+    const handleTrigger = () => {
+      setActiveTab("deposit");
+      setTimeout(() => {
+        const input = document.querySelector(".input-field") as HTMLInputElement | null;
+        if (input) input.focus();
+      }, 0);
+    };
+    window.addEventListener("TRIGGER_DEPOSIT", handleTrigger);
+    return () => window.removeEventListener("TRIGGER_DEPOSIT", handleTrigger);
+  }, []);
+
+  const isProcessing = depositMutation.isPending
+    ? "deposit"
+    : withdrawMutation.isPending
+      ? "withdraw"
+      : null;
+  const isBusy = isProcessing !== null;
+
+  const availableBalance = walletAddress ? usdcBalance : 0;
+  const strategy = summary.strategy;
+  const enteredAmount = Number(amount);
+  const activeAmountError = getAmountValidationError(
+    activeTab,
+    amount,
+    availableBalance,
+    isCapReached,
+  );
+  const isValidAmount = !activeAmountError;
+  const showInlineError = touched[activeTab] && Boolean(activeAmountError);
+  const managementFeeBps = 35;
+  const estimatedFee = isValidAmount
+    ? (enteredAmount * managementFeeBps) / 10_000
+    : 0;
+  const estimatedNetAmount = isValidAmount
+    ? Math.max(enteredAmount - estimatedFee, 0)
+    : 0;
+  const isSubmitDisabled =
+    !walletAddress ||
+    isBusy ||
+    Boolean(activeAmountError) ||
+    (activeTab === "deposit" && isCapReached);
+
+
+  const handleTransaction = async (actionType: TransactionTab) => {
+    const value = Number(amount);
+    const validationError = getAmountValidationError(
+      actionType,
+      amount,
+      availableBalance,
+      isCapReached,
+    );
+
+    if (!walletAddress) {
+      toast.warning({
+        title: "Wallet required",
+        description: "Connect your wallet before submitting a transaction.",
+      });
+      return;
+    }
+
+    if (validationError) {
+      setTouched((previous) => ({ ...previous, [actionType]: true }));
+      toast.warning({
+        title: "Enter a valid amount",
+        description: validationError,
+      });
+      return;
+    }
+
+    try {
+      if (actionType === "deposit") {
+        await depositMutation.mutateAsync({ walletAddress, amount: value });
+      } else {
+        await withdrawMutation.mutateAsync({ walletAddress, amount: value });
+      }
+
+      setAmount("");
+      setTouched(INITIAL_TOUCHED_STATE);
+      toast.success({
+        title: actionType === "deposit" ? "Deposit Successful" : "Withdrawal Successful",
+        description:
+          actionType === "deposit"
+            ? `${value.toFixed(2)} USDC has been deposited into the vault.`
+            : `${value.toFixed(2)} USDC has been withdrawn from the vault.`,
+      });
+    } catch (err: unknown) {
+      toast.error({
+        title: "Transaction Failed",
+        description:
+          err instanceof Error
+            ? err.message
+            : "An error occurred during the transaction.",
+      });
+    }
+  };
+
+  return (
+    <div className="vault-dashboard gap-lg">
+      <div className="vault-dashboard-stats">
+        <div className="glass-panel vault-stats-panel">
+          {error && (
+            <ApiStatusBanner error={{ ...error, userMessage: "Failed to load vault data" }} />
+          )}
+          <div className="vault-stats-header flex justify-between items-center" style={{ marginBottom: "24px" }}>
+            <div>
+              <h2 style={{ fontSize: "1.5rem", marginBottom: "4px" }}>
+                Global RWA Yield Fund
+              </h2>
+              <span
+                className="tag"
+                style={{
+                  background: "rgba(255, 255, 255, 0.05)",
+                  color: "var(--text-secondary)",
+                }}
+              >
+                Tokens: USDC
+              </span>
+              <SharePriceDisplay />
+            </div>
+            <div style={{ textAlign: "right" }}>
+              <div style={{ color: "var(--text-secondary)", fontSize: "0.85rem", display: "flex", alignItems: "center", justifyContent: "flex-end", gap: "6px" }}>
+                Current APY
+                <HelpIcon
+                  variant="tooltip"
+                  content="Annualized yield based on the historical performance of the vault's underlying assets."
+                />
+              </div>
+              <div className="text-gradient" style={{ fontSize: "2rem", fontFamily: "var(--font-display)", fontWeight: 700 }}>
+                {isLoading ? <Skeleton width="100px" height="2.5rem" /> : formattedApy}
+              </div>
+            </div>
+          </div>
+
+          <div
+            style={{
+              height: "1px",
+              background: "var(--border-glass)",
+              margin: "24px 0",
+            }}
+          />
+
+          <div className="vault-stats-meta flex gap-xl" style={{ marginBottom: "32px" }}>
+            <div>
+              <div
+                style={{
+                  color: "var(--text-secondary)",
+                  fontSize: "0.85rem",
+                  marginBottom: "4px",
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "6px",
+                }}
+              >
+                Total Value Locked
+                <span
+                  className="flex items-center gap-xs"
+                  style={{
+                    color: "var(--accent-cyan)",
+                    fontSize: "0.7rem",
+                    fontWeight: 600,
+                    textTransform: "uppercase",
+                    letterSpacing: "0.05em",
+                  }}
+                >
+                  <Activity size={10} className={isLoading ? "animate-pulse" : undefined} />
+                  {isLoading ? "Syncing" : "Live"}
+                </span>
+              </div>
+              <div style={{ fontSize: "1.25rem", fontFamily: "var(--font-display)", fontWeight: 600 }}>
+                {isLoading ? <Skeleton width="140px" height="1.5rem" /> : formattedTvl}
+              </div>
+            </div>
+            <div>
+              <div style={{ color: "var(--text-secondary)", fontSize: "0.85rem", marginBottom: "4px" }}>
+                Underlying Asset
+              </div>
+              <div className="flex items-center gap-sm">
+                <ShieldCheck size={16} color="var(--accent-cyan)" />
+                <span style={{ fontSize: "1.1rem", fontWeight: 500 }}>{summary.assetLabel}</span>
+              </div>
+            </div>
+          </div>
+
+          <div className="glass-panel" style={{ padding: "20px", background: "var(--bg-muted)" }}>
+            <h3
+              style={{
+                fontSize: "1.1rem",
+                marginBottom: "12px",
+                display: "flex",
+                alignItems: "center",
+                gap: "8px",
+              }}
+            >
+              <TrendingUp size={18} color="var(--accent-purple)" />
+              Strategy Overview
+            </h3>
+            <div
+              style={{
+                marginBottom: "12px",
+                color: "var(--text-secondary)",
+                fontSize: "0.8rem",
+                fontWeight: 600,
+              }}
+            >
+              BENJI Strategy
+            </div>
+            <p style={{ color: "var(--text-secondary)", fontSize: "0.9rem", lineHeight: "1.6" }}>
+              This vault pools USDC and deploys it into verified tokenized sovereign bonds available on
+              the Stellar network.
+            </p>
+            <div className="flex gap-md" style={{ marginTop: "14px", flexWrap: "wrap" }}>
+              <div
+                style={{
+                  flex: "1 1 150px",
+                  padding: "10px 12px",
+                  borderRadius: "10px",
+                  background: "rgba(255,255,255,0.03)",
+                  border: "1px solid var(--border-glass)",
+                }}
+              >
+                <div style={{ color: "var(--text-secondary)", fontSize: "0.75rem", marginBottom: "4px" }}>
+                  Target Allocation
+                </div>
+                <div style={{ fontWeight: 600 }}>70% Treasuries</div>
+                <div style={{ color: "var(--text-secondary)", fontSize: "0.8rem" }}>30% Cash Reserve</div>
+              </div>
+              <div
+                style={{
+                  flex: "1 1 150px",
+                  padding: "10px 12px",
+                  borderRadius: "10px",
+                  background: "rgba(255,255,255,0.03)",
+                  border: "1px solid var(--border-glass)",
+                }}
+              >
+                <div style={{ color: "var(--text-secondary)", fontSize: "0.75rem", marginBottom: "4px" }}>
+                  Yield Distribution
+                </div>
+                <div style={{ fontWeight: 600 }}>Daily Compounding</div>
+                <div style={{ color: "var(--text-secondary)", fontSize: "0.8rem" }}>
+                  Reflected in yvUSDC NAV
+                </div>
+              </div>
+              <div
+                style={{
+                  flex: "1 1 150px",
+                  padding: "10px 12px",
+                  borderRadius: "10px",
+                  background: "rgba(255,255,255,0.03)",
+                  border: "1px solid var(--border-glass)",
+                }}
+              >
+                <div style={{ color: "var(--text-secondary)", fontSize: "0.75rem", marginBottom: "4px" }}>
+                  Risk Controls
+                </div>
+                <div style={{ fontWeight: 600 }}>Issuer + Duration Caps</div>
+                <div style={{ color: "var(--text-secondary)", fontSize: "0.8rem" }}>
+                  Rebalanced every epoch
+                </div>
+              </div>
+            </div>
+            <div style={{ marginTop: "12px", color: "var(--text-secondary)", fontSize: "0.82rem" }}>
+              Strategy: <span style={{ color: "var(--text-primary)" }}>{strategy.name}</span> ({strategy.issuer})
+            </div>
+            <div
+              className="copy-field"
+              style={{ marginTop: "8px", color: "var(--text-secondary)", fontSize: "0.78rem" }}
+            >
+              <span>Strategy ID:</span>
+              <span className="copy-field-value copy-field-value-mono">{strategy.id}</span>
+              <CopyButton value={strategy.id} label="strategy ID" />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="vault-dashboard-chart">
+        <div className="glass-panel vault-chart-panel">
+          <VaultPerformanceChart />
+        </div>
+      </div>
+
+      <div className="vault-dashboard-actions">
+        <div
+          className="glass-panel vault-actions-panel"
+          style={{ position: "relative", overflow: "hidden" }}
+        >
+          <div
+            style={{
+              position: "absolute",
+              top: "-50px",
+              right: "-50px",
+              width: "150px",
+              height: "150px",
+              background: "var(--accent-purple)",
+              filter: "blur(80px)",
+              opacity: 0.2,
+              borderRadius: "50%",
+              pointerEvents: "none",
+            }}
+          />
+
+          {!walletAddress && (
+            <div
+              className="wallet-overlay"
+              style={{
+                position: "absolute",
+                inset: 0,
+                background: "var(--bg-overlay)",
+                backdropFilter: "blur(8px)",
+                zIndex: 10,
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                justifyContent: "center",
+                padding: "32px",
+                textAlign: "center",
+              }}
+            >
+              <WalletIcon size={48} color="var(--accent-cyan)" style={{ marginBottom: "16px", opacity: 0.8 }} />
+              <h3>Wallet Not Connected</h3>
+              <p style={{ color: "var(--text-secondary)", fontSize: "0.9rem" }}>
+                Please connect your Freighter wallet to interact with the vault.
+              </p>
+            </div>
+          )}
+
+          <Tabs
+            value={activeTab}
+            defaultValue="deposit"
+            onValueChange={(value) => {
+              setActiveTab(value as TransactionTab);
+              setAmount("");
+              setTouched(INITIAL_TOUCHED_STATE);
+            }}
+          >
+            <TabsList style={{ marginBottom: "24px" }}>
+              <TabsTrigger value="deposit">Deposit</TabsTrigger>
+              <TabsTrigger value="withdraw">Withdraw</TabsTrigger>
+            </TabsList>
+
+            {(["deposit", "withdraw"] as const).map((tab) => (
+              <TabsContent key={tab} value={tab}>
+                {(isCapReached || isCapWarning) && tab === "deposit" && (
+                  <VaultCapWarning utilization={utilization} isReached={isCapReached} />
+                )}
+
+                <form
+                  onSubmit={(event) => {
+                    event.preventDefault();
+                    void handleTransaction(tab);
+                  }}
+                >
+                  <div style={{ marginBottom: "24px" }}>
+                    <div className="flex justify-between items-center" style={{ marginBottom: "16px" }}>
+                      <div style={{ color: "var(--text-secondary)", fontSize: "0.9rem" }}>
+                        {tab === "deposit" ? "Amount to deposit" : "Amount to withdraw"}
+                      </div>
+                      <div style={{ color: "var(--text-secondary)", fontSize: "0.85rem" }}>
+                        Balance: <span style={{ color: "var(--text-primary)", fontWeight: 600 }}>{availableBalance.toFixed(2)}</span>
+                      </div>
+                    </div>
+
+                    <FormField
+                      label={tab === "deposit" ? "Deposit amount" : "Withdrawal amount"}
+                      name={`${tab}-amount`}
+                      type="number"
+                      step="any"
+                      placeholder="0.00"
+                      value={amount}
+                      onChange={(event) => {
+                        setAmount(event.target.value);
+                        setTouched((previous) => ({ ...previous, [tab]: true }));
+                      }}
+                      onBlur={() =>
+                        setTouched((previous) => ({ ...previous, [tab]: true }))
+                      }
+                      disabled={isBusy || (tab === "deposit" && isCapReached)}
+                      error={showInlineError ? activeAmountError ?? undefined : undefined}
+                    />
+
+                    <div className="flex justify-between items-center" style={{ margin: "16px 0 24px" }}>
+                      <div className="flex items-center gap-sm">
+                        <span style={{ color: "var(--text-secondary)", fontSize: "0.85rem" }}>Asset: USDC</span>
+                        {tab === "deposit" && (
+                          <>
+                            <div style={{ width: "1px", height: "14px", background: "var(--border-glass)", margin: "0 4px" }} />
+                            <button
+                              type="button"
+                              className="btn-link flex items-center gap-xs"
+                              style={{ fontSize: "0.75rem", color: "var(--accent-cyan)", padding: 0 }}
+                              onClick={async () => {
+                                const baseUrl = window.location.origin + window.location.pathname;
+                                const shareUrl = amount && !isNaN(Number(amount)) && Number(amount) > 0
+                                  ? `${baseUrl}?action=deposit&amount=${amount}`
+                                  : baseUrl;
+                                
+                                try {
+                                  await copyTextToClipboard(shareUrl);
+                                  toast.success({
+                                    title: "Link copied",
+                                    description: "Shareable vault link is ready to paste."
+                                  });
+                                } catch {
+                                  toast.error({
+                                    title: "Copy failed",
+                                    description: "Could not copy link to clipboard."
+                                  });
+                                }
+                              }}
+                            >
+                              <Share2 size={12} />
+                              Share Link
+                            </button>
+                          </>
+                        )}
+                      </div>
+                      <button
+                        type="button"
+                        className="btn-max"
+                        onClick={() => {
+                          setAmount(availableBalance.toFixed(2));
+                          setTouched((previous) => ({ ...previous, [tab]: true }));
+                        }}
+                        disabled={
+                          !walletAddress ||
+                          availableBalance <= 0 ||
+                          isBusy ||
+                          (tab === "deposit" && isCapReached)
+                        }
+                      >
+                        MAX
+                      </button>
+                    </div>
+                  </div>
+
+                  <div
+                    className="glass-panel"
+                    style={{
+                      padding: "14px 16px",
+                      background: "rgba(0, 0, 0, 0.15)",
+                      marginBottom: "16px",
+                    }}
+                  >
+                    <div className="flex justify-between items-center" style={{ marginBottom: "6px" }}>
+                      <span style={{ color: "var(--text-secondary)", fontSize: "0.86rem", display: "flex", alignItems: "center", gap: "6px" }}>
+                        Estimated protocol fee
+                        <HelpIcon
+                          variant="popover"
+                          content="A protocol fee of 35 basis points (0.35%) of the transaction amount is applied. This fee is deducted before settlement."
+                        />
+                      </span>
+                      <span style={{ fontSize: "0.9rem", fontWeight: 600 }}>
+                        {isValidAmount ? `${estimatedFee.toFixed(4)} USDC` : "0.0000 USDC"}
+                      </span>
+                    </div>
+                    <div className="flex justify-between items-center" style={{ marginBottom: "6px" }}>
+                      <span style={{ color: "var(--text-secondary)", fontSize: "0.86rem" }}>
+                        Estimated network fee
+                      </span>
+                      <span style={{ fontSize: "0.9rem", fontWeight: 600, display: "flex", flexDirection: "column", alignItems: "flex-end" }}>
+                        {isEstimating ? (
+                          <Skeleton width="60px" height="1.1rem" />
+                        ) : (
+                          <>
+                            <span>{feeXlm.toFixed(6)} XLM</span>
+                            <span style={{ fontSize: "0.75rem", color: "var(--text-secondary)", fontWeight: 400 }}>
+                              ≈ ${feeUsd.toFixed(4)}
+                            </span>
+                          </>
+                        )}
+                      </span>
+                    </div>
+                    <div className="flex justify-between items-center">
+                      <span style={{ color: "var(--text-secondary)", fontSize: "0.82rem" }}>
+                        {tab === "deposit" ? "Estimated net deposit" : "Estimated net withdrawal"}
+                      </span>
+                      <span style={{ fontSize: "0.9rem", fontWeight: 600 }}>
+                        {isValidAmount ? `${estimatedNetAmount.toFixed(4)} USDC` : "0.0000 USDC"}
+                      </span>
+                    </div>
+                    {isHighFee && (
+                      <div
+                        className="flex items-start gap-sm"
+                        style={{
+                          marginTop: "12px",
+                          padding: "10px 12px",
+                          borderRadius: "8px",
+                          background: "rgba(255, 69, 58, 0.1)",
+                          border: "1px solid rgba(255, 69, 58, 0.2)",
+                        }}
+                      >
+                        <AlertTriangle size={16} color="var(--text-error)" style={{ marginTop: "2px" }} />
+                        <div style={{ fontSize: "0.78rem", color: "var(--text-error)", lineHeight: "1.4" }}>
+                          High fee detected: The estimated network fee exceeds 1% of your transaction value.
+                        </div>
+                      </div>
+                    )}
+                  </div>
+
+                  {tab === "deposit" && isValidAmount && needsApproval(enteredAmount) && (
+                    <div
+                      className="glass-panel"
+                      style={{
+                        padding: "14px 16px",
+                        marginBottom: "12px",
+                        border: approvalStatus === "confirmed"
+                          ? "1px solid rgba(0, 240, 255, 0.4)"
+                          : "1px solid rgba(255, 159, 10, 0.4)",
+                        background: approvalStatus === "confirmed"
+                          ? "rgba(0, 240, 255, 0.05)"
+                          : "rgba(255, 159, 10, 0.05)",
+                      }}
+                    >
+                      <div className="flex items-center gap-sm" style={{ marginBottom: "10px" }}>
+                        <div
+                          className="flex items-center gap-xs"
+                          style={{
+                            fontSize: "0.78rem",
+                            fontWeight: 600,
+                            color: approvalStatus === "confirmed"
+                              ? "var(--accent-cyan)"
+                              : "rgba(255, 159, 10, 0.9)",
+                          }}
+                        >
+                          <div
+                            style={{
+                              width: "20px",
+                              height: "20px",
+                              borderRadius: "50%",
+                              display: "flex",
+                              alignItems: "center",
+                              justifyContent: "center",
+                              background: approvalStatus === "confirmed"
+                                ? "var(--accent-cyan)"
+                                : "rgba(255, 159, 10, 0.2)",
+                              border: approvalStatus === "confirmed"
+                                ? "none"
+                                : "1px solid rgba(255, 159, 10, 0.6)",
+                              fontSize: "0.7rem",
+                              color: approvalStatus === "confirmed" ? "#000" : "rgba(255, 159, 10, 0.9)",
+                            }}
+                          >
+                            {approvalStatus === "confirmed" ? <Check size={12} /> : "1"}
+                          </div>
+                          Approve USDC
+                        </div>
+                        <div style={{ flex: 1, height: "1px", background: "var(--border-glass)" }} />
+                        <div
+                          className="flex items-center gap-xs"
+                          style={{
+                            fontSize: "0.78rem",
+                            fontWeight: 600,
+                            color: approvalStatus === "confirmed"
+                              ? "var(--text-primary)"
+                              : "var(--text-secondary)",
+                          }}
+                        >
+                          <div
+                            style={{
+                              width: "20px",
+                              height: "20px",
+                              borderRadius: "50%",
+                              display: "flex",
+                              alignItems: "center",
+                              justifyContent: "center",
+                              background: "rgba(255,255,255,0.05)",
+                              border: "1px solid var(--border-glass)",
+                              fontSize: "0.7rem",
+                            }}
+                          >
+                            2
+                          </div>
+                          Deposit
+                        </div>
+                      </div>
+
+                      {approvalStatus !== "confirmed" && (
+                        <p style={{ fontSize: "0.82rem", color: "var(--text-secondary)", marginBottom: "10px" }}>
+                          You need to approve the vault contract to spend{" "}
+                          <strong style={{ color: "var(--text-primary)" }}>
+                            {enteredAmount.toFixed(2)} USDC
+                          </strong>{" "}
+                          before depositing.
+                        </p>
+                      )}
+
+                      {approvalStatus === "error" && (
+                        <p style={{ fontSize: "0.82rem", color: "var(--text-error)", marginBottom: "10px" }}>
+                          Approval failed. Please try again.
+                        </p>
+                      )}
+
+                      {approvalStatus !== "confirmed" && (
+                        <button
+                          type="button"
+                          className="btn btn-outline"
+                          style={{ width: "100%", padding: "10px", display: "flex", alignItems: "center", justifyContent: "center", gap: "8px" }}
+                          disabled={approvalStatus === "pending" || !walletAddress}
+                          onClick={async () => {
+                            try {
+                              await approve(enteredAmount);
+                              toast.success({ title: "USDC Approved", description: "You can now proceed with your deposit." });
+                            } catch {
+                              toast.error({ title: "Approval Failed", description: "Could not approve USDC. Please try again." });
+                            }
+                          }}
+                        >
+                          {approvalStatus === "pending" ? (
+                            <>
+                              <Loader2 size={14} style={{ animation: "spin 0.9s linear infinite" }} />
+                              Approving...
+                            </>
+                          ) : (
+                            "Approve USDC"
+                          )}
+                        </button>
+                      )}
+                    </div>
+                  )}
+
+                  <button
+                    className="btn btn-primary"
+                    style={{
+                      width: "100%",
+                      padding: "16px",
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      gap: "8px",
+                    }}
+                    type="submit"
+                    disabled={
+                      isSubmitDisabled ||
+                      isEstimating ||
+                      (tab === "deposit" && isValidAmount && needsApproval(enteredAmount) && approvalStatus !== "confirmed")
+                    }
+                  >
+                    {isProcessing === tab ? (
+                      <>
+                        <Loader2
+                          size={16}
+                          className="spin"
+                          style={{ animation: "spin 0.9s linear infinite" }}
+                        />
+                        Waiting for confirmation...
+                      </>
+                    ) : isEstimating ? (
+                      <>
+                        <Loader2
+                          size={16}
+                          className="spin"
+                          style={{ animation: "spin 0.9s linear infinite" }}
+                        />
+                        Estimating fee...
+                      </>
+                    ) : tab === "deposit" ? (
+                      isCapReached ? "Vault is full" : "Deposit"
+                    ) : (
+                      "Withdraw Funds"
+                    )}
+                  </button>
+                </form>
+              </TabsContent>
+            ))}
+          </Tabs>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default VaultDashboard;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,7 +2,6 @@
 import { defineConfig, loadEnv } from "vite";
 import path from "path";
 import react from "@vitejs/plugin-react";
-import path from "path";
 import { sentryVitePlugin } from "@sentry/vite-plugin";
 import { visualizer } from "rollup-plugin-visualizer";
 


### PR DESCRIPTION

Closes #292 
Summary
Fixed a UX bug where the amount field and validation errors were not reset when switching between Deposit and Withdraw tabs in VaultDashboard.tsx.
Changes

Added setAmount("") and setTouched(INITIAL_TOUCHED_STATE) to the onValueChange callback on the Tabs component (line ~460)

Before
Typing 500 in Deposit tab then switching to Withdraw would show the same value and any validation errors immediately, before the user had interacted with the Withdraw tab.
After
Switching tabs clears the amount field and resets touched state so no stale errors are shown