### PR TITLE
feat: persistent network mismatch warning with switch instructions

### DIFF
--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -8,7 +8,7 @@ import TvlTicker from "./TvlTicker";
 import HealthStatusIndicator from "./HealthStatusIndicator";
 import { Layers } from "./icons";
 import { useTranslation } from "../i18n";
-import { networkConfig } from "../config/network";
+import { useWalletNetwork } from "../hooks/useWalletNetwork";
 
 interface NavbarProps {
   currentPath?: "/" | "/analytics" | "/portfolio";
@@ -26,9 +26,9 @@ const Navbar: FC<NavbarProps> = ({
   onDisconnect,
 }) => {
   const { t } = useTranslation();
-  const [networkLabel, setNetworkLabel] = useState(
-    networkConfig.isTestnet ? "Testnet" : "Mainnet",
-  );
+  const { walletNetwork, expectedNetwork } = useWalletNetwork(walletAddress);
+  // Show wallet's actual network when known, otherwise fall back to app's expected network
+  const networkLabel = walletNetwork ?? expectedNetwork;
   const [menuOpen, setMenuOpen] = useState(false);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -44,41 +44,6 @@ const Navbar: FC<NavbarProps> = ({
     document.addEventListener("mousedown", handler);
     return () => document.removeEventListener("mousedown", handler);
   }, [menuOpen]);
-
-  // Resolve network label
-  useEffect(() => {
-    let active = true;
-
-    const resolveNetworkLabel = async () => {
-      if (!walletAddress) return;
-      try {
-        const freighterApi = await import("@stellar/freighter-api");
-        if (typeof freighterApi.getNetworkDetails !== "function") return;
-
-        const details = await freighterApi.getNetworkDetails();
-        if (!active || !details) return;
-
-        const isMainnet = details.networkPassphrase
-          ?.toLowerCase()
-          .includes("public");
-
-        setNetworkLabel(isMainnet ? "Mainnet" : "Testnet");
-      } catch {
-        // fallback stays
-      }
-    };
-
-    void resolveNetworkLabel();
-
-    const interval = window.setInterval(() => {
-      void resolveNetworkLabel();
-    }, 10_000);
-
-    return () => {
-      active = false;
-      window.clearInterval(interval);
-    };
-  }, [walletAddress]);
 
   return (
     <nav

--- a/frontend/src/components/NetworkWarningBanner.tsx
+++ b/frontend/src/components/NetworkWarningBanner.tsx
@@ -1,124 +1,47 @@
-import React, { useState, useEffect } from "react";
-import { AlertTriangle, X } from "./icons";
-import { networkConfig } from "../config/network";
+import React from "react";
+import { AlertTriangle } from "./icons";
+import { useWalletNetwork } from "../hooks/useWalletNetwork";
 
 interface NetworkWarningBannerProps {
   walletAddress: string | null;
-  onDismiss?: () => void;
 }
 
-const NetworkWarningBanner: React.FC<NetworkWarningBannerProps> = ({
-  walletAddress,
-  onDismiss,
-}) => {
-  const [isVisible, setIsVisible] = useState(false);
-  const [isWrongNetwork, setIsWrongNetwork] = useState(false);
+const NetworkWarningBanner: React.FC<NetworkWarningBannerProps> = ({ walletAddress }) => {
+  const { isMismatch, walletNetwork, expectedNetwork } = useWalletNetwork(walletAddress);
 
-  useEffect(() => {
-    let showTimer: ReturnType<typeof setTimeout> | undefined;
-    let hideTimer: ReturnType<typeof setTimeout> | undefined;
-
-    if (!walletAddress) {
-      hideTimer = setTimeout(() => {
-        setIsVisible(false);
-      }, 0);
-
-      return () => {
-        if (hideTimer) clearTimeout(hideTimer);
-      };
-    }
-
-    // Check network when wallet connects
-    const checkNetwork = async () => {
-      try {
-        // In a real implementation, this would check the actual network via Freighter API
-        // For now, we'll simulate network detection
-        showTimer = setTimeout(() => {
-          // Mock: assume wrong network initially, then correct after 2 seconds
-          setIsWrongNetwork(true);
-          setIsVisible(true);
-
-          // Simulate network switch detection
-          hideTimer = setTimeout(() => {
-            setIsWrongNetwork(false);
-            setIsVisible(false);
-          }, 2000);
-        }, 0);
-      } catch (error) {
-        console.error("Network check failed:", error);
-      }
-    };
-
-    checkNetwork();
-
-    return () => {
-      if (showTimer) clearTimeout(showTimer);
-      if (hideTimer) clearTimeout(hideTimer);
-    };
-  }, [walletAddress]);
-
-  const handleDismiss = () => {
-    setIsVisible(false);
-    onDismiss?.();
-  };
-
-  if (!isVisible || !isWrongNetwork) {
-    return null;
-  }
-
-  const expectedNetwork = networkConfig.isTestnet ? "Testnet" : "Mainnet";
-  const currentNetwork = networkConfig.isTestnet ? "Mainnet" : "Testnet"; // Mock opposite
+  if (!isMismatch) return null;
 
   return (
     <div
-      className="network-warning-banner"
+      role="alert"
+      aria-live="assertive"
       style={{
         position: "fixed",
-        top: "80px",
-        left: "50%",
-        transform: "translateX(-50%)",
-        zIndex: 1000,
-        maxWidth: "600px",
-        width: "90%",
-        padding: "16px 20px",
-        background: "rgba(255, 69, 58, 0.95)",
-        border: "1px solid rgba(255, 69, 58, 0.8)",
-        borderRadius: "12px",
-        boxShadow: "0 8px 32px rgba(255, 69, 58, 0.3)",
-        backdropFilter: "blur(12px)",
-        color: "white",
+        top: "72px",
+        left: 0,
+        right: 0,
+        zIndex: 200,
+        background: "rgba(220, 38, 38, 0.95)",
+        borderBottom: "1px solid rgba(255, 100, 100, 0.5)",
+        backdropFilter: "blur(8px)",
+        color: "#fff",
+        padding: "10px 24px",
         display: "flex",
         alignItems: "center",
-        gap: "12px",
+        justifyContent: "center",
+        gap: "10px",
+        fontSize: "0.875rem",
+        lineHeight: "1.5",
       }}
     >
-      <AlertTriangle size={24} />
-      <div style={{ flex: 1 }}>
-        <div style={{ fontWeight: 600, fontSize: "1rem", marginBottom: "4px" }}>
-          Wrong Stellar Network
-        </div>
-        <div style={{ fontSize: "0.9rem", lineHeight: "1.4" }}>
-          You are connected to Stellar {currentNetwork}, but this vault requires {expectedNetwork}.
-          Please switch networks in your wallet to continue.
-        </div>
-      </div>
-      <button
-        onClick={handleDismiss}
-        style={{
-          background: "none",
-          border: "none",
-          color: "white",
-          cursor: "pointer",
-          padding: "4px",
-          opacity: 0.8,
-          transition: "opacity 0.2s",
-        }}
-        onMouseEnter={(e) => (e.currentTarget.style.opacity = "1")}
-        onMouseLeave={(e) => (e.currentTarget.style.opacity = "0.8")}
-        aria-label="Dismiss network warning"
-      >
-        <X size={20} />
-      </button>
+      <AlertTriangle size={18} style={{ flexShrink: 0 }} />
+      <span>
+        <strong>Wrong network:</strong> your wallet is on{" "}
+        <strong>{walletNetwork}</strong>, but this app requires{" "}
+        <strong>{expectedNetwork}</strong>.{" "}
+        Open Freighter → Settings → Network and switch to{" "}
+        <strong>{expectedNetwork}</strong> to continue.
+      </span>
     </div>
   );
 };

--- a/frontend/src/hooks/useWalletNetwork.ts
+++ b/frontend/src/hooks/useWalletNetwork.ts
@@ -1,0 +1,57 @@
+import { useEffect, useState } from "react";
+import { networkConfig } from "../config/network";
+
+const POLL_MS = 10_000;
+
+export interface WalletNetworkState {
+  /** Human-readable label of the wallet's current network, e.g. "Testnet" */
+  walletNetwork: string | null;
+  /** True when the wallet is connected to a different network than the app expects */
+  isMismatch: boolean;
+  /** Human-readable label of the network the app expects */
+  expectedNetwork: string;
+}
+
+/**
+ * Polls Freighter's getNetworkDetails and compares the wallet's network
+ * passphrase against the app's configured networkPassphrase.
+ */
+export function useWalletNetwork(walletAddress: string | null): WalletNetworkState {
+  const expectedNetwork = networkConfig.isTestnet ? "Testnet" : "Mainnet";
+  const [walletNetwork, setWalletNetwork] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!walletAddress) {
+      setWalletNetwork(null);
+      return;
+    }
+
+    let active = true;
+
+    const poll = async () => {
+      try {
+        const { getNetworkDetails } = await import("@stellar/freighter-api");
+        if (typeof getNetworkDetails !== "function") return;
+        const details = await getNetworkDetails();
+        if (!active || !details?.networkPassphrase) return;
+        const isMainnet = details.networkPassphrase.toLowerCase().includes("public");
+        setWalletNetwork(isMainnet ? "Mainnet" : "Testnet");
+      } catch {
+        // leave previous value; don't flash a false mismatch on transient errors
+      }
+    };
+
+    void poll();
+    const id = window.setInterval(() => void poll(), POLL_MS);
+
+    return () => {
+      active = false;
+      window.clearInterval(id);
+    };
+  }, [walletAddress]);
+
+  const isMismatch =
+    walletNetwork !== null && walletNetwork !== expectedNetwork;
+
+  return { walletNetwork, isMismatch, expectedNetwork };
+}


### PR DESCRIPTION
 Here's a PR description you can use:
  
  ───────────────────────────────────────────────────────────────────────────────────────────────
  
  feat: Persistent network mismatch warning with switch instructions
  
  Shows a persistent warning banner when the connected Freighter wallet is on a different Stellar
  network than the app expects (e.g. wallet on Mainnet, app targeting Testnet).
  
  Changes:
  
  - useWalletNetwork hook — polls getNetworkDetails() every 10s, compares the wallet's network
  passphrase against networkConfig, and exposes { walletNetwork, isMismatch, expectedNetwork }
  - NetworkWarningBanner — replaced the fake mock (which auto-dismissed after 2s) with real
  detection; banner is persistent (no dismiss) and shows explicit instructions: "Open Freighter →
  Settings → Network and switch to Testnet to continue"
  - Navbar — removed duplicate getNetworkDetails polling; now uses useWalletNetwork so the
  network badge and the warning banner share the same data source
  
  Testing:
  
  - Connect Freighter on the wrong network → banner appears immediately and stays until the
  network is switched
  - Connect on the correct network → no banner shown
  - Navbar network badge reflects the wallet's actual network in both cases
closes #542