### PR TITLE
feat: add vault health status indicator to navbar (#364)

### DIFF
--- a/frontend/src/components/HealthStatusIndicator.tsx
+++ b/frontend/src/components/HealthStatusIndicator.tsx
@@ -1,0 +1,117 @@
+import { useRef, useState, useCallback, type FC } from "react";
+import { useHealthStatus, type HealthState } from "../hooks/useHealthStatus";
+
+const CONFIG = {
+  healthy:   { dot: "#22c55e", glow: "#22c55e59", label: "Healthy",     icon: "✓" },
+  degraded:  { dot: "#eab308", glow: "#eab30859", label: "Degraded",    icon: "⚠" },
+  unhealthy: { dot: "#ef4444", glow: "#ef444459", label: "Unavailable", icon: "✕" },
+} satisfies Record<HealthState, { dot: string; glow: string; label: string; icon: string }>;
+
+function relativeTime(date: Date | null) {
+  if (!date) return "Checking…";
+  const s = Math.floor((Date.now() - date.getTime()) / 1000);
+  if (s < 5)  return "just now";
+  if (s < 60) return `${s}s ago`;
+  return `${Math.floor(s / 60)}m ago`;
+}
+
+const HealthStatusIndicator: FC = () => {
+  const { state, message, checks, lastChecked, refetch } = useHealthStatus();
+  const [show, setShow] = useState(false);
+  const [pos, setPos]   = useState<"top" | "bottom">("top");
+  const ref = useRef<HTMLDivElement>(null);
+  const { dot, glow, label, icon } = CONFIG[state];
+
+  const onEnter = useCallback(() => {
+    if (ref.current) {
+      setPos(ref.current.getBoundingClientRect().top < window.innerHeight / 3 ? "bottom" : "top");
+    }
+    setShow(true);
+  }, []);
+
+  return (
+    <>
+      <style>{`
+        @keyframes pulseHard { 0%,100%{opacity:1;transform:scale(1)} 50%{opacity:.55;transform:scale(.9)} }
+        @keyframes pulseSoft { 0%,100%{opacity:1} 50%{opacity:.7} }
+      `}</style>
+
+      <div
+        ref={ref}
+        style={{ position: "relative", display: "inline-flex", alignItems: "center" }}
+        onMouseEnter={onEnter}
+        onMouseLeave={() => setShow(false)}
+        onFocus={onEnter}
+        onBlur={() => setShow(false)}
+      >
+        <button
+          type="button"
+          onClick={() => void refetch()}
+          aria-label={`Vault health: ${label}. ${message}. Click to refresh.`}
+          aria-describedby={show ? "hs-tooltip" : undefined}
+          style={{
+            all: "unset",
+            cursor: "pointer",
+            width: 10, height: 10,
+            borderRadius: "50%",
+            background: dot,
+            boxShadow: `0 0 0 3px ${glow}`,
+            outline: "revert",
+            outlineOffset: 3,
+            animation: state === "unhealthy" ? "pulseHard 1.8s ease-in-out infinite"
+                     : state === "degraded"  ? "pulseSoft 2.5s ease-in-out infinite"
+                     : "none",
+          }}
+        />
+
+        {show && (
+          <div
+            id="hs-tooltip"
+            role="tooltip"
+            style={{
+              position: "absolute",
+              ...(pos === "top" ? { bottom: "calc(100% + 10px)" } : { top: "calc(100% + 10px)" }),
+              left: "50%", transform: "translateX(-50%)",
+              minWidth: 200, maxWidth: 260,
+              background: "var(--bg-surface, #1a1a2e)",
+              border: `1px solid ${dot}33`,
+              borderRadius: 8,
+              padding: "10px 14px",
+              fontSize: "0.75rem",
+              color: "var(--text-secondary, #94a3b8)",
+              zIndex: 1000,
+              pointerEvents: "none",
+              whiteSpace: "nowrap",
+            }}
+          >
+            <div style={{ fontWeight: 600, color: dot, marginBottom: 6, fontSize: "0.8rem" }}>
+              <span aria-hidden="true">{icon}</span> {label}
+            </div>
+
+            <div style={{ marginBottom: checks ? 8 : 6, lineHeight: 1.4 }}>{message}</div>
+
+            {checks && Object.keys(checks).length > 0 && (
+              <div style={{ borderTop: "1px solid rgba(255,255,255,0.08)", paddingTop: 8, marginBottom: 6 }}>
+                <div style={{ fontWeight: 600, fontSize: "0.7rem", textTransform: "uppercase", letterSpacing: "0.06em", opacity: 0.6, marginBottom: 4 }}>
+                  Services
+                </div>
+                {Object.entries(checks).map(([svc, s]) => (
+                  <div key={svc} style={{ display: "flex", gap: 6, padding: "2px 0", fontSize: "0.72rem", color: s === "up" ? "#22c55e" : "#ef4444" }}>
+                    <span aria-hidden="true">{s === "up" ? "✓" : "✕"}</span>
+                    <span style={{ color: "var(--text-secondary, #94a3b8)" }}>{svc}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            <div style={{ borderTop: "1px solid rgba(255,255,255,0.08)", paddingTop: 6, fontSize: "0.68rem", opacity: 0.5 }}>
+              Last checked {relativeTime(lastChecked)}
+            </div>
+          </div>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default HealthStatusIndicator;

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -5,6 +5,7 @@ import WalletConnect from "./WalletConnect";
 import type { DisconnectReason } from "./WalletConnect";
 import ThemeToggle from "./ThemeToggle";
 import TvlTicker from "./TvlTicker";
+import HealthStatusIndicator from "./HealthStatusIndicator";
 import { Layers } from "./icons";
 import { useTranslation } from "../i18n";
 import { networkConfig } from "../config/network";
@@ -151,6 +152,8 @@ const Navbar: FC<NavbarProps> = ({
         {/* RIGHT */}
         <div className="flex items-center gap-md">
           <TvlTicker />
+
+          <HealthStatusIndicator />
 
           <div className="flex items-center gap-sm nav-desktop-links">
             {walletAddress && (

--- a/frontend/src/hooks/useHealthStatus.ts
+++ b/frontend/src/hooks/useHealthStatus.ts
@@ -1,0 +1,114 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type HealthState = "healthy" | "degraded" | "unhealthy";
+
+export interface HealthStatus {
+  state: HealthState;
+  message: string;
+  checks?: Record<string, "up" | "down" | string>;
+  lastChecked: Date | null;
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const POLL_INTERVAL_MS = 30_000;
+const FETCH_TIMEOUT_MS = 5_000;
+
+const INITIAL_STATUS: HealthStatus = {
+  state: "healthy",
+  message: "All systems operational",
+  lastChecked: null,
+};
+
+const UNREACHABLE_STATUS: HealthStatus = {
+  state: "unhealthy",
+  message: "Unable to connect to health service",
+  lastChecked: null,
+};
+
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
+export function useHealthStatus(
+  url = "/health",
+  intervalMs = POLL_INTERVAL_MS
+): HealthStatus & { refetch: () => void } {
+  const [status, setStatus] = useState<HealthStatus>(INITIAL_STATUS);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const fetchHealth = useCallback(async () => {
+    abortRef.current?.abort();
+    abortRef.current = new AbortController();
+
+    try {
+      const response = await fetch(url, {
+        signal: AbortSignal.any([
+          abortRef.current.signal,
+          AbortSignal.timeout(FETCH_TIMEOUT_MS),
+        ]),
+        credentials: "same-origin",
+      });
+
+      const data = await response.json();
+      const { checks } = data as { checks?: Record<string, string> };
+      const timestamp = new Date();
+
+      if (!response.ok) {
+        setStatus({
+          state: "unhealthy",
+          message: data?.message ?? "System unavailable",
+          checks,
+          lastChecked: timestamp,
+        });
+        return;
+      }
+
+      if (checks) {
+        const downServices = Object.entries(checks)
+          .filter(([, v]) => v !== "up")
+          .map(([k]) => k);
+
+        if (downServices.length > 0) {
+          setStatus({
+            state: "degraded",
+            message: `Issues with: ${downServices.join(", ")}`,
+            checks,
+            lastChecked: timestamp,
+          });
+          return;
+        }
+      }
+
+      setStatus({
+        state: "healthy",
+        message: "All systems operational",
+        checks,
+        lastChecked: timestamp,
+      });
+    } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") return;
+
+      setStatus((prev) => ({
+        ...UNREACHABLE_STATUS,
+        lastChecked: new Date(),
+        checks: prev.checks,
+      }));
+    }
+  }, [url]);
+
+  useEffect(() => {
+    void fetchHealth();
+
+    const intervalId = window.setInterval(() => {
+      void fetchHealth();
+    }, intervalMs);
+
+    return () => {
+      window.clearInterval(intervalId);
+      abortRef.current?.abort();
+    };
+  }, [fetchHealth, intervalMs]);
+
+  return { ...status, refetch: fetchHealth };
+}


### PR DESCRIPTION
Closes #364

## Summary

Resolves [#364 — Frontend: Add vault health status indicator to navigation bar](https://github.com/Junirezz/YieldVault-RWA/issues/364).

Adds a live health status dot to the nav bar so users always know the vault's operational state without leaving their current page. 


## Screenshots

<summary>🔴 Unhealthy</summary>
<img width="1366" height="768" alt="Screenshot (734)" src="https://github.com/user-attachments/assets/a961f27e-ea20-4df6-a199-1598fb225ec3" />
<summary>🟢 Healthy</summary>
<img width="1366" height="768" alt="Screenshot (737)" src="https://github.com/user-attachments/assets/f1d160d5-5b16-4efa-93fa-d6c8eac7297f" />
<summary>🟡 Degraded</summary>
<img width="1366" height="768" alt="Screenshot (738)" src="https://github.com/user-attachments/assets/c43948fe-a945-4b67-bf80-3aa04228e388" />

## Files changed

| File | Type | Description |
|------|------|-------------|
| `src/hooks/useHealthStatus.ts` | New | Custom hook — polling, status derivation, request lifecycle |
| `src/components/HealthStatusIndicator.tsx` | New | Nav bar dot + tooltip component |
| `src/components/Navbar.tsx` | Modified | Mounts `<HealthStatusIndicator />` |

---

## Implementation details

**Polling**
- `GET /health` fetched on mount and every 30 seconds
- 5-second request timeout via `AbortSignal.timeout`
- `AbortController` (via `useRef`) cancels in-flight requests before each new fetch and on unmount
- `credentials: "same-origin"` prevents CORS failures being misread as vault outages
- Clicking the dot triggers an immediate refetch

**Status logic**
- Non-200 → 🔴 unhealthy
- 200 but one or more `checks` not `"up"` → 🟡 degraded, lists affected services
- 200 and all checks pass → 🟢 healthy
- Last known `checks` preserved on network failure so tooltip stays useful

**UI**
- Green / amber / red dot with glow ring in the nav bar
- Unhealthy pulses fast; degraded pulses slowly — severity is visually distinct
- Tooltip on hover/focus shows: status label, message, per-service breakdown, "last checked X ago"
- Tooltip flips below the dot when near the top of the viewport
- Fully keyboard accessible — `<button>` with `aria-label`, `role="tooltip"`, `aria-describedby`


## Testing checklist

- [ ] 🟢 Green dot — `/health` returns 200, all checks `up`
- [ ] 🟡 Amber dot — one or more checks not `up`
- [ ] 🔴 Red dot — `/health` returns non-200
- [ ] 🔴 Red dot — `/health` unreachable
- [ ] Tooltip renders above dot; flips below near top of viewport
- [ ] Clicking dot triggers immediate refetch
- [ ] Keyboard focus shows tooltip
- [ ] No requests fire after component unmounts

## Challenges & notes
- **Backend always returns non-200** — the `/health` endpoint consistently returned a non-200 response during development, which meant the indicator was permanently red and the degraded/healthy states could never be visually verified.

- **Workaround: fetch interception** — to unblock UI development and verify all three states rendered correctly, I intercepted the fetch call and returned mock responses simulating healthy and degraded payloads. This allowed full visual testing of the green and amber states, the tooltip per-service breakdown, and the pulse animations before the backend is fixed.