### PR TITLE
test: add k6 load test suite

### DIFF
--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -1,0 +1,35 @@
+name: Load Tests (Staging)
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+jobs:
+  load-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run k6 load test
+        uses: grafana/k6-action@v0.3.1
+        env:
+          BASE_URL: ${{ secrets.STAGING_BACKEND_URL || 'https://yieldvault-backend-staging.vercel.app' }}
+          WALLET_ADDRESS: ${{ secrets.LOAD_TEST_WALLET_ADDRESS }}
+          ASSET: ${{ secrets.LOAD_TEST_ASSET || 'USDC' }}
+          AMOUNT: ${{ secrets.LOAD_TEST_AMOUNT || '100.0' }}
+          METRICS_PATH: ${{ secrets.LOAD_TEST_METRICS_PATH || '/metrics' }}
+        with:
+          filename: tests/load/vault-load.test.js
+
+      - name: Publish load test summary
+        if: always()
+        run: |
+          if [ -f summary.md ]; then
+            cat summary.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Load test summary not found." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/tests/load/vault-load.test.js
+++ b/tests/load/vault-load.test.js
@@ -1,0 +1,127 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+const BASE_URL = (__ENV.BASE_URL || 'https://yieldvault-backend-staging.vercel.app').replace(/\/$/, '');
+const WALLET_ADDRESS = __ENV.WALLET_ADDRESS || 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+const ASSET = __ENV.ASSET || 'USDC';
+const AMOUNT = __ENV.AMOUNT || '100.0';
+const METRICS_PATH = __ENV.METRICS_PATH || '/metrics';
+
+function buildIdempotencyKey(prefix) {
+  return `${prefix}-${__VU}-${__ITER}-${Date.now()}`;
+}
+
+export const options = {
+  thresholds: {
+    http_req_duration: ['p(95)<500'],
+    http_req_failed: ['rate<0.001'],
+  },
+  scenarios: {
+    deposits: {
+      executor: 'ramping-vus',
+      exec: 'depositScenario',
+      startVUs: 0,
+      stages: [
+        { duration: '2m', target: 200 },
+        { duration: '5m', target: 200 },
+        { duration: '1m', target: 0 },
+      ],
+    },
+    withdrawals: {
+      executor: 'ramping-vus',
+      exec: 'withdrawalScenario',
+      startVUs: 0,
+      stages: [
+        { duration: '2m', target: 200 },
+        { duration: '5m', target: 200 },
+        { duration: '1m', target: 0 },
+      ],
+    },
+    metrics: {
+      executor: 'ramping-vus',
+      exec: 'metricsScenario',
+      startVUs: 0,
+      stages: [
+        { duration: '2m', target: 100 },
+        { duration: '5m', target: 100 },
+        { duration: '1m', target: 0 },
+      ],
+    },
+  },
+};
+
+export function depositScenario() {
+  const url = `${BASE_URL}/api/v1/vault/deposits`;
+  const payload = JSON.stringify({
+    amount: AMOUNT,
+    asset: ASSET,
+    walletAddress: WALLET_ADDRESS,
+  });
+  const params = {
+    headers: {
+      'Content-Type': 'application/json',
+      'Idempotency-Key': buildIdempotencyKey('deposit'),
+      'x-wallet-address': WALLET_ADDRESS,
+    },
+  };
+
+  const res = http.post(url, payload, params);
+  check(res, {
+    'deposit status is 201': (r) => r.status === 201,
+  });
+  sleep(1);
+}
+
+export function withdrawalScenario() {
+  const url = `${BASE_URL}/api/v1/vault/withdrawals`;
+  const payload = JSON.stringify({
+    amount: AMOUNT,
+    asset: ASSET,
+    walletAddress: WALLET_ADDRESS,
+  });
+  const params = {
+    headers: {
+      'Content-Type': 'application/json',
+      'Idempotency-Key': buildIdempotencyKey('withdrawal'),
+      'x-wallet-address': WALLET_ADDRESS,
+    },
+  };
+
+  const res = http.post(url, payload, params);
+  check(res, {
+    'withdrawal status is 201': (r) => r.status === 201,
+  });
+  sleep(1);
+}
+
+export function metricsScenario() {
+  const url = `${BASE_URL}${METRICS_PATH}`;
+  const res = http.get(url);
+  check(res, {
+    'metrics status is 200': (r) => r.status === 200,
+  });
+  sleep(1);
+}
+
+export function handleSummary(data) {
+  const p95 = data.metrics.http_req_duration.values['p(95)'];
+  const errorRate = data.metrics.http_req_failed.values.rate;
+  const p95Ms = Number.isFinite(p95) ? p95.toFixed(2) : 'n/a';
+  const errorPct = Number.isFinite(errorRate) ? (errorRate * 100).toFixed(3) : 'n/a';
+  let requestCount = 0;
+  if (data.metrics.http_reqs && data.metrics.http_reqs.values) {
+    const countValue = data.metrics.http_reqs.values.count;
+    if (typeof countValue === 'number') {
+      requestCount = countValue;
+    }
+  }
+
+  const summary = `\nLoad test summary\nP95 latency: ${p95Ms} ms\nError rate: ${errorPct}%\nRequests: ${requestCount}\n`;
+
+  const markdown = `# Load Test Summary\n\n- P95 latency: ${p95Ms} ms (threshold < 500 ms)\n- Error rate: ${errorPct}% (threshold < 0.1%)\n- Total requests: ${requestCount}\n`;
+
+  return {
+    stdout: summary,
+    'summary.md': markdown,
+  };
+}


### PR DESCRIPTION
Closes #391

### Summary

No load testing infrastructure existed to validate staging performance under
peak concurrency. This PR introduces a k6 load test suite covering the three
critical endpoints, and a weekly GitHub Actions workflow that enforces P95
latency and error-rate thresholds automatically.

---

### Root Cause

Without scheduled load tests, regressions in throughput or latency could
reach production undetected. There were no defined P95 or error-rate
thresholds against which staging deployments were validated.

---

### What Changed

**1. k6 load test scripts**
Added load test coverage for three endpoints:

| Endpoint | Thresholds enforced |
|---|---|
| `deposit` | P95 latency · error rate |
| `withdrawal` | P95 latency · error rate |
| `metrics` | P95 latency · error rate |

**2. Weekly GitHub Actions workflow**
Added a scheduled CI workflow that:
- Runs the k6 suite against staging on a weekly cadence
- Publishes P95 latency and error rate as a job summary on each run

---

### Testing

| Check | Result |
|---|---|
| Local execution | ⚠️ Not run — scheduled workflow, validates on CI push |
| CI trigger | ✅ Weekly schedule via GitHub Actions |
| Result surface | ✅ P95 / error rate published in job summary |

---