### PR TITLE
Advanced Transaction Filtering & URL State Sync

### DIFF
--- a/frontend/src/components/TransactionFilterPanel.tsx
+++ b/frontend/src/components/TransactionFilterPanel.tsx
@@ -1,0 +1,400 @@
+import React, { useState, useEffect, useCallback, useId } from "react";
+import type { TransactionFilters, TxType, TxStatus } from "../hooks/useTransactionFilters";
+import { VALID_TX_TYPES, VALID_TX_STATUSES } from "../hooks/useTransactionFilters";
+
+// ---------------------------------------------------------------------------
+// Labels
+// ---------------------------------------------------------------------------
+
+const TYPE_LABELS: Record<TxType, string> = {
+  deposit: "Deposit",
+  withdrawal: "Withdrawal",
+  transfer: "Transfer",
+  trade: "Trade",
+};
+
+const STATUS_LABELS: Record<TxStatus, string> = {
+  pending: "Pending",
+  completed: "Completed",
+  failed: "Failed",
+};
+
+const STATUS_COLORS: Record<TxStatus, string> = {
+  pending: "var(--text-warning)",
+  completed: "var(--accent-green)",
+  failed: "var(--text-error)",
+};
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface TransactionFilterPanelProps {
+  filters: TransactionFilters;
+  onSearchChange: (value: string) => void;
+  onTypesChange: (types: TxType[]) => void;
+  onStatusesChange: (statuses: TxStatus[]) => void;
+  onDateFromChange: (value: string) => void;
+  onDateToChange: (value: string) => void;
+  onAmountMinChange: (value: string) => void;
+  onAmountMaxChange: (value: string) => void;
+  onClearAll: () => void;
+  hasActiveFilters: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Sub-component: CheckGroup
+// ---------------------------------------------------------------------------
+
+interface CheckGroupProps<T extends string> {
+  id: string;
+  label: string;
+  options: readonly T[];
+  selected: T[];
+  labelMap: Record<T, string>;
+  colorMap?: Record<T, string>;
+  onChange: (selected: T[]) => void;
+}
+
+function CheckGroup<T extends string>({
+  id,
+  label,
+  options,
+  selected,
+  labelMap,
+  colorMap,
+  onChange,
+}: CheckGroupProps<T>) {
+  const toggle = (value: T) => {
+    if (selected.includes(value)) {
+      onChange(selected.filter((v) => v !== value));
+    } else {
+      onChange([...selected, value]);
+    }
+  };
+
+  return (
+    <fieldset className="tx-filter-fieldset" id={id}>
+      <legend className="tx-filter-legend">{label}</legend>
+      <div className="tx-filter-check-group">
+        {options.map((option) => {
+          const isChecked = selected.includes(option);
+          const color = colorMap?.[option];
+          return (
+            <label
+              key={option}
+              className={`tx-filter-check-label${isChecked ? " tx-filter-check-label--active" : ""}`}
+              style={isChecked && color ? { borderColor: color, color } : undefined}
+            >
+              <input
+                type="checkbox"
+                className="tx-filter-checkbox"
+                checked={isChecked}
+                aria-label={`Filter by ${label} ${labelMap[option]}`}
+                onChange={() => toggle(option)}
+              />
+              <span
+                className="tx-filter-check-pip"
+                style={color ? { background: color } : undefined}
+              />
+              {labelMap[option]}
+            </label>
+          );
+        })}
+      </div>
+    </fieldset>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+const DEBOUNCE_MS = 300;
+
+export const TransactionFilterPanel: React.FC<TransactionFilterPanelProps> = ({
+  filters,
+  onSearchChange,
+  onTypesChange,
+  onStatusesChange,
+  onDateFromChange,
+  onDateToChange,
+  onAmountMinChange,
+  onAmountMaxChange,
+  onClearAll,
+  hasActiveFilters,
+}) => {
+  const uid = useId();
+  const [isExpanded, setIsExpanded] = useState(true);
+
+  // ---------------------------------------------------------------------------
+  // Local controlled state for debounced inputs
+  // ---------------------------------------------------------------------------
+
+  const [localSearch, setLocalSearch] = useState(filters.search);
+  const [localAmountMin, setLocalAmountMin] = useState(filters.amountMin);
+  const [localAmountMax, setLocalAmountMax] = useState(filters.amountMax);
+
+  // Sync local state when URL changes externally (e.g. back/forward, clearAll)
+  useEffect(() => {
+    setLocalSearch(filters.search);
+  }, [filters.search]);
+
+  useEffect(() => {
+    setLocalAmountMin(filters.amountMin);
+  }, [filters.amountMin]);
+
+  useEffect(() => {
+    setLocalAmountMax(filters.amountMax);
+  }, [filters.amountMax]);
+
+  // ---------------------------------------------------------------------------
+  // Debounced propagation
+  // ---------------------------------------------------------------------------
+
+  useEffect(() => {
+    if (localSearch === filters.search) return;
+    const id = window.setTimeout(() => onSearchChange(localSearch), DEBOUNCE_MS);
+    return () => window.clearTimeout(id);
+  }, [localSearch, filters.search, onSearchChange]);
+
+  useEffect(() => {
+    if (localAmountMin === filters.amountMin) return;
+    const id = window.setTimeout(
+      () => onAmountMinChange(localAmountMin),
+      DEBOUNCE_MS,
+    );
+    return () => window.clearTimeout(id);
+  }, [localAmountMin, filters.amountMin, onAmountMinChange]);
+
+  useEffect(() => {
+    if (localAmountMax === filters.amountMax) return;
+    const id = window.setTimeout(
+      () => onAmountMaxChange(localAmountMax),
+      DEBOUNCE_MS,
+    );
+    return () => window.clearTimeout(id);
+  }, [localAmountMax, filters.amountMax, onAmountMaxChange]);
+
+  // ---------------------------------------------------------------------------
+  // Handlers
+  // ---------------------------------------------------------------------------
+
+  const handleClearAll = useCallback(() => {
+    setLocalSearch("");
+    setLocalAmountMin("");
+    setLocalAmountMax("");
+    onClearAll();
+  }, [onClearAll]);
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+
+  return (
+    <div className="tx-filter-panel glass-panel" aria-label="Transaction filters">
+      {/* ── Panel header ─────────────────────────────────────────── */}
+      <div className="tx-filter-header">
+        <div className="tx-filter-header-left">
+          <span className="tx-filter-icon" aria-hidden="true">⚡</span>
+          <span className="tx-filter-title">Filters</span>
+          {hasActiveFilters && (
+            <span className="tx-filter-badge" aria-label="Filters active">
+              Active
+            </span>
+          )}
+        </div>
+
+        <div className="tx-filter-header-right">
+          {hasActiveFilters && (
+            <button
+              type="button"
+              id={`${uid}-clear`}
+              className="tx-filter-clear-btn"
+              onClick={handleClearAll}
+              aria-label="Clear all filters"
+            >
+              ✕ Clear Filters
+            </button>
+          )}
+          <button
+            type="button"
+            className="tx-filter-toggle"
+            aria-expanded={isExpanded}
+            aria-controls={`${uid}-body`}
+            onClick={() => setIsExpanded((p) => !p)}
+            aria-label={isExpanded ? "Collapse filters" : "Expand filters"}
+          >
+            <span
+              className="tx-filter-chevron"
+              style={{ transform: isExpanded ? "rotate(180deg)" : "rotate(0deg)" }}
+              aria-hidden="true"
+            >
+              ▾
+            </span>
+          </button>
+        </div>
+      </div>
+
+      {/* ── Panel body ───────────────────────────────────────────── */}
+      {isExpanded && (
+        <div
+          id={`${uid}-body`}
+          className="tx-filter-body"
+          role="group"
+          aria-label="Filter controls"
+        >
+          {/* Row 1: Search + Date range */}
+          <div className="tx-filter-row">
+            {/* Text search */}
+            <div className="tx-filter-field tx-filter-field--wide">
+              <label
+                htmlFor={`${uid}-search`}
+                className="tx-filter-field-label"
+              >
+                Search
+              </label>
+              <div className="tx-filter-input-wrapper">
+                <span className="tx-filter-input-icon" aria-hidden="true">🔍</span>
+                <input
+                  id={`${uid}-search`}
+                  type="search"
+                  className="tx-filter-input"
+                  placeholder="Hash, description, counterparty…"
+                  value={localSearch}
+                  onChange={(e) => setLocalSearch(e.target.value)}
+                  aria-label="Search transactions"
+                  autoComplete="off"
+                />
+                {localSearch && (
+                  <button
+                    type="button"
+                    className="tx-filter-input-clear"
+                    onClick={() => setLocalSearch("")}
+                    aria-label="Clear search"
+                  >
+                    ✕
+                  </button>
+                )}
+              </div>
+            </div>
+
+            {/* Date from */}
+            <div className="tx-filter-field">
+              <label
+                htmlFor={`${uid}-date-from`}
+                className="tx-filter-field-label"
+              >
+                From date
+              </label>
+              <div className="tx-filter-input-wrapper">
+                <input
+                  id={`${uid}-date-from`}
+                  type="date"
+                  className="tx-filter-input"
+                  value={filters.dateFrom}
+                  max={filters.dateTo || undefined}
+                  onChange={(e) => onDateFromChange(e.target.value)}
+                  aria-label="Filter from date"
+                />
+              </div>
+            </div>
+
+            {/* Date to */}
+            <div className="tx-filter-field">
+              <label
+                htmlFor={`${uid}-date-to`}
+                className="tx-filter-field-label"
+              >
+                To date
+              </label>
+              <div className="tx-filter-input-wrapper">
+                <input
+                  id={`${uid}-date-to`}
+                  type="date"
+                  className="tx-filter-input"
+                  value={filters.dateTo}
+                  min={filters.dateFrom || undefined}
+                  onChange={(e) => onDateToChange(e.target.value)}
+                  aria-label="Filter to date"
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Row 2: Amount range */}
+          <div className="tx-filter-row">
+            <div className="tx-filter-field">
+              <label
+                htmlFor={`${uid}-amount-min`}
+                className="tx-filter-field-label"
+              >
+                Min amount
+              </label>
+              <div className="tx-filter-input-wrapper">
+                <span className="tx-filter-input-prefix" aria-hidden="true">$</span>
+                <input
+                  id={`${uid}-amount-min`}
+                  type="number"
+                  className="tx-filter-input tx-filter-input--amount"
+                  placeholder="0"
+                  min="0"
+                  step="any"
+                  value={localAmountMin}
+                  onChange={(e) => setLocalAmountMin(e.target.value)}
+                  aria-label="Minimum transaction amount"
+                />
+              </div>
+            </div>
+
+            <div className="tx-filter-field">
+              <label
+                htmlFor={`${uid}-amount-max`}
+                className="tx-filter-field-label"
+              >
+                Max amount
+              </label>
+              <div className="tx-filter-input-wrapper">
+                <span className="tx-filter-input-prefix" aria-hidden="true">$</span>
+                <input
+                  id={`${uid}-amount-max`}
+                  type="number"
+                  className="tx-filter-input tx-filter-input--amount"
+                  placeholder="∞"
+                  min="0"
+                  step="any"
+                  value={localAmountMax}
+                  onChange={(e) => setLocalAmountMax(e.target.value)}
+                  aria-label="Maximum transaction amount"
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Row 3: Type + Status multi-select */}
+          <div className="tx-filter-row tx-filter-row--checks">
+            <CheckGroup
+              id={`${uid}-types`}
+              label="Type"
+              options={VALID_TX_TYPES}
+              selected={filters.types}
+              labelMap={TYPE_LABELS}
+              onChange={(v) => onTypesChange(v as TxType[])}
+            />
+            <CheckGroup
+              id={`${uid}-statuses`}
+              label="Status"
+              options={VALID_TX_STATUSES}
+              selected={filters.statuses}
+              labelMap={STATUS_LABELS}
+              colorMap={STATUS_COLORS}
+              onChange={(v) => onStatusesChange(v as TxStatus[])}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TransactionFilterPanel;

--- a/frontend/src/hooks/useTransactionFilters.test.ts
+++ b/frontend/src/hooks/useTransactionFilters.test.ts
@@ -1,0 +1,289 @@
+/**
+ * useTransactionFilters — URL query parameter parser tests
+ *
+ * These tests verify that the hook correctly serialises and deserialises all
+ * filter values from URL search params, and that invalid / malformed values
+ * are discarded gracefully without crashing.
+ */
+
+import { describe, it, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import React from "react";
+import { useTransactionFilters } from "./useTransactionFilters";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderFilters(initialSearch = "") {
+  return renderHook(() => useTransactionFilters(), {
+    wrapper: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(
+        MemoryRouter,
+        { initialEntries: [`/?${initialSearch}`] },
+        children,
+      ),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Default / empty state
+// ---------------------------------------------------------------------------
+
+describe("useTransactionFilters — defaults", () => {
+  it("returns all defaults when URL has no params", () => {
+    const { result } = renderFilters("");
+
+    expect(result.current.filters).toEqual({
+      search: "",
+      types: [],
+      statuses: [],
+      dateFrom: "",
+      dateTo: "",
+      amountMin: "",
+      amountMax: "",
+    });
+    expect(result.current.hasActiveFilters).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Valid param parsing
+// ---------------------------------------------------------------------------
+
+describe("useTransactionFilters — valid param parsing", () => {
+  it("parses a valid search string", () => {
+    const { result } = renderFilters("search=abc123");
+    expect(result.current.filters.search).toBe("abc123");
+    expect(result.current.hasActiveFilters).toBe(true);
+  });
+
+  it("parses a single valid type", () => {
+    const { result } = renderFilters("types=deposit");
+    expect(result.current.filters.types).toEqual(["deposit"]);
+    expect(result.current.hasActiveFilters).toBe(true);
+  });
+
+  it("parses multiple valid types", () => {
+    const { result } = renderFilters("types=deposit,withdrawal,transfer");
+    expect(result.current.filters.types).toEqual([
+      "deposit",
+      "withdrawal",
+      "transfer",
+    ]);
+  });
+
+  it("parses multiple valid statuses", () => {
+    const { result } = renderFilters("statuses=pending,completed");
+    expect(result.current.filters.statuses).toEqual(["pending", "completed"]);
+  });
+
+  it("parses valid ISO date strings", () => {
+    const { result } = renderFilters("dateFrom=2026-01-01&dateTo=2026-06-30");
+    expect(result.current.filters.dateFrom).toBe("2026-01-01");
+    expect(result.current.filters.dateTo).toBe("2026-06-30");
+  });
+
+  it("parses valid positive numeric amounts", () => {
+    const { result } = renderFilters("amountMin=10&amountMax=5000.5");
+    expect(result.current.filters.amountMin).toBe("10");
+    expect(result.current.filters.amountMax).toBe("5000.5");
+  });
+
+  it("correctly identifies hasActiveFilters when at least one filter is set", () => {
+    const { result } = renderFilters("amountMax=100");
+    expect(result.current.hasActiveFilters).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Invalid / malformed param handling — must discard without crashing
+// ---------------------------------------------------------------------------
+
+describe("useTransactionFilters — invalid param handling", () => {
+  it("discards an unknown type value", () => {
+    // 'swap' is not a valid TxType
+    const { result } = renderFilters("types=deposit,swap");
+    expect(result.current.filters.types).toEqual(["deposit"]);
+  });
+
+  it("discards all types if none are valid", () => {
+    const { result } = renderFilters("types=unknown,bogus");
+    expect(result.current.filters.types).toEqual([]);
+  });
+
+  it("discards an invalid status value", () => {
+    const { result } = renderFilters("statuses=completed,cancelled");
+    expect(result.current.filters.statuses).toEqual(["completed"]);
+  });
+
+  it("discards a non-ISO dateFrom value", () => {
+    const { result } = renderFilters("dateFrom=not-a-date");
+    expect(result.current.filters.dateFrom).toBe("");
+  });
+
+  it("discards a date with wrong format (DD/MM/YYYY)", () => {
+    const { result } = renderFilters("dateFrom=15/01/2026");
+    expect(result.current.filters.dateFrom).toBe("");
+  });
+
+  it("discards an impossible date (Feb 30)", () => {
+    const { result } = renderFilters("dateFrom=2026-02-30");
+    expect(result.current.filters.dateFrom).toBe("");
+  });
+
+  it("discards a negative amountMin", () => {
+    const { result } = renderFilters("amountMin=-50");
+    expect(result.current.filters.amountMin).toBe("");
+  });
+
+  it("discards a non-numeric amountMax", () => {
+    const { result } = renderFilters("amountMax=abc");
+    expect(result.current.filters.amountMax).toBe("");
+  });
+
+  it("discards zero-length / empty param values", () => {
+    const { result } = renderFilters("types=&statuses=&dateFrom=&amountMin=");
+    expect(result.current.filters.types).toEqual([]);
+    expect(result.current.filters.statuses).toEqual([]);
+    expect(result.current.filters.dateFrom).toBe("");
+    expect(result.current.filters.amountMin).toBe("");
+    expect(result.current.hasActiveFilters).toBe(false);
+  });
+
+  it("amountMin of 0 is valid (zero is non-negative)", () => {
+    const { result } = renderFilters("amountMin=0");
+    expect(result.current.filters.amountMin).toBe("0");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Setter behaviour — clearAll
+// ---------------------------------------------------------------------------
+
+describe("useTransactionFilters — clearAll", () => {
+  it("clearAll removes all filter params from URL and sets hasActiveFilters=false", async () => {
+    const { result } = renderFilters(
+      "search=xyz&types=deposit&statuses=completed&dateFrom=2026-01-01&amountMin=10",
+    );
+
+    // Verify all filters loaded
+    expect(result.current.hasActiveFilters).toBe(true);
+
+    // Clear
+    act(() => {
+      result.current.clearAll();
+    });
+
+    expect(result.current.filters).toEqual({
+      search: "",
+      types: [],
+      statuses: [],
+      dateFrom: "",
+      dateTo: "",
+      amountMin: "",
+      amountMax: "",
+    });
+    expect(result.current.hasActiveFilters).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Setter behaviour — individual setters
+// ---------------------------------------------------------------------------
+
+describe("useTransactionFilters — individual setters", () => {
+  it("setSearch updates the search filter", () => {
+    const { result } = renderFilters("");
+
+    act(() => {
+      result.current.setSearch("hello");
+    });
+
+    expect(result.current.filters.search).toBe("hello");
+    expect(result.current.hasActiveFilters).toBe(true);
+  });
+
+  it("setSearch with empty string clears the filter", () => {
+    const { result } = renderFilters("search=hello");
+
+    act(() => {
+      result.current.setSearch("");
+    });
+
+    expect(result.current.filters.search).toBe("");
+    expect(result.current.hasActiveFilters).toBe(false);
+  });
+
+  it("setTypes updates type filter", () => {
+    const { result } = renderFilters("");
+
+    act(() => {
+      result.current.setTypes(["deposit", "trade"]);
+    });
+
+    expect(result.current.filters.types).toEqual(["deposit", "trade"]);
+  });
+
+  it("setTypes with empty array clears type filter", () => {
+    const { result } = renderFilters("types=deposit");
+
+    act(() => {
+      result.current.setTypes([]);
+    });
+
+    expect(result.current.filters.types).toEqual([]);
+    expect(result.current.hasActiveFilters).toBe(false);
+  });
+
+  it("setStatuses updates status filter", () => {
+    const { result } = renderFilters("");
+
+    act(() => {
+      result.current.setStatuses(["pending", "failed"]);
+    });
+
+    expect(result.current.filters.statuses).toEqual(["pending", "failed"]);
+  });
+
+  it("setDateFrom updates date from", () => {
+    const { result } = renderFilters("");
+
+    act(() => {
+      result.current.setDateFrom("2026-03-01");
+    });
+
+    expect(result.current.filters.dateFrom).toBe("2026-03-01");
+  });
+
+  it("setDateTo updates date to", () => {
+    const { result } = renderFilters("");
+
+    act(() => {
+      result.current.setDateTo("2026-12-31");
+    });
+
+    expect(result.current.filters.dateTo).toBe("2026-12-31");
+  });
+
+  it("setAmountMin updates amount min", () => {
+    const { result } = renderFilters("");
+
+    act(() => {
+      result.current.setAmountMin("50");
+    });
+
+    expect(result.current.filters.amountMin).toBe("50");
+  });
+
+  it("setAmountMax updates amount max", () => {
+    const { result } = renderFilters("");
+
+    act(() => {
+      result.current.setAmountMax("999");
+    });
+
+    expect(result.current.filters.amountMax).toBe("999");
+  });
+});

--- a/frontend/src/hooks/useTransactionFilters.ts
+++ b/frontend/src/hooks/useTransactionFilters.ts
@@ -1,0 +1,235 @@
+import { useMemo, useCallback } from "react";
+import { useSearchParams } from "react-router-dom";
+
+// ---------------------------------------------------------------------------
+// Valid filter enum values — used for safe deserialization
+// ---------------------------------------------------------------------------
+
+export const VALID_TX_TYPES = ["deposit", "withdrawal", "transfer", "trade"] as const;
+export const VALID_TX_STATUSES = ["pending", "completed", "failed"] as const;
+
+export type TxType = (typeof VALID_TX_TYPES)[number];
+export type TxStatus = (typeof VALID_TX_STATUSES)[number];
+
+// ---------------------------------------------------------------------------
+// Parsed filter shape
+// ---------------------------------------------------------------------------
+
+export interface TransactionFilters {
+  /** Free-text search (hash, description, counterparty) */
+  search: string;
+  /** Active type filters — empty array means "all" */
+  types: TxType[];
+  /** Active status filters — empty array means "all" */
+  statuses: TxStatus[];
+  /** ISO date string (YYYY-MM-DD), or "" */
+  dateFrom: string;
+  /** ISO date string (YYYY-MM-DD), or "" */
+  dateTo: string;
+  /** Minimum amount as a string, or "" */
+  amountMin: string;
+  /** Maximum amount as a string, or "" */
+  amountMax: string;
+}
+
+// ---------------------------------------------------------------------------
+// URL param names
+// ---------------------------------------------------------------------------
+
+const PARAM = {
+  SEARCH: "search",
+  TYPES: "types",
+  STATUSES: "statuses",
+  DATE_FROM: "dateFrom",
+  DATE_TO: "dateTo",
+  AMOUNT_MIN: "amountMin",
+  AMOUNT_MAX: "amountMax",
+  PAGE: "page",
+} as const;
+
+// ---------------------------------------------------------------------------
+// Safe parsers
+// ---------------------------------------------------------------------------
+
+function parseCommaList<T extends string>(
+  raw: string | null,
+  validValues: readonly T[],
+): T[] {
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((v) => v.trim().toLowerCase() as T)
+    .filter((v): v is T => (validValues as readonly string[]).includes(v));
+}
+
+function parseIsoDate(raw: string | null): string {
+  if (!raw) return "";
+  // Must match YYYY-MM-DD and be a valid date
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(raw)) return "";
+  const d = new Date(raw);
+  if (isNaN(d.getTime())) return "";
+  return raw;
+}
+
+function parsePositiveNumericString(raw: string | null): string {
+  if (!raw) return "";
+  const n = parseFloat(raw);
+  if (!isFinite(n) || n < 0) return "";
+  return raw;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useTransactionFilters() {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  /** Parsed, type-safe filter state derived entirely from the URL */
+  const filters = useMemo<TransactionFilters>(() => {
+    return {
+      search: searchParams.get(PARAM.SEARCH) ?? "",
+      types: parseCommaList(searchParams.get(PARAM.TYPES), VALID_TX_TYPES),
+      statuses: parseCommaList(
+        searchParams.get(PARAM.STATUSES),
+        VALID_TX_STATUSES,
+      ),
+      dateFrom: parseIsoDate(searchParams.get(PARAM.DATE_FROM)),
+      dateTo: parseIsoDate(searchParams.get(PARAM.DATE_TO)),
+      amountMin: parsePositiveNumericString(searchParams.get(PARAM.AMOUNT_MIN)),
+      amountMax: parsePositiveNumericString(searchParams.get(PARAM.AMOUNT_MAX)),
+    };
+  }, [searchParams]);
+
+  /** True when any filter is non-default */
+  const hasActiveFilters = useMemo(
+    () =>
+      Boolean(filters.search) ||
+      filters.types.length > 0 ||
+      filters.statuses.length > 0 ||
+      Boolean(filters.dateFrom) ||
+      Boolean(filters.dateTo) ||
+      Boolean(filters.amountMin) ||
+      Boolean(filters.amountMax),
+    [filters],
+  );
+
+  // ---------------------------------------------------------------------------
+  // Helpers for updating the URL (always uses replace to avoid history bloat)
+  // ---------------------------------------------------------------------------
+
+  const updateParams = useCallback(
+    (
+      updater: (next: URLSearchParams) => void,
+      resetPage = true,
+    ) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          updater(next);
+          if (resetPage) next.set(PARAM.PAGE, "1");
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  const setSearch = useCallback(
+    (value: string) => {
+      updateParams((next) => {
+        if (value) next.set(PARAM.SEARCH, value);
+        else next.delete(PARAM.SEARCH);
+      });
+    },
+    [updateParams],
+  );
+
+  const setTypes = useCallback(
+    (types: TxType[]) => {
+      updateParams((next) => {
+        if (types.length > 0) next.set(PARAM.TYPES, types.join(","));
+        else next.delete(PARAM.TYPES);
+      });
+    },
+    [updateParams],
+  );
+
+  const setStatuses = useCallback(
+    (statuses: TxStatus[]) => {
+      updateParams((next) => {
+        if (statuses.length > 0)
+          next.set(PARAM.STATUSES, statuses.join(","));
+        else next.delete(PARAM.STATUSES);
+      });
+    },
+    [updateParams],
+  );
+
+  const setDateFrom = useCallback(
+    (value: string) => {
+      updateParams((next) => {
+        if (value) next.set(PARAM.DATE_FROM, value);
+        else next.delete(PARAM.DATE_FROM);
+      });
+    },
+    [updateParams],
+  );
+
+  const setDateTo = useCallback(
+    (value: string) => {
+      updateParams((next) => {
+        if (value) next.set(PARAM.DATE_TO, value);
+        else next.delete(PARAM.DATE_TO);
+      });
+    },
+    [updateParams],
+  );
+
+  const setAmountMin = useCallback(
+    (value: string) => {
+      updateParams((next) => {
+        if (value) next.set(PARAM.AMOUNT_MIN, value);
+        else next.delete(PARAM.AMOUNT_MIN);
+      });
+    },
+    [updateParams],
+  );
+
+  const setAmountMax = useCallback(
+    (value: string) => {
+      updateParams((next) => {
+        if (value) next.set(PARAM.AMOUNT_MAX, value);
+        else next.delete(PARAM.AMOUNT_MAX);
+      });
+    },
+    [updateParams],
+  );
+
+  /** Strips all filter params and resets page to 1 */
+  const clearAll = useCallback(() => {
+    updateParams((next) => {
+      next.delete(PARAM.SEARCH);
+      next.delete(PARAM.TYPES);
+      next.delete(PARAM.STATUSES);
+      next.delete(PARAM.DATE_FROM);
+      next.delete(PARAM.DATE_TO);
+      next.delete(PARAM.AMOUNT_MIN);
+      next.delete(PARAM.AMOUNT_MAX);
+    });
+  }, [updateParams]);
+
+  return {
+    filters,
+    hasActiveFilters,
+    setSearch,
+    setTypes,
+    setStatuses,
+    setDateFrom,
+    setDateTo,
+    setAmountMin,
+    setAmountMax,
+    clearAll,
+  };
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2517,3 +2517,373 @@ button {
     display: none !important;
   }
 }
+
+/* ── TransactionFilterPanel ──────────────────────────────────────────────── */
+
+.tx-filter-panel {
+  padding: 20px 24px;
+  border-radius: var(--radius-md);
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+/* Header */
+.tx-filter-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.tx-filter-header-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.tx-filter-header-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.tx-filter-icon {
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.tx-filter-title {
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  color: var(--text-primary);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.tx-filter-badge {
+  font-size: var(--text-xs);
+  font-weight: var(--font-semibold);
+  color: var(--accent-cyan);
+  background: var(--accent-cyan-dim);
+  border: 1px solid rgba(0, 240, 255, 0.25);
+  border-radius: 999px;
+  padding: 1px 8px;
+  letter-spacing: 0.03em;
+}
+
+.tx-filter-clear-btn {
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+  font-family: var(--font-sans);
+  color: var(--text-error);
+  background: var(--bg-error);
+  border: 1px solid var(--border-error);
+  border-radius: var(--radius-sm);
+  padding: 5px 12px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, transform 0.1s;
+  white-space: nowrap;
+}
+
+.tx-filter-clear-btn:hover {
+  background: rgba(255, 50, 50, 0.18);
+  transform: translateY(-1px);
+}
+
+.tx-filter-clear-btn:active {
+  transform: translateY(0);
+}
+
+.tx-filter-toggle {
+  background: transparent;
+  border: 1px solid var(--border-glass);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 4px 8px;
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  line-height: 1;
+  transition: background 0.15s, color 0.15s;
+}
+
+.tx-filter-toggle:hover {
+  background: var(--bg-surface-hover);
+  color: var(--text-primary);
+}
+
+.tx-filter-chevron {
+  display: inline-block;
+  transition: transform 0.2s ease;
+  font-size: 0.875rem;
+}
+
+/* Body */
+.tx-filter-body {
+  margin-top: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.tx-filter-row {
+  display: flex;
+  gap: 14px;
+  flex-wrap: wrap;
+  align-items: flex-end;
+}
+
+.tx-filter-row--checks {
+  align-items: flex-start;
+  gap: 24px;
+}
+
+/* Individual field */
+.tx-filter-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 140px;
+  flex: 1;
+}
+
+.tx-filter-field--wide {
+  flex: 2;
+  min-width: 220px;
+}
+
+.tx-filter-field-label {
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+  color: var(--text-secondary);
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+/* Input wrapper with icon support */
+.tx-filter-input-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--border-glass);
+  border-radius: var(--radius-sm);
+  transition: border-color 0.15s, background 0.15s, box-shadow 0.15s;
+}
+
+.tx-filter-input-wrapper:focus-within {
+  border-color: var(--accent-cyan);
+  background: rgba(0, 240, 255, 0.04);
+  box-shadow: 0 0 0 2px rgba(0, 240, 255, 0.1);
+}
+
+.tx-filter-input-icon {
+  padding-left: 10px;
+  font-size: 0.8rem;
+  color: var(--text-tertiary);
+  pointer-events: none;
+  user-select: none;
+}
+
+.tx-filter-input-prefix {
+  padding-left: 10px;
+  font-size: var(--text-sm);
+  color: var(--text-tertiary);
+  pointer-events: none;
+  user-select: none;
+  font-weight: var(--font-medium);
+}
+
+.tx-filter-input {
+  width: 100%;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  font-family: var(--font-sans);
+  padding: 9px 10px;
+}
+
+/* Date inputs in dark mode tend to render a white calendar icon on Chromium —
+   invert it so it matches the theme. */
+.tx-filter-input[type="date"]::-webkit-calendar-picker-indicator {
+  filter: invert(1) brightness(0.7);
+  cursor: pointer;
+}
+
+[data-theme="light"] .tx-filter-input[type="date"]::-webkit-calendar-picker-indicator {
+  filter: none;
+}
+
+.tx-filter-input[type="number"] {
+  -moz-appearance: textfield;
+}
+
+.tx-filter-input[type="number"]::-webkit-inner-spin-button,
+.tx-filter-input[type="number"]::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+}
+
+.tx-filter-input::placeholder {
+  color: var(--text-tertiary);
+  opacity: 0.7;
+}
+
+.tx-filter-input--amount {
+  padding-left: 4px;
+}
+
+/* Inline clear button inside search input */
+.tx-filter-input-clear {
+  background: transparent;
+  border: none;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  font-size: 0.7rem;
+  padding: 0 10px;
+  font-family: var(--font-sans);
+  transition: color 0.15s;
+  flex-shrink: 0;
+}
+
+.tx-filter-input-clear:hover {
+  color: var(--text-primary);
+}
+
+/* CheckGroup */
+.tx-filter-fieldset {
+  border: none;
+  padding: 0;
+  margin: 0;
+  min-width: 0;
+}
+
+.tx-filter-legend {
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+  color: var(--text-secondary);
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+
+.tx-filter-check-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.tx-filter-check-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+  color: var(--text-secondary);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--border-glass);
+  border-radius: 999px;
+  padding: 5px 12px;
+  cursor: pointer;
+  user-select: none;
+  transition: background 0.15s, border-color 0.15s, color 0.15s, transform 0.1s;
+}
+
+.tx-filter-check-label:hover {
+  background: var(--bg-surface-hover);
+  color: var(--text-primary);
+  transform: translateY(-1px);
+}
+
+.tx-filter-check-label--active {
+  background: rgba(0, 240, 255, 0.08);
+  border-color: var(--accent-cyan);
+  color: var(--accent-cyan);
+}
+
+.tx-filter-check-label--active:hover {
+  background: rgba(0, 240, 255, 0.14);
+}
+
+/* Hide native checkbox visually */
+.tx-filter-checkbox {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+}
+
+/* Colored pip dot inside check labels */
+.tx-filter-check-pip {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  flex-shrink: 0;
+  opacity: 0.8;
+}
+
+.tx-filter-check-label:not(.tx-filter-check-label--active) .tx-filter-check-pip {
+  background: var(--text-tertiary);
+}
+
+/* ── Light theme overrides ──────────────────────────────────────────────── */
+
+[data-theme="light"] .tx-filter-input-wrapper {
+  background: rgba(0, 0, 0, 0.03);
+}
+
+[data-theme="light"] .tx-filter-input-wrapper:focus-within {
+  background: rgba(2, 132, 199, 0.04);
+}
+
+[data-theme="light"] .tx-filter-check-label {
+  background: rgba(0, 0, 0, 0.03);
+}
+
+[data-theme="light"] .tx-filter-check-label:hover {
+  background: rgba(0, 0, 0, 0.07);
+}
+
+[data-theme="light"] .tx-filter-check-label--active {
+  background: rgba(2, 132, 199, 0.08);
+  border-color: var(--accent-cyan);
+  color: var(--accent-cyan);
+}
+
+[data-theme="light"] .tx-filter-badge {
+  color: var(--accent-cyan);
+  background: var(--accent-cyan-dim);
+  border-color: rgba(2, 132, 199, 0.25);
+}
+
+/* ── Responsive ─────────────────────────────────────────────────────────── */
+
+@media (max-width: 640px) {
+  .tx-filter-panel {
+    padding: 16px;
+  }
+
+  .tx-filter-field {
+    min-width: 100%;
+    flex: 1 1 100%;
+  }
+
+  .tx-filter-field--wide {
+    min-width: 100%;
+    flex: 1 1 100%;
+  }
+
+  .tx-filter-row {
+    gap: 12px;
+  }
+
+  .tx-filter-row--checks {
+    flex-direction: column;
+    gap: 16px;
+  }
+}

--- a/frontend/src/lib/transactionApi.ts
+++ b/frontend/src/lib/transactionApi.ts
@@ -2,9 +2,14 @@ import { validate, TransactionQuerySchema } from "./api";
 import { formatNumber } from "./formatters";
 import type { TransactionQueryInput } from "./api/schemas";
 
+export type TxType = "deposit" | "withdrawal" | "transfer" | "trade";
+export type TxStatus = "pending" | "completed" | "failed";
+
 export interface Transaction {
   id: string;
-  type: "deposit" | "withdrawal";
+  type: TxType;
+  /** Transaction settlement status */
+  status: TxStatus;
   amount: string | null;
   asset: string | null;
   timestamp: string; // ISO 8601
@@ -38,6 +43,9 @@ export function normalizeOperation(
   return {
     id: op.id,
     type: isDeposit ? "deposit" : "withdrawal",
+    // Horizon operations are always settled on-chain; default to "completed".
+    // Future API versions may expose a real status field.
+    status: "completed",
     amount: op.amount ?? null,
     asset: op.asset_type === "native" ? "XLM" : (op.asset_code ?? null),
     timestamp: op.created_at,

--- a/frontend/src/pages/TransactionHistory.test.tsx
+++ b/frontend/src/pages/TransactionHistory.test.tsx
@@ -35,6 +35,7 @@ function makeTransaction(overrides: Partial<Transaction> = {}): Transaction {
   return {
     id: "1",
     type: "deposit",
+    status: "completed",
     amount: "100.00",
     asset: "USDC",
     timestamp: "2025-01-15T10:30:00Z",
@@ -410,7 +411,7 @@ describe("TransactionHistory", () => {
     mockGetTransactions.mockImplementation(async (params: unknown) => {
       const p = params as { type?: string };
       if (p.type === "withdrawal") return [];
-      return [makeTransaction({ id: "1", type: "deposit" })];
+      return [makeTransaction({ id: "1", type: "deposit", status: "completed" })];
     });
 
     renderPage(WALLET);
@@ -427,6 +428,55 @@ describe("TransactionHistory", () => {
         screen.getByText("No matches found"),
       ).toBeInTheDocument(),
     );
+  });
+
+  // New: clear filters hides the clear button
+  it("Clear Filters button hides itself after clearing active filters", async () => {
+    mockGetTransactions.mockResolvedValue([makeTransaction()]);
+
+    render(
+      <MemoryRouter initialEntries={["/?search=USDC"]}>
+        <TransactionHistory walletAddress={WALLET} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(screen.getByRole("table")).toBeInTheDocument());
+
+    // "Clear all filters" is the aria-label on the clear button in TransactionFilterPanel
+    const clearBtn = await screen.findByRole("button", {
+      name: /Clear all filters/i,
+    });
+    expect(clearBtn).toBeInTheDocument();
+
+    fireEvent.click(clearBtn);
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: /Clear all filters/i }),
+      ).not.toBeInTheDocument(),
+    );
+  });
+
+  // New: empty state with active filters shows Reset filters action
+  it("shows 'Reset filters' action button in empty state when filters are active", async () => {
+    // All completed; filtering to 'failed' yields no results
+    mockGetTransactions.mockResolvedValue([
+      makeTransaction({ id: "1", status: "completed" }),
+    ]);
+
+    render(
+      <MemoryRouter initialEntries={["/?statuses=failed"]}>
+        <TransactionHistory walletAddress={WALLET} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText("No transactions found")).toBeInTheDocument(),
+    );
+
+    expect(
+      screen.getByRole("button", { name: /Reset filters/i }),
+    ).toBeInTheDocument();
   });
 });
 
@@ -450,7 +500,7 @@ describe("TransactionHistory — Stellar Explorer link network", () => {
   it("generates a testnet explorer URL when networkConfig.isTestnet is true", async () => {
     mockNetworkConfig.isTestnet = true;
     mockGetTransactions.mockResolvedValue([
-      makeTransaction({ transactionHash: VALID_HASH }),
+      makeTransaction({ transactionHash: VALID_HASH, status: "completed" }),
     ]);
 
     renderPage(WALLET);
@@ -487,5 +537,192 @@ describe("TransactionHistory — Stellar Explorer link network", () => {
     const link = await screen.findByTitle(VALID_HASH);
     expect(link).toHaveAttribute("target", "_blank");
     expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Amount range filtering
+// ---------------------------------------------------------------------------
+
+describe("TransactionHistory — amount range filter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    mockNetworkConfig.isTestnet = true;
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("hides rows below amountMin when amountMin param is set in URL", async () => {
+    mockGetTransactions.mockResolvedValue([
+      makeTransaction({ id: "1", amount: "50.00", asset: "USDC" }),
+      makeTransaction({
+        id: "2",
+        amount: "200.00",
+        asset: "USDC",
+        transactionHash: "hash200000000000000000000000000000000000000",
+      }),
+      makeTransaction({
+        id: "3",
+        amount: "500.00",
+        asset: "USDC",
+        transactionHash: "hash500000000000000000000000000000000000000",
+      }),
+    ]);
+
+    render(
+      <MemoryRouter initialEntries={["/?amountMin=100"]}>
+        <TransactionHistory walletAddress={WALLET} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(screen.getByRole("table")).toBeInTheDocument());
+
+    // 50 should be hidden; 200 and 500 should be visible
+    await waitFor(() =>
+      expect(screen.queryAllByText(/50\.00 USDC/).length).toBe(0),
+    );
+    expect(screen.getByText("200.00 USDC")).toBeInTheDocument();
+    expect(screen.getByText("500.00 USDC")).toBeInTheDocument();
+  });
+
+  it("hides rows above amountMax when amountMax param is set in URL", async () => {
+    mockGetTransactions.mockResolvedValue([
+      makeTransaction({ id: "1", amount: "50.00", asset: "USDC" }),
+      makeTransaction({
+        id: "2",
+        amount: "200.00",
+        asset: "USDC",
+        transactionHash: "hash200000000000000000000000000000000000000",
+      }),
+      makeTransaction({
+        id: "3",
+        amount: "500.00",
+        asset: "USDC",
+        transactionHash: "hash500000000000000000000000000000000000000",
+      }),
+    ]);
+
+    render(
+      <MemoryRouter initialEntries={["/?amountMax=150"]}>
+        <TransactionHistory walletAddress={WALLET} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(screen.getByRole("table")).toBeInTheDocument());
+
+    // Only 50 should be visible
+    await waitFor(() =>
+      expect(screen.queryAllByText(/500\.00 USDC/).length).toBe(0),
+    );
+    expect(screen.getByText("50.00 USDC")).toBeInTheDocument();
+    expect(screen.queryAllByText(/200\.00 USDC/).length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Status filtering
+// ---------------------------------------------------------------------------
+
+describe("TransactionHistory — status filter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    mockNetworkConfig.isTestnet = true;
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shows only matching status rows when statuses param is set in URL", async () => {
+    mockGetTransactions.mockResolvedValue([
+      makeTransaction({ id: "1", status: "completed", asset: "USDC" }),
+      makeTransaction({
+        id: "2",
+        status: "pending",
+        asset: "EURC",
+        transactionHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      }),
+      makeTransaction({
+        id: "3",
+        status: "failed",
+        asset: "XLM",
+        transactionHash: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      }),
+    ]);
+
+    render(
+      <MemoryRouter initialEntries={["/?statuses=pending"]}>
+        <TransactionHistory walletAddress={WALLET} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(screen.getByRole("table")).toBeInTheDocument());
+
+    // Only EURC (pending) should survive the filter
+    await waitFor(() =>
+      expect(screen.queryAllByText("USDC").length).toBe(0),
+    );
+    expect(screen.getByText("EURC")).toBeInTheDocument();
+    expect(screen.queryAllByText("XLM").length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// URL shareability
+// ---------------------------------------------------------------------------
+
+describe("TransactionHistory — URL shareability", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    mockNetworkConfig.isTestnet = true;
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("restores date range inputs from URL on mount", async () => {
+    mockGetTransactions.mockResolvedValue([]);
+
+    render(
+      <MemoryRouter initialEntries={["/?dateFrom=2026-01-01&dateTo=2026-06-30"]}>
+        <TransactionHistory walletAddress={WALLET} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(screen.getByRole("table")).toBeInTheDocument());
+
+    const dateFromInput = screen.getByLabelText(/Filter from date/i);
+    const dateToInput = screen.getByLabelText(/Filter to date/i);
+
+    expect(dateFromInput).toHaveValue("2026-01-01");
+    expect(dateToInput).toHaveValue("2026-06-30");
+  });
+
+  it("restores amount range inputs from URL on mount", async () => {
+    mockGetTransactions.mockResolvedValue([]);
+
+    render(
+      <MemoryRouter initialEntries={["/?amountMin=10&amountMax=500"]}>
+        <TransactionHistory walletAddress={WALLET} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(screen.getByRole("table")).toBeInTheDocument());
+
+    const amountMinInput = screen.getByLabelText(/Minimum transaction amount/i);
+    const amountMaxInput = screen.getByLabelText(/Maximum transaction amount/i);
+
+    expect(amountMinInput).toHaveValue(10);
+    expect(amountMaxInput).toHaveValue(500);
   });
 });

--- a/frontend/src/pages/TransactionHistory.tsx
+++ b/frontend/src/pages/TransactionHistory.tsx
@@ -4,13 +4,14 @@ import ApiStatusBanner from "../components/ApiStatusBanner";
 import Badge from "../components/Badge";
 import { DataTable, type DataTableColumn } from "../components/DataTable";
 import PageHeader from "../components/PageHeader";
+import TransactionFilterPanel from "../components/TransactionFilterPanel";
 import EmptyState from "../components/ui/EmptyState";
 import { Activity } from "../components/icons";
-import { 
-  normalizeApiError, 
-  isValidationError, 
-  type ApiError, 
-  type ValidationError 
+import {
+  normalizeApiError,
+  isValidationError,
+  type ApiError,
+  type ValidationError,
 } from "../lib/api";
 import {
   formatAmount,
@@ -21,6 +22,7 @@ import {
 } from "../lib/transactionApi";
 import { useClientDataTable } from "../hooks/useClientDataTable";
 import { useDataTableState } from "../hooks/useDataTableState";
+import { useTransactionFilters } from "../hooks/useTransactionFilters";
 import { getStellarExplorerUrl } from "../lib/security";
 import { networkConfig } from "../config/network";
 
@@ -28,7 +30,6 @@ interface TransactionHistoryProps {
   walletAddress: string | null;
 }
 
-type TxTypeFilter = "all" | "deposit" | "withdrawal";
 const DEFAULT_PAGE_SIZE = 10;
 const PAGE_SIZE_OPTIONS = [10, 25, 50] as const;
 
@@ -57,6 +58,12 @@ function persistPreferredPageSize(walletAddress: string | null, pageSize: number
   }
 }
 
+const STATUS_COLOR_MAP: Record<Transaction["status"], "success" | "warning" | "error"> = {
+  completed: "success",
+  pending: "warning",
+  failed: "error",
+};
+
 const columns: DataTableColumn<Transaction>[] = [
   {
     id: "type",
@@ -65,6 +72,16 @@ const columns: DataTableColumn<Transaction>[] = [
     cell: (row) => (
       <Badge variant="status" color={row.type === "deposit" ? "cyan" : "error"}>
         {row.type}
+      </Badge>
+    ),
+  },
+  {
+    id: "status",
+    header: "Status",
+    sortable: true,
+    cell: (row) => (
+      <Badge variant="status" color={STATUS_COLOR_MAP[row.status]}>
+        {row.status}
       </Badge>
     ),
   },
@@ -113,11 +130,13 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<ApiError | ValidationError | null>(null);
+
   const preferredPageSize = React.useMemo(
     () => loadPreferredPageSize(walletAddress),
     [walletAddress],
   );
 
+  // ── Sort / pagination state (URL-synced via useDataTableState) ──────────
   const { state, setSearch, setSort, setPage, setPageSize } = useDataTableState(
     {
       defaultSortBy: "date",
@@ -125,75 +144,42 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({
       defaultPageSize: preferredPageSize,
     },
   );
-  const [searchInput, setSearchInput] = useState(state.search);
 
-  const [searchParams, setSearchParams] = useSearchParams();
-  const txType = (searchParams.get("txType") ?? "all") as TxTypeFilter;
+  // ── Multi-filter state (URL-synced via useTransactionFilters) ───────────
+  const {
+    filters,
+    hasActiveFilters,
+    setSearch: setFilterSearch,
+    setTypes,
+    setStatuses,
+    setDateFrom,
+    setDateTo,
+    setAmountMin,
+    setAmountMax,
+    clearAll,
+  } = useTransactionFilters();
 
-  const setTxType = (value: TxTypeFilter) => {
-    const nextParams = new URLSearchParams(searchParams);
-    nextParams.set("txType", value);
-    nextParams.set("page", "1");
-    setSearchParams(nextParams, { replace: true });
-  };
-
-  // Date range from URL
-  const dateFrom = searchParams.get("dateFrom") ?? "";
-  const dateTo = searchParams.get("dateTo") ?? "";
-
-  const setDateFrom = (value: string) => {
-    const nextParams = new URLSearchParams(searchParams);
-    if (value) nextParams.set("dateFrom", value);
-    else nextParams.delete("dateFrom");
-    nextParams.set("page", "1");
-    setSearchParams(nextParams, { replace: true });
-  };
-
-  const setDateTo = (value: string) => {
-    const nextParams = new URLSearchParams(searchParams);
-    if (value) nextParams.set("dateTo", value);
-    else nextParams.delete("dateTo");
-    nextParams.set("page", "1");
-    setSearchParams(nextParams, { replace: true });
-  };
-
-  const clearAllFilters = () => {
-    const nextParams = new URLSearchParams(searchParams);
-    nextParams.delete("txType");
-    nextParams.delete("dateFrom");
-    nextParams.delete("dateTo");
-    nextParams.set("page", "1");
-    setSearchParams(nextParams, { replace: true });
-    setSearchInput("");
-    setSearch("");
-  };
-
-  const hasActiveFilters =
-    txType !== "all" ||
-    Boolean(dateFrom) ||
-    Boolean(dateTo) ||
-    Boolean(state.search);
-
+  // Keep useDataTableState's search in sync with the filter panel's search
+  // so that useClientDataTable's text-search logic still runs correctly.
+  const [searchParams] = useSearchParams();
   useEffect(() => {
-    setSearchInput(state.search);
-  }, [state.search]);
-
-  useEffect(() => {
-    if (searchInput === state.search) {
-      return;
+    const urlSearch = searchParams.get("search") ?? "";
+    if (urlSearch !== state.search) {
+      setSearch(urlSearch);
     }
+  }, [searchParams, state.search, setSearch]);
 
-    const timeoutId = window.setTimeout(() => {
-      setSearch(searchInput);
-    }, 300);
+  // ── Derive "legacy" txType for the API call (first selected type or "all") ──
+  // The API only accepts a single type param; client-side multi-type filtering
+  // handles the rest after fetch.
+  const apiTxType =
+    filters.types.length === 1
+      ? (filters.types[0] as "deposit" | "withdrawal" | "all")
+      : "all";
 
-    return () => window.clearTimeout(timeoutId);
-  }, [searchInput, setSearch, state.search]);
-
+  // ── Fetch ───────────────────────────────────────────────────────────────
   useEffect(() => {
-    if (!walletAddress) {
-      return;
-    }
+    if (!walletAddress) return;
 
     let isMounted = true;
 
@@ -205,7 +191,7 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({
           walletAddress,
           limit: state.pageSize,
           order: state.sortDirection,
-          type: txType,
+          type: apiTxType,
         });
         if (!isMounted) return;
         setTransactions(data);
@@ -229,8 +215,9 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({
     return () => {
       isMounted = false;
     };
-  }, [walletAddress, state.pageSize, state.sortDirection, txType]);
+  }, [walletAddress, state.pageSize, state.sortDirection, apiTxType]);
 
+  // ── Client-side filtering ───────────────────────────────────────────────
   const { rows, sortedRows, page, totalItems, totalPages } = useClientDataTable(
     {
       rows: transactions,
@@ -241,6 +228,8 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({
         switch (columnId) {
           case "type":
             return row.type;
+          case "status":
+            return row.status;
           case "amount":
             return row.amount !== null ? parseFloat(row.amount) : 0;
           case "date":
@@ -250,29 +239,58 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({
         }
       },
       filterRow: (row) => {
-        if (dateFrom) {
-          const from = new Date(dateFrom);
+        // Multi-type filter (client-side)
+        if (filters.types.length > 0 && !filters.types.includes(row.type)) {
+          return false;
+        }
+
+        // Status filter (client-side)
+        if (
+          filters.statuses.length > 0 &&
+          !filters.statuses.includes(row.status)
+        ) {
+          return false;
+        }
+
+        // Date range
+        if (filters.dateFrom) {
+          const from = new Date(filters.dateFrom);
           from.setHours(0, 0, 0, 0);
           if (new Date(row.timestamp) < from) return false;
         }
-        if (dateTo) {
-          const to = new Date(dateTo);
+        if (filters.dateTo) {
+          const to = new Date(filters.dateTo);
           to.setHours(23, 59, 59, 999);
           if (new Date(row.timestamp) > to) return false;
         }
+
+        // Amount range (numeric)
+        if (filters.amountMin !== "" && row.amount !== null) {
+          const min = parseFloat(filters.amountMin);
+          const amt = parseFloat(row.amount);
+          if (!isNaN(min) && !isNaN(amt) && amt < min) return false;
+        }
+        if (filters.amountMax !== "" && row.amount !== null) {
+          const max = parseFloat(filters.amountMax);
+          const amt = parseFloat(row.amount);
+          if (!isNaN(max) && !isNaN(amt) && amt > max) return false;
+        }
+
         return true;
       },
     },
   );
 
+  // ── CSV export ──────────────────────────────────────────────────────────
   const buildCsvContent = (transactionsToExport: Transaction[]) => {
-    const headers = ["date", "type", "amount", "share price", "fee", "tx hash"];
+    const headers = ["date", "type", "status", "amount", "share price", "fee", "tx hash"];
 
     const escapeCsvValue = (value: string) => `"${value.replace(/"/g, '""')}"`;
 
     const csvRows = transactionsToExport.map((transaction) => [
       formatTimestamp(transaction.timestamp),
       transaction.type,
+      transaction.status,
       formatAmount(transaction.amount, transaction.asset),
       "",
       "",
@@ -309,16 +327,20 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({
     }
   };
 
+  // ── Empty state ─────────────────────────────────────────────────────────
   const emptyMessage = (
     <EmptyState
       variant="minimal"
-      title={txType !== "all" ? "No matches found" : "No transactions yet"}
+      title={hasActiveFilters ? "No transactions found" : "No transactions yet"}
       description={
-        txType !== "all"
-          ? "Try changing your filter settings to see more history."
+        hasActiveFilters
+          ? "No transactions match your current filters."
           : "Once you make a deposit or withdrawal, it will appear here."
       }
       icon={<Activity size={24} />}
+      {...(hasActiveFilters
+        ? { actionLabel: "Reset filters", onAction: clearAll }
+        : {})}
     />
   );
 
@@ -358,6 +380,21 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({
         <div className="flex flex-col gap-lg">
           {error && <ApiStatusBanner error={error} />}
 
+          {/* ── Filter panel ──────────────────────────────────────── */}
+          <TransactionFilterPanel
+            filters={filters}
+            onSearchChange={setFilterSearch}
+            onTypesChange={setTypes}
+            onStatusesChange={setStatuses}
+            onDateFromChange={setDateFrom}
+            onDateToChange={setDateTo}
+            onAmountMinChange={setAmountMin}
+            onAmountMaxChange={setAmountMax}
+            onClearAll={clearAll}
+            hasActiveFilters={hasActiveFilters}
+          />
+
+          {/* ── Data table ────────────────────────────────────────── */}
           <section
             className="glass-panel"
             style={{ padding: "24px", background: "var(--bg-muted)" }}
@@ -377,78 +414,6 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({
               </div>
 
               <div className="portfolio-toolbar-controls">
-                <label className="input-group" style={{ minWidth: "220px" }}>
-                  <span className="text-body-sm">Search transactions</span>
-                  <div className="input-wrapper">
-                    <input
-                      aria-label="Search transactions"
-                      className="input-field"
-                      type="search"
-                      placeholder="Search asset, hash, type..."
-                      value={searchInput}
-                      onChange={(event) => setSearchInput(event.target.value)}
-                      style={{
-                        fontSize: "var(--text-base)",
-                        fontFamily: "var(--font-sans)",
-                      }}
-                    />
-                  </div>
-                </label>
-
-                <label className="input-group" style={{ minWidth: "160px" }}>
-                  <span className="text-body-sm">Type</span>
-                  <div className="input-wrapper">
-                    <select
-                      aria-label="Filter by type"
-                      value={txType}
-                      onChange={(e) =>
-                        setTxType(e.target.value as TxTypeFilter)
-                      }
-                      className="portfolio-select"
-                    >
-                      <option value="all">All</option>
-                      <option value="deposit">Deposit</option>
-                      <option value="withdrawal">Withdrawal</option>
-                    </select>
-                  </div>
-                </label>
-
-                <label className="input-group" style={{ minWidth: "140px" }}>
-                  <span className="text-body-sm">From date</span>
-                  <div className="input-wrapper">
-                    <input
-                      aria-label="Filter from date"
-                      className="input-field"
-                      type="date"
-                      value={dateFrom}
-                      max={dateTo || undefined}
-                      onChange={(e) => setDateFrom(e.target.value)}
-                      style={{
-                        fontSize: "var(--text-base)",
-                        fontFamily: "var(--font-sans)",
-                      }}
-                    />
-                  </div>
-                </label>
-
-                <label className="input-group" style={{ minWidth: "140px" }}>
-                  <span className="text-body-sm">To date</span>
-                  <div className="input-wrapper">
-                    <input
-                      aria-label="Filter to date"
-                      className="input-field"
-                      type="date"
-                      value={dateTo}
-                      min={dateFrom || undefined}
-                      onChange={(e) => setDateTo(e.target.value)}
-                      style={{
-                        fontSize: "var(--text-base)",
-                        fontFamily: "var(--font-sans)",
-                      }}
-                    />
-                  </div>
-                </label>
-
                 <label className="input-group" style={{ minWidth: "120px" }}>
                   <span className="text-body-sm">Rows</span>
                   <div className="input-wrapper">
@@ -477,17 +442,6 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({
                 >
                   Export CSV
                 </button>
-
-                {hasActiveFilters && (
-                  <button
-                    type="button"
-                    className="btn btn-outline"
-                    onClick={clearAllFilters}
-                    style={{ alignSelf: "flex-end", height: "42px" }}
-                  >
-                    Clear Filters
-                  </button>
-                )}
               </div>
             </div>
 


### PR DESCRIPTION
# Advanced Transaction Filtering & URL State Sync

## Summary

Expands the `/transactions` page from a basic toolbar into a full **power-user filter panel**, with every filter field persisted in the browser URL. Users can now bookmark, refresh, and share precisely filtered views of their transaction history — and all filter state is restored exactly as left.

Closes: #506 

---

## Motivation

The previous filter UI supported only a single-select type dropdown, a text search (not URL-synced), and a date range. There was no status filtering, no amount range, and sharing a filtered view was impossible because the search query was held only in component state.

---

## Changes

### `frontend/src/hooks/useTransactionFilters.ts` *(new)*
- Single hook that owns **all** filter state via `useSearchParams`
- Exposes typed setters for each field: `setSearch`, `setTypes`, `setStatuses`, `setDateFrom`, `setDateTo`, `setAmountMin`, `setAmountMax`
- `clearAll()` strips every filter param and resets page to 1
- `hasActiveFilters` boolean for conditional UI
- All URL params are **safely parsed** on mount — invalid values (bad dates, negative amounts, unknown enum strings) are silently discarded without crashing

| URL param | Type | Notes |
|---|---|---|
| `search` | string | free-text |
| `types` | comma-separated | `deposit,withdrawal,transfer,trade` |
| `statuses` | comma-separated | `pending,completed,failed` |
| `dateFrom` | `YYYY-MM-DD` | validated ISO date |
| `dateTo` | `YYYY-MM-DD` | validated ISO date |
| `amountMin` | numeric string | must be ≥ 0 |
| `amountMax` | numeric string | must be ≥ 0 |

### `frontend/src/components/TransactionFilterPanel.tsx` *(new)*
- Collapsible panel (▾ toggle) that houses all filter controls
- **Text search** — 300 ms debounced local state, synced to URL after threshold
- **Type multi-select** — pill checkboxes (`Deposit`, `Withdrawal`, `Transfer`, `Trade`), URL updates immediately on toggle
- **Status multi-select** — pill checkboxes (`Pending`, `Completed`, `Failed`) with per-status color pips (green / amber / red), URL updates immediately
- **Date range** — From / To date pickers, URL updates immediately
- **Amount range** — Min / Max numeric inputs, 300 ms debounced
- **Clear Filters** button — visible only when `hasActiveFilters`, resets all params + page

### `frontend/src/lib/transactionApi.ts` *(modified)*
- `Transaction.type` widened: `"deposit" | "withdrawal" | "transfer" | "trade"`
- `Transaction.status` added: `"pending" | "completed" | "failed"`
- `normalizeOperation` defaults `status` to `"completed"` (Horizon ops are always settled; field ready for future API support)

### `frontend/src/pages/TransactionHistory.tsx` *(modified)*
- Replaced the inline toolbar with `<TransactionFilterPanel>`
- `filterRow` in `useClientDataTable` now handles multi-type, status, date range, and amount range — all client-side
- Added **Status** column to the data table with color-coded badges
- Empty state passes `actionLabel="Reset filters"` and `onAction={clearAll}` when filters are active, giving users a direct shortcut back to the full list
- Pagination resets to page 1 on every filter change

### `frontend/src/index.css` *(modified)*
- ~370 lines of new CSS for `.tx-filter-*` namespace
- Glassmorphism panel using existing design tokens
- Pill checkbox labels with active-glow border and pip dots
- Input wrappers with focus ring (`var(--accent-cyan)`) and icon prefix slots
- Full light-theme overrides via `[data-theme="light"]`
- Responsive: all fields stack to full-width on ≤ 640 px

### `frontend/src/hooks/useTransactionFilters.test.ts` *(new)*
25+ unit tests covering:
- All defaults when URL has no params
- Valid parsing for every field type
- **Edge cases**: unknown type values, invalid ISO dates (wrong format, impossible date), negative `amountMin`, non-numeric amounts, empty strings, `amountMin=0` (valid)
- `clearAll()` resets all fields
- All individual setters

### `frontend/src/pages/TransactionHistory.test.tsx` *(modified)*
- Added `status: "completed"` to `makeTransaction` factory (required by extended type)
- New inline tests: Clear Filters button hides after clearing, empty state shows Reset action
- New standalone suites:
  - **Amount range** — `amountMin` hides rows below threshold; `amountMax` hides rows above
  - **Status filter** — `?statuses=pending` shows only pending rows
  - **URL shareability** — date range and amount range inputs correctly populated from URL params on mount

---

## Testing

### Automated
```bash
cd frontend && npm run test
```
> New test file: `src/hooks/useTransactionFilters.test.ts`
> Extended: `src/pages/TransactionHistory.test.tsx`

### Manual verification checklist
1. Open `/transactions` with a connected wallet
2. Type in the search field — URL updates after 300 ms; no lag in the UI
3. Check two type pills (e.g. Deposit + Transfer) — table filters immediately, URL reflects `?types=deposit,transfer`
4. Set a date range — URL updates, table narrows correctly
5. Enter a min/max amount — URL updates after 300 ms debounce
6. Copy the full URL, paste into an incognito window — exact same filters and dataset load
7. Click **Clear Filters** — all URL params stripped, full transaction list returns, button disappears
8. Navigate to page 3, change a filter — pagination snaps back to page 1
9. Filter to zero results — empty state shows **"Reset filters"** button; clicking it restores the full list

---

## Acceptance Criteria

- [x] **Combined logic** — text search, type restriction, and date range can be applied simultaneously
- [x] **Shareability** — copying the URL from a filtered view and loading it in incognito restores the exact same state
- [x] **No layout shifts** — filter panel is fixed above the table; toggling filters does not shift the table position
- [x] **Performance** — typing in search / amount fields does not trigger URL or network updates until 300 ms after the last keystroke
- [x] **Invalid params** — malformed URL params are discarded gracefully; UI renders its default state without errors
- [x] **Pagination alignment** — changing any filter resets pagination to page 1

---

## Screenshots

<!-- Add screenshots of the filter panel open and filtered states -->

---

## Checklist

- [x] Follows project naming conventions (PascalCase components, `use` prefix hooks)
- [x] No `any` types introduced
- [x] No hardcoded secrets
- [x] New CSS uses existing design tokens only (`var(--*)`)
- [x] Existing tests updated for `Transaction.status` field
- [ ] E2E Playwright test — follow-up in separate PR
