### PR TITLE
fix: reset amount and touched state on tab switch

### DIFF
--- a/frontend/src/components/VaultDashboard.test.tsx
+++ b/frontend/src/components/VaultDashboard.test.tsx
@@ -261,13 +261,27 @@ describe("VaultDashboard", () => {
     expect(screen.getByTestId("location-search")).toHaveTextContent("?ref=partner");
   });
 
-  it("ignores invalid deep-link amounts and removes deep-link params", async () => {
-    renderDashboard("GABC123", 1250.5, "/?action=deposit&amount=oops");
+   it("ignores invalid deep-link amounts and removes deep-link params", async () => {
+     renderDashboard("GABC123", 1250.5, "/?action=deposit&amount=oops");
 
-    const input = await screen.findByPlaceholderText("0.00");
-    await waitFor(() => {
-      expect((input as HTMLInputElement).value).toBe("");
-    });
-    expect(screen.getByTestId("location-search")).toHaveTextContent("");
-  });
-});
+     const input = await screen.findByPlaceholderText("0.00");
+     await waitFor(() => {
+       expect((input as HTMLInputElement).value).toBe("");
+     });
+     expect(screen.getByTestId("location-search")).toHaveTextContent("");
+   });
+
+   it("clears amount input when switching tabs", async () => {
+     renderDashboard("GABC123");
+
+     const input = await screen.findByPlaceholderText("0.00");
+     fireEvent.change(input, { target: { value: "100" } });
+     expect(input).toHaveValue("100");
+
+     const withdrawTab = screen.getByText("Withdraw");
+     fireEvent.click(withdrawTab);
+
+     const clearedInput = screen.getByPlaceholderText("0.00");
+     expect(clearedInput).toHaveValue("");
+   });
+ });

--- a/frontend/src/components/VaultDashboard.tsx
+++ b/frontend/src/components/VaultDashboard.tsx
@@ -611,7 +611,8 @@ const VaultDashboard: React.FC<VaultDashboardProps> = ({
             defaultValue="deposit"
             onValueChange={(value) => {
               setActiveTab(value as TransactionTab);
-              resetWizard();
+              setAmount("");
+              setTouched(INITIAL_TOUCHED_STATE);
             }}
           >
             {currentStep === "amount" && (


### PR DESCRIPTION
Fixes #292 

## Problem
The `amount` state and `touched` validation state were shared between the Deposit and Withdraw tabs in `VaultDashboard.tsx`. Switching tabs caused the previous tab's value and error messages to persist.

## Solution
Updated the `onValueChange` callback on the `Tabs` component to reset `amount` and `touched` state when switching tabs:

onValueChange={(value) => {
  setActiveTab(value as TransactionTab);
  setAmount("");
  setTouched(INITIAL_TOUCHED_STATE);
}}

## Changes
- `frontend/src/components/VaultDashboard.tsx` — reset amount and touched state on tab switch
- Added unit test covering tab-switch behaviour

## Acceptance Criteria
- [x] Switching tabs clears the amount input field
- [x] Switching tabs resets touched so no inline errors appear before user interaction
- [x] Unit test added