### PR TITLE
Track protocol fee accrual and treasury claim with on-chain events

### DIFF
--- a/contracts/vault/src/event_tests.rs
+++ b/contracts/vault/src/event_tests.rs
@@ -107,3 +107,117 @@ fn test_distribute_yield_works() {
     vault.accrue_yield(&100);
     assert_eq!(vault.total_assets(), 100);
 }
+
+#[test]
+fn test_fee_accrual_event_emitted() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let usdc = create_token_contract(&env, &token_admin);
+    let usdc_admin = token::StellarAssetClient::new(&env, &usdc.address);
+    usdc_admin.mint(&admin, &1000);
+
+    let vault_id = env.register(YieldVault, ());
+    let vault = YieldVaultClient::new(&env, &vault_id);
+    vault.initialize(&admin, &usdc.address);
+
+    // 500 bps = 5% fee
+    vault.set_fee_bps(&500);
+    vault.accrue_yield(&1000);
+
+    // fee = 1000 * 500 / 10000 = 50; net yield = 950
+    assert_eq!(vault.treasury_balance(), 50);
+    assert_eq!(vault.total_assets(), 950);
+}
+
+#[test]
+fn test_fee_accrual_no_event_when_zero_fee() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let usdc = create_token_contract(&env, &token_admin);
+    let usdc_admin = token::StellarAssetClient::new(&env, &usdc.address);
+    usdc_admin.mint(&admin, &500);
+
+    let vault_id = env.register(YieldVault, ());
+    let vault = YieldVaultClient::new(&env, &vault_id);
+    vault.initialize(&admin, &usdc.address);
+
+    // fee_bps defaults to 0 — no fee should accrue
+    vault.accrue_yield(&500);
+    assert_eq!(vault.treasury_balance(), 0);
+    assert_eq!(vault.total_assets(), 500);
+}
+
+#[test]
+fn test_claim_fees_transfers_to_treasury() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let usdc = create_token_contract(&env, &token_admin);
+    let usdc_admin = token::StellarAssetClient::new(&env, &usdc.address);
+    usdc_admin.mint(&admin, &1000);
+
+    let vault_id = env.register(YieldVault, ());
+    let vault = YieldVaultClient::new(&env, &vault_id);
+    vault.initialize(&admin, &usdc.address);
+
+    vault.set_fee_bps(&1000); // 10%
+    vault.set_treasury(&treasury);
+    vault.accrue_yield(&1000); // fee = 100
+
+    assert_eq!(vault.treasury_balance(), 100);
+    vault.claim_fees();
+
+    // Balance zeroed after claim
+    assert_eq!(vault.treasury_balance(), 0);
+    // Treasury address received the tokens
+    assert_eq!(usdc.balance(&treasury), 100);
+}
+
+#[test]
+#[should_panic(expected = "no fees to claim")]
+fn test_claim_fees_panics_when_balance_zero() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let usdc = create_token_contract(&env, &token_admin);
+
+    let vault_id = env.register(YieldVault, ());
+    let vault = YieldVaultClient::new(&env, &vault_id);
+    vault.initialize(&admin, &usdc.address);
+    vault.set_treasury(&treasury);
+
+    vault.claim_fees(); // should panic
+}
+
+#[test]
+#[should_panic(expected = "treasury not set")]
+fn test_claim_fees_panics_when_no_treasury() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let usdc = create_token_contract(&env, &token_admin);
+    let usdc_admin = token::StellarAssetClient::new(&env, &usdc.address);
+    usdc_admin.mint(&admin, &1000);
+
+    let vault_id = env.register(YieldVault, ());
+    let vault = YieldVaultClient::new(&env, &vault_id);
+    vault.initialize(&admin, &usdc.address);
+    vault.set_fee_bps(&500);
+    vault.accrue_yield(&1000); // accrues 50 in treasury balance
+
+    vault.claim_fees(); // should panic — no treasury set
+}

--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -1040,10 +1040,12 @@ impl YieldVault {
                 .instance()
                 .get(&DataKey::TreasuryBalance)
                 .unwrap_or(0);
-            env.storage().instance().set(
-                &DataKey::TreasuryBalance,
-                &treasury_bal.checked_add(fee_amount).expect("overflow"),
-            );
+            let new_treasury_bal = treasury_bal.checked_add(fee_amount).expect("overflow");
+            env.storage()
+                .instance()
+                .set(&DataKey::TreasuryBalance, &new_treasury_bal);
+            env.events()
+                .publish((symbol_short!("feeacc"),), (fee_amount, new_treasury_bal));
         }
 
         let ta = env
@@ -1099,6 +1101,42 @@ impl YieldVault {
             .instance()
             .get(&DataKey::TreasuryBalance)
             .unwrap_or(0)
+    }
+
+    /// Transfers the entire accumulated treasury balance to the treasury address.
+    /// Only the Admin can call this. Emits a `feeclm` event.
+    ///
+    /// ### Errors
+    /// Panics if no treasury address is configured or the balance is zero.
+    pub fn claim_fees(env: Env) {
+        let admin: Address = get_admin(&env).expect("Admin not set");
+        admin.require_auth();
+
+        let treasury: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Treasury)
+            .expect("treasury not set");
+
+        let balance: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::TreasuryBalance)
+            .unwrap_or(0);
+        if balance == 0 {
+            panic!("no fees to claim");
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::TreasuryBalance, &0i128);
+
+        let token_addr: Address = env.storage().instance().get(&DataKey::TokenAsset).unwrap();
+        token::Client::new(&env, &token_addr)
+            .transfer(&env.current_contract_address(), &treasury, &balance);
+
+        env.events()
+            .publish((symbol_short!("feeclm"),), (treasury, balance));
     }
 
     // ── Goal 2: Large-withdrawal timelock ────────────────────────────────────


### PR DESCRIPTION
Track protocol fee accrual and treasury claim with explicit on-chain accounting
  
  What changed
  
  - accrue_yield now emits a feeacc event (fee_amount, cumulative_treasury_balance) each time a
  non-zero protocol fee is collected, giving indexers a precise on-chain audit trail.
  - New claim_fees function (admin-only) transfers the full TreasuryBalance to the configured
  treasury address and emits a feeclm event (treasury_address, amount). Panics if no treasury is
  set or the balance is zero.
  
  Tests added (event_tests.rs)
  
  - Fee splits correctly at 5% and 10% rates
  - Zero fee_bps leaves treasury balance untouched
  - claim_fees zeroes the on-chain balance and transfers tokens to treasury
  - Guard panics for empty balance and unconfigured treasury
closes #562