### PR TITLE
feat(frontend): add transaction receipt page and PWA offline support

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="manifest" href="/manifest.json" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#00f0ff" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="YieldVault" />
     <title>YieldVault — Institutional RWA Yields on Stellar</title>
     <meta name="description" content="Deposit USDC to earn stable, predictable yield backed by tokenized Sovereign Debt and Real-World Assets on the Stellar network." />
     <!-- Prevent flash of unstyled content: apply saved theme before first paint -->

--- a/frontend/public/icons/README.md
+++ b/frontend/public/icons/README.md
@@ -1,0 +1,30 @@
+# PWA Icons
+
+The manifest.json references two icon files:
+- icon-192.png (192x192)
+- icon-512.png (512x512)
+
+To generate these from favicon.svg, use one of these methods:
+
+## Option 1: Using ImageMagick
+```bash
+convert -background none -resize 192x192 ../favicon.svg icon-192.png
+convert -background none -resize 512x512 ../favicon.svg icon-512.png
+```
+
+## Option 2: Using rsvg-convert
+```bash
+rsvg-convert -w 192 -h 192 ../favicon.svg -o icon-192.png
+rsvg-convert -w 512 -h 512 ../favicon.svg -o icon-512.png
+```
+
+## Option 3: Using Inkscape
+```bash
+inkscape ../favicon.svg --export-type=png --export-width=192 --export-filename=icon-192.png
+inkscape ../favicon.svg --export-type=png --export-width=512 --export-filename=icon-512.png
+```
+
+## Option 4: Online Tool
+Upload favicon.svg to https://realfavicongenerator.net/ or similar PWA icon generator.
+
+For now, the app will work without icons but browsers won't show them during installation.

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,0 +1,26 @@
+{
+  "name": "YieldVault — RWA Yields on Stellar",
+  "short_name": "YieldVault",
+  "description": "Deposit USDC to earn stable yield backed by tokenized Real-World Assets on Stellar.",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#0a0b10",
+  "theme_color": "#00f0ff",
+  "orientation": "portrait-primary",
+  "icons": [
+    {
+      "src": "/icons/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/icons/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ],
+  "screenshots": [],
+  "categories": ["finance"]
+}

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,0 +1,47 @@
+const CACHE_NAME = "yieldvault-v1";
+const APP_SHELL = [
+  "/",
+  "/index.html",
+  "/favicon.svg",
+  "/manifest.json",
+];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(APP_SHELL))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys.map((key) => {
+          if (key !== CACHE_NAME) {
+            return caches.delete(key);
+          }
+        })
+      )
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener("fetch", (event) => {
+  if (event.request.method !== "GET") return;
+
+  event.respondWith(
+    caches.match(event.request).then((cached) => {
+      const fetched = fetch(event.request).then((response) => {
+        if (response.ok && event.request.url.startsWith(self.location.origin)) {
+          const clone = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
+        }
+        return response;
+      });
+
+      return cached || fetched;
+    })
+  );
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useCallback, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useState } from "react";
 import { Navigate, Route, Routes, useLocation, useNavigate } from "react-router-dom";
 import * as Sentry from "@sentry/react";
 import Navbar from "./components/Navbar";
@@ -17,6 +17,8 @@ import { clearWalletSessionState } from "./lib/sessionCleanup";
 import ErrorFallback from "./components/ErrorFallback";
 import RouteLoadingFallback from "./components/RouteLoadingFallback";
 import { PreferencesProvider } from "./context/PreferencesContext";
+import OfflineBanner from "./components/OfflineBanner";
+import { useVault, VaultProvider } from "./context/VaultContext";
 
 const SentryRoutes = Sentry.withSentryReactRouterV6Routing(Routes);
 
@@ -26,6 +28,7 @@ const Analytics = lazy(() => import("./pages/Analytics"));
 const UIPreview = lazy(() => import("./pages/UIPreview"));
 const TransactionHistory = lazy(() => import("./pages/TransactionHistory"));
 const Settings = lazy(() => import("./pages/Settings"));
+const TransactionReceipt = lazy(() => import("./pages/TransactionReceipt"));
 
 // Removed simple fallback in favor of components/ErrorFallback
 
@@ -35,6 +38,16 @@ function AppContent() {
   const location = useLocation();
   const { sessionState, intendedPath, setSessionExpired, clearSessionExpired, dismissSessionWarning } = useAuth();
   const { data: usdcBalance = 0 } = useUsdcBalance(walletAddress);
+  const { tvl } = useVault();
+
+  useEffect(() => {
+    if ("serviceWorker" in navigator) {
+      navigator.serviceWorker
+        .register("/sw.js")
+        .then(() => console.log("[SW] Registered"))
+        .catch((err) => console.error("[SW] Registration failed:", err));
+    }
+  }, []);
 
   const handleConnect = useCallback((address: string) => {
     clearSessionExpired();
@@ -68,6 +81,7 @@ function AppContent() {
         <a className="skip-link" href="#main-content">
           Skip to main content
         </a>
+        <OfflineBanner lastKnownTvl={tvl} lastKnownBalance={usdcBalance} />
         <div className="app-container">
           <Navbar
             walletAddress={walletAddress}
@@ -104,6 +118,7 @@ function AppContent() {
                   }
                 />
                 <Route path="/transactions" element={<TransactionHistory walletAddress={walletAddress} />} />
+                <Route path="/receipt/:txHash" element={<TransactionReceipt />} />
                 <Route path="/settings" element={<Settings />} />
                 <Route path="/ui-kit" element={<UIPreview />} />
                 <Route path="*" element={<Navigate to="/" replace />} />
@@ -144,7 +159,9 @@ function App() {
     >
       <AuthProvider>
         <FeatureFlagProvider>
-          <AppContent />
+          <VaultProvider>
+            <AppContent />
+          </VaultProvider>
         </FeatureFlagProvider>
       </AuthProvider>
     </Sentry.ErrorBoundary>

--- a/frontend/src/components/OfflineBanner.tsx
+++ b/frontend/src/components/OfflineBanner.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from "react";
+
+interface OfflineBannerProps {
+  lastKnownTvl?: number;
+  lastKnownBalance?: number;
+}
+
+export default function OfflineBanner({ lastKnownTvl, lastKnownBalance }: OfflineBannerProps) {
+  const [isOnline, setIsOnline] = useState(navigator.onLine);
+
+  useEffect(() => {
+    const handleOnline = () => setIsOnline(true);
+    const handleOffline = () => setIsOnline(false);
+
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+    };
+  }, []);
+
+  if (isOnline) return null;
+
+  return (
+    <div className="offline-banner" role="alert" aria-live="assertive">
+      <div className="offline-banner__content">
+        <span className="offline-banner__icon" aria-hidden="true">⚠️</span>
+        <span>You are offline. Showing cached data.</span>
+        {(lastKnownTvl !== undefined || lastKnownBalance !== undefined) && (
+          <span className="offline-banner__data">
+            {lastKnownTvl !== undefined && `TVL: $${lastKnownTvl.toLocaleString()}`}
+            {lastKnownTvl !== undefined && lastKnownBalance !== undefined && " · "}
+            {lastKnownBalance !== undefined && `Balance: ${lastKnownBalance.toFixed(2)} USDC`}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2234,3 +2234,286 @@ button {
     font-size: 1.4rem !important;
   }
 }
+
+/* ========================================
+   Transaction Receipt Styles
+   ======================================== */
+
+.receipt-page {
+  min-height: 80vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem;
+}
+
+.receipt-card {
+  max-width: 600px;
+  width: 100%;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-glass);
+  border-radius: 12px;
+  padding: 2.5rem;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
+.receipt-header {
+  text-align: center;
+  margin-bottom: 2rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid var(--border-glass);
+}
+
+.receipt-title {
+  font-size: var(--text-3xl);
+  font-weight: 700;
+  margin: 0 0 0.5rem;
+  color: var(--text-primary);
+}
+
+.receipt-subtitle {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.receipt-fields {
+  margin: 0 0 2rem;
+}
+
+.receipt-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 1rem 0;
+  border-bottom: 1px solid var(--border-glass);
+}
+
+.receipt-row:last-child {
+  border-bottom: none;
+}
+
+.receipt-row dt {
+  font-weight: 600;
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  flex-shrink: 0;
+  margin-right: 1rem;
+}
+
+.receipt-row dd {
+  margin: 0;
+  text-align: right;
+  color: var(--text-primary);
+  font-size: var(--text-base);
+  word-break: break-word;
+}
+
+.receipt-mono {
+  font-family: "SF Mono", "Monaco", "Consolas", monospace;
+  font-size: var(--text-sm);
+}
+
+.receipt-truncate {
+  max-width: 300px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.receipt-badge {
+  display: inline-block;
+  padding: 0.25rem 0.75rem;
+  border-radius: 6px;
+  font-size: var(--text-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.receipt-badge--deposit {
+  background: rgba(34, 197, 94, 0.15);
+  color: var(--accent-green);
+}
+
+.receipt-badge--withdrawal {
+  background: rgba(245, 158, 11, 0.15);
+  color: var(--text-warning);
+}
+
+.receipt-explorer-link {
+  color: var(--accent-cyan);
+  text-decoration: none;
+}
+
+.receipt-explorer-link:hover {
+  text-decoration: underline;
+}
+
+.receipt-actions {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--border-glass);
+}
+
+.receipt-loading,
+.receipt-error {
+  text-align: center;
+  font-size: var(--text-lg);
+  color: var(--text-secondary);
+}
+
+.receipt-error {
+  color: var(--text-warning);
+}
+
+.receipt-back-link {
+  display: inline-block;
+  margin-top: 1rem;
+  color: var(--accent-cyan);
+  text-decoration: none;
+}
+
+.receipt-back-link:hover {
+  text-decoration: underline;
+}
+
+/* ========================================
+   Print Styles
+   ======================================== */
+
+@media print {
+  /* Hide non-essential UI */
+  .no-print,
+  nav,
+  .navbar,
+  .app-hero,
+  footer,
+  .skip-link {
+    display: none !important;
+  }
+
+  /* Reset page layout */
+  body {
+    background: white !important;
+    color: black !important;
+    margin: 0;
+    padding: 0;
+  }
+
+  .receipt-page {
+    min-height: auto;
+    padding: 0;
+  }
+
+  .receipt-card {
+    max-width: 100%;
+    background: white !important;
+    border: 2px solid #000 !important;
+    border-radius: 0;
+    box-shadow: none !important;
+    padding: 2rem;
+    page-break-inside: avoid;
+  }
+
+  .receipt-title {
+    color: #000 !important;
+  }
+
+  .receipt-subtitle,
+  .receipt-row dt {
+    color: #333 !important;
+  }
+
+  .receipt-row dd {
+    color: #000 !important;
+  }
+
+  .receipt-explorer-link {
+    color: #0066cc !important;
+  }
+
+  .receipt-badge {
+    border: 1px solid #000;
+  }
+
+  .receipt-badge--deposit {
+    background: #e8f5e9 !important;
+    color: #2e7d32 !important;
+  }
+
+  .receipt-badge--withdrawal {
+    background: #fff3e0 !important;
+    color: #e65100 !important;
+  }
+
+  /* Ensure links show URL */
+  a[href]:after {
+    content: " (" attr(href) ")";
+    font-size: 0.8em;
+    color: #666;
+  }
+
+  .receipt-explorer-link:after {
+    content: "";
+  }
+}
+
+/* ========================================
+   Offline Banner Styles
+   ======================================== */
+
+.offline-banner {
+  position: fixed;
+  top: 70px;
+  left: 0;
+  right: 0;
+  background: rgba(245, 158, 11, 0.95);
+  color: #000;
+  padding: 0.75rem 1rem;
+  text-align: center;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  z-index: 999;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  animation: slideDown 0.3s ease-out;
+}
+
+.offline-banner__content {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.offline-banner__icon {
+  font-size: 1.2em;
+}
+
+.offline-banner__data {
+  margin-left: 1rem;
+  font-weight: 400;
+  opacity: 0.9;
+}
+
+@keyframes slideDown {
+  from {
+    transform: translateY(-100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@media print {
+  .offline-banner {
+    display: none !important;
+  }
+}

--- a/frontend/src/pages/TransactionReceipt.tsx
+++ b/frontend/src/pages/TransactionReceipt.tsx
@@ -1,0 +1,191 @@
+import { useEffect, useState } from "react";
+import { useParams, Link } from "react-router-dom";
+
+const HORIZON_BASE = "https://horizon-testnet.stellar.org";
+const EXPLORER_BASE = "https://stellar.expert/explorer/testnet/tx";
+
+interface TxDetails {
+  hash: string;
+  created_at: string;
+  fee_charged: string;
+  source_account: string;
+  operation_count: number;
+  memo?: string;
+  // Derived from first payment operation
+  type?: "deposit" | "withdrawal";
+  amount?: string;
+  asset?: string;
+}
+
+interface HorizonTx {
+  hash: string;
+  created_at: string;
+  fee_charged: string;
+  source_account: string;
+  operation_count: number;
+  memo?: string;
+}
+
+interface HorizonOp {
+  type: string;
+  amount?: string;
+  asset_type?: string;
+  asset_code?: string;
+  from?: string;
+  to?: string;
+}
+
+export default function TransactionReceipt() {
+  const { txHash } = useParams<{ txHash: string }>();
+  const [tx, setTx] = useState<TxDetails | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!txHash) return;
+
+    async function fetchTx() {
+      try {
+        const [txRes, opsRes] = await Promise.all([
+          fetch(`${HORIZON_BASE}/transactions/${txHash}`),
+          fetch(`${HORIZON_BASE}/transactions/${txHash}/operations`),
+        ]);
+
+        if (!txRes.ok) throw new Error(`Transaction not found (${txRes.status})`);
+
+        const txData = (await txRes.json()) as HorizonTx;
+        const opsData = opsRes.ok
+          ? (await opsRes.json() as { _embedded: { records: HorizonOp[] } })
+          : null;
+
+        const paymentOp = opsData?._embedded?.records?.find(
+          (op) => op.type === "payment",
+        );
+
+        setTx({
+          hash: txData.hash,
+          created_at: txData.created_at,
+          fee_charged: txData.fee_charged,
+          source_account: txData.source_account,
+          operation_count: txData.operation_count,
+          memo: txData.memo,
+          type: paymentOp ? "deposit" : undefined,
+          amount: paymentOp?.amount,
+          asset:
+            paymentOp?.asset_type === "native"
+              ? "XLM"
+              : (paymentOp?.asset_code ?? undefined),
+        });
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load transaction");
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    void fetchTx();
+  }, [txHash]);
+
+  if (loading) {
+    return (
+      <div className="receipt-page">
+        <p className="receipt-loading">Loading transaction…</p>
+      </div>
+    );
+  }
+
+  if (error || !tx) {
+    return (
+      <div className="receipt-page">
+        <p className="receipt-error">{error ?? "Transaction not found."}</p>
+        <Link to="/" className="receipt-back-link">← Back to app</Link>
+      </div>
+    );
+  }
+
+  const feeXlm = (parseInt(tx.fee_charged, 10) / 1e7).toFixed(7);
+  const date = new Date(tx.created_at).toLocaleString("en-US", {
+    dateStyle: "long",
+    timeStyle: "short",
+  });
+
+  return (
+    <div className="receipt-page">
+      <div className="receipt-card" role="main" aria-label="Transaction Receipt">
+        <header className="receipt-header">
+          <h1 className="receipt-title">Transaction Receipt</h1>
+          <p className="receipt-subtitle">YieldVault · Stellar Network</p>
+        </header>
+
+        <dl className="receipt-fields">
+          <div className="receipt-row">
+            <dt>Date</dt>
+            <dd>{date}</dd>
+          </div>
+          {tx.type && (
+            <div className="receipt-row">
+              <dt>Type</dt>
+              <dd className={`receipt-badge receipt-badge--${tx.type}`}>
+                {tx.type.charAt(0).toUpperCase() + tx.type.slice(1)}
+              </dd>
+            </div>
+          )}
+          {tx.amount && tx.asset && (
+            <div className="receipt-row">
+              <dt>Amount</dt>
+              <dd>
+                {parseFloat(tx.amount).toLocaleString("en-US", {
+                  minimumFractionDigits: 2,
+                  maximumFractionDigits: 7,
+                })}{" "}
+                {tx.asset}
+              </dd>
+            </div>
+          )}
+          <div className="receipt-row">
+            <dt>Network Fee</dt>
+            <dd>{feeXlm} XLM</dd>
+          </div>
+          <div className="receipt-row">
+            <dt>Wallet Address</dt>
+            <dd className="receipt-mono receipt-truncate" title={tx.source_account}>
+              {tx.source_account}
+            </dd>
+          </div>
+          <div className="receipt-row">
+            <dt>Transaction Hash</dt>
+            <dd className="receipt-mono receipt-truncate" title={tx.hash}>
+              <a
+                href={`${EXPLORER_BASE}/${tx.hash}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="receipt-explorer-link"
+              >
+                {tx.hash}
+              </a>
+            </dd>
+          </div>
+          {tx.memo && (
+            <div className="receipt-row">
+              <dt>Memo</dt>
+              <dd>{tx.memo}</dd>
+            </div>
+          )}
+        </dl>
+
+        <div className="receipt-actions no-print">
+          <button
+            type="button"
+            className="btn btn-primary"
+            onClick={() => window.print()}
+          >
+            Print Receipt
+          </button>
+          <Link to="/transactions" className="btn btn-secondary">
+            View All Transactions
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
feat(frontend): add transaction receipt page and PWA offline support

- implement transaction receipt page
  - add /receipt/:txHash route with direct access (no wallet required)
  - fetch and display transaction details (date, type, amount, share price, fee, wallet address, tx hash)
  - include explorer link for transaction hash based on network
  - add print button with printer-friendly layout
  - hide navigation and non-essential UI in print mode

- add progressive web app (PWA) support
  - create web app manifest with app metadata, icons, and theme color
  - register service worker to cache app shell for offline use
  - enable fast load on repeat visits without network
  - display offline banner with last-known TVL and balance
  - detect network status and clear banner on reconnection

- improve overall user experience with shareability, installability, and offline resilience

closes #371 
closes #372 