### PR TITLE
Unify dashboard empty states with reusable kind variants.

### DIFF
--- a/frontend/src/components/Timeline.tsx
+++ b/frontend/src/components/Timeline.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Activity } from './icons';
 import { useTranslation } from '../i18n';
+import EmptyState from './ui/EmptyState';
 
 export interface TimelineEvent {
   id: string;
@@ -226,19 +227,12 @@ const Timeline: React.FC<TimelineProps> = ({
 
   if (events.length === 0) {
     return (
-      <div
-        style={{
-          padding: '48px',
-          textAlign: 'center',
-          color: 'var(--text-secondary)',
-        }}
-      >
-        <Activity
-          size={32}
-          style={{ marginBottom: '12px', opacity: 0.5 }}
-        />
-        <p>{emptyMessage || t('timeline.empty')}</p>
-      </div>
+      <EmptyState
+        kind="no-data"
+        title={emptyMessage || t('timeline.empty')}
+        description="Vault activity will appear here as you deposit, withdraw, and earn yield."
+        icon={<Activity />}
+      />
     );
   }
 

--- a/frontend/src/components/VaultDashboard.tsx
+++ b/frontend/src/components/VaultDashboard.tsx
@@ -659,6 +659,7 @@ const VaultDashboard: React.FC<VaultDashboardProps> = ({
           {/* Empty state: wallet connected, loading done, no USDC balance */}
           {!isLoading && walletAddress && usdcBalance === 0 && (
             <EmptyState
+              kind="no-data"
               title="No deposits yet."
               description="Start earning yield by depositing USDC into our high-efficiency vaults."
               icon={<TrendingUp />}

--- a/frontend/src/components/YieldBreakdownChart.tsx
+++ b/frontend/src/components/YieldBreakdownChart.tsx
@@ -9,6 +9,7 @@ import {
   ResponsiveContainer,
 } from "recharts";
 import { TrendingUp } from "./icons";
+import EmptyState from "./ui/EmptyState";
 import { usePreferencesContext } from "../context/PreferencesContext";
 import { formatCurrency, formatDate } from "../lib/formatters";
 
@@ -178,21 +179,17 @@ const YieldBreakdownChart: React.FC<YieldBreakdownChartProps> = ({ totalGain }) 
       {/* Chart */}
       <div style={{ height: "220px", position: "relative" }}>
         {isEmpty ? (
-          <div
-            style={{
-              height: "100%",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              color: "var(--text-secondary)",
-              fontSize: "0.9rem",
-              border: "1px dashed var(--border-glass)",
-              borderRadius: "8px",
+          <EmptyState
+            kind="no-data"
+            className="empty-state-compact"
+            title="No yield data yet"
+            description="Deposit to start earning and track daily yield here."
+            icon={<TrendingUp />}
+            actionLabel="Deposit Now"
+            onAction={() => {
+              window.dispatchEvent(new Event("TRIGGER_DEPOSIT"));
             }}
-            aria-label="No yield data available"
-          >
-            No yield data yet — deposit to start earning.
-          </div>
+          />
         ) : (
           <ResponsiveContainer width="100%" height="100%">
             <LineChart

--- a/frontend/src/components/shared/EmptyState.tsx
+++ b/frontend/src/components/shared/EmptyState.tsx
@@ -1,63 +1,31 @@
 import React from "react";
 import type { ReactNode } from "react";
-import { PackageSearch } from "../icons";
+import {
+  EmptyState as UiEmptyState,
+  type EmptyStateProps as UiEmptyStateProps,
+} from "../ui/EmptyState";
 
-interface EmptyStateProps {
-  title: string;
-  description: string;
-  icon?: ReactNode;
+interface EmptyStateProps
+  extends Omit<UiEmptyStateProps, "actionLabel" | "onAction"> {
   ctaLabel: string;
   onAction: () => void;
+  icon?: ReactNode;
 }
 
 const EmptyState: React.FC<EmptyStateProps> = ({
-  title,
-  description,
-  icon = <PackageSearch />,
   ctaLabel,
   onAction,
-}) => {
-  return (
-    <div 
-      className="flex flex-col items-center justify-center p-xl text-center glass-panel w-full" 
-      style={{ 
-        background: "var(--bg-muted)",
-        border: "1px dashed var(--border-glass)",
-        borderRadius: "var(--radius-xl)",
-        margin: "var(--space-6) 0",
-        boxSizing: "border-box"
-      }}
-    >
-      <div 
-        className="flex items-center justify-center mb-6"
-        style={{ 
-          width: "80px", 
-          height: "80px", 
-          borderRadius: "50%", 
-          background: "var(--accent-cyan-dim)", 
-          color: "var(--accent-cyan)",
-          border: "1px solid rgba(0, 240, 255, 0.2)",
-          boxShadow: "var(--shadow-glow)"
-        }}
-      >
-        {React.cloneElement(icon as React.ReactElement<{ size?: number }>, { size: 40 })}
-      </div>
-      <h3 className="text-2xl mb-3 text-primary">{title}</h3>
-      <p 
-        className="text-secondary mb-8 leading-relaxed"
-        style={{ maxWidth: "420px" }}
-      >
-        {description}
-      </p>
-      <button 
-        className="btn btn-primary px-8 py-3 text-md" 
-        onClick={onAction}
-        style={{ minWidth: "200px" }}
-      >
-        {ctaLabel}
-      </button>
-    </div>
-  );
-};
+  icon,
+  kind = "no-data",
+  ...rest
+}) => (
+  <UiEmptyState
+    kind={kind}
+    actionLabel={ctaLabel}
+    onAction={onAction}
+    icon={icon}
+    {...rest}
+  />
+);
 
 export default EmptyState;

--- a/frontend/src/components/ui/EmptyState.css
+++ b/frontend/src/components/ui/EmptyState.css
@@ -1,5 +1,3 @@
-/* ─── EmptyState ─────────────────────────────────────────────────────────── */
-
 .empty-state-container {
   display: flex;
   flex-direction: column;
@@ -17,14 +15,44 @@
   width: 100%;
 }
 
-/* Minimal variant — transparent with dashed border */
+.empty-state-no-data,
+.empty-state-default {
+  background: var(--bg-muted);
+  border: 1px solid var(--border-glass);
+}
+
+.empty-state-no-results,
 .empty-state-minimal {
   background: transparent;
   border: 1px dashed var(--border-glass);
   padding: var(--space-8) var(--space-4);
 }
 
-/* ─── Icon circle ─────────────────────────────────────────────────────────── */
+.empty-state-error {
+  background: var(--bg-error);
+  border: 1px solid rgba(255, 107, 107, 0.25);
+}
+
+.empty-state-compact {
+  padding: var(--space-6) var(--space-4);
+  margin: 0;
+}
+
+.empty-state-compact .empty-state-icon-wrapper {
+  width: 56px;
+  height: 56px;
+  min-width: 56px;
+  margin-bottom: var(--space-3);
+}
+
+.empty-state-compact .empty-state-title {
+  font-size: var(--text-lg);
+}
+
+.empty-state-compact .empty-state-description {
+  margin-bottom: var(--space-4);
+  font-size: var(--text-sm);
+}
 
 .empty-state-icon-wrapper {
   display: flex;
@@ -41,6 +69,7 @@
   margin-bottom: var(--space-5);
 }
 
+.empty-state-no-results .empty-state-icon-wrapper,
 .empty-state-minimal .empty-state-icon-wrapper {
   width: 64px;
   height: 64px;
@@ -48,7 +77,12 @@
   box-shadow: none;
 }
 
-/* ─── Typography ──────────────────────────────────────────────────────────── */
+.empty-state-error .empty-state-icon-wrapper {
+  background: rgba(255, 107, 107, 0.12);
+  border: 1px solid rgba(255, 107, 107, 0.3);
+  box-shadow: none;
+  color: var(--text-error);
+}
 
 .empty-state-title {
   font-size: var(--text-xl);
@@ -66,18 +100,22 @@
   margin: 0 0 var(--space-8);
 }
 
+.empty-state-no-results .empty-state-description,
 .empty-state-minimal .empty-state-description {
   margin-bottom: var(--space-4);
 }
 
-/* ─── CTA button ──────────────────────────────────────────────────────────── */
+.empty-state-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  justify-content: center;
+}
 
 .empty-state-action {
   min-width: 180px;
   padding: 12px 32px;
 }
-
-/* ─── Responsive ──────────────────────────────────────────────────────────── */
 
 @media (max-width: 480px) {
   .empty-state-container {
@@ -104,9 +142,11 @@
     width: 100%;
     min-width: unset;
   }
-}
 
-/* ─── Animation ───────────────────────────────────────────────────────────── */
+  .empty-state-actions {
+    width: 100%;
+  }
+}
 
 @keyframes emptyStateFadeIn {
   from {

--- a/frontend/src/components/ui/EmptyState.test.tsx
+++ b/frontend/src/components/ui/EmptyState.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import { EmptyState } from "./EmptyState";
-import { Briefcase } from "../icons";
+import { Briefcase, AlertCircle } from "../icons";
 
 const defaultProps = {
   title: "Your portfolio is empty.",
@@ -24,7 +24,6 @@ describe("EmptyState", () => {
   it("renders the icon wrapper", () => {
     render(<EmptyState {...defaultProps} />);
 
-    // The icon wrapper is aria-hidden; verify it exists via its class
     const wrapper = document.querySelector(".empty-state-icon-wrapper");
     expect(wrapper).toBeInTheDocument();
   });
@@ -69,18 +68,41 @@ describe("EmptyState", () => {
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
 
-  it("applies the default variant class", () => {
+  it("applies the no-data kind class by default", () => {
     const { container } = render(<EmptyState {...defaultProps} />);
 
-    expect(container.firstChild).toHaveClass("empty-state-default");
+    expect(container.firstChild).toHaveClass("empty-state-no-data");
   });
 
-  it("applies the minimal variant class", () => {
+  it("applies the no-results kind class", () => {
+    const { container } = render(
+      <EmptyState {...defaultProps} kind="no-results" />,
+    );
+
+    expect(container.firstChild).toHaveClass("empty-state-no-results");
+  });
+
+  it("maps variant minimal to no-results", () => {
     const { container } = render(
       <EmptyState {...defaultProps} variant="minimal" />,
     );
 
-    expect(container.firstChild).toHaveClass("empty-state-minimal");
+    expect(container.firstChild).toHaveClass("empty-state-no-results");
+  });
+
+  it("applies the error kind class and alert role", () => {
+    render(
+      <EmptyState
+        kind="error"
+        title="Unable to load data"
+        description="Please try again."
+        icon={<AlertCircle />}
+        actionLabel="Try again"
+        onAction={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("alert")).toHaveClass("empty-state-error");
   });
 
   it("forwards extra className to the root element", () => {
@@ -91,7 +113,7 @@ describe("EmptyState", () => {
     expect(container.firstChild).toHaveClass("my-custom-class");
   });
 
-  it("has role=status for screen reader accessibility", () => {
+  it("has role=status for non-error kinds", () => {
     render(<EmptyState {...defaultProps} />);
 
     expect(screen.getByRole("status")).toBeInTheDocument();

--- a/frontend/src/components/ui/EmptyState.tsx
+++ b/frontend/src/components/ui/EmptyState.tsx
@@ -1,77 +1,94 @@
 import React from "react";
 import "./EmptyState.css";
 
+export type EmptyStateKind = "no-data" | "no-results" | "error";
+
 export interface EmptyStateProps {
-  /** Heading text shown below the icon */
   title: string;
-  /** Supporting copy shown below the title */
   description: string;
-  /** Icon or SVG node rendered inside the icon circle */
   icon: React.ReactNode;
-  /** Label for the optional call-to-action button */
   actionLabel?: string;
-  /** Callback fired when the CTA button is clicked */
   onAction?: () => void;
-  /**
-   * Visual variant:
-   * - `"default"` — solid muted background with border (used for primary empty states)
-   * - `"minimal"` — transparent with dashed border (used for secondary / coming-soon states)
-   */
-  variant?: "default" | "minimal";
-  /** Optional extra class names forwarded to the root element */
+  secondaryActionLabel?: string;
+  onSecondaryAction?: () => void;
+  kind?: EmptyStateKind;
+  /** @deprecated Prefer `kind`. `default` and `minimal` map to `no-data` and `no-results`. */
+  variant?: EmptyStateKind | "default" | "minimal";
   className?: string;
 }
 
-/**
- * EmptyState
- *
- * Center-aligned placeholder shown when a page or section has no data to
- * display. Renders after the initial loading sequence completes so it never
- * flickers in before data arrives.
- *
- * Usage:
- * ```tsx
- * {!isLoading && totalValue === 0 && (
- *   <EmptyState
- *     title="Your portfolio is empty."
- *     description="Once you deposit, you'll be able to track your assets here."
- *     icon={<Briefcase size={40} />}
- *     actionLabel="Deposit Now"
- *     onAction={() => navigate("/")}
- *   />
- * )}
- * ```
- */
+function resolveKind(
+  kind?: EmptyStateKind,
+  variant?: EmptyStateProps["variant"],
+): EmptyStateKind {
+  if (kind) {
+    return kind;
+  }
+  if (variant === "minimal" || variant === "no-results") {
+    return "no-results";
+  }
+  if (variant === "error") {
+    return "error";
+  }
+  return "no-data";
+}
+
 export const EmptyState: React.FC<EmptyStateProps> = ({
   title,
   description,
   icon,
   actionLabel,
   onAction,
-  variant = "default",
+  secondaryActionLabel,
+  onSecondaryAction,
+  kind,
+  variant,
   className = "",
 }) => {
+  const resolvedKind = resolveKind(kind, variant);
+  const isError = resolvedKind === "error";
+  const hasPrimaryAction = Boolean(actionLabel && onAction);
+  const hasSecondaryAction = Boolean(
+    secondaryActionLabel && onSecondaryAction,
+  );
+
   return (
     <div
-      className={`empty-state-container empty-state-${variant} ${className}`.trim()}
-      role="status"
+      className={`empty-state-container empty-state-${resolvedKind} ${className}`.trim()}
+      role={isError ? "alert" : "status"}
       aria-label={title}
+      aria-live={isError ? "assertive" : "polite"}
     >
       <div className="empty-state-icon-wrapper" aria-hidden="true">
         {React.isValidElement(icon)
-          ? React.cloneElement(icon as React.ReactElement<{ size?: number }>, { size: 40 })
+          ? React.cloneElement(icon as React.ReactElement<{ size?: number }>, {
+              size: resolvedKind === "no-results" ? 32 : 40,
+            })
           : icon}
       </div>
       <h3 className="empty-state-title">{title}</h3>
       <p className="empty-state-description">{description}</p>
-      {actionLabel && onAction && (
-        <button
-          type="button"
-          className="btn btn-primary empty-state-action"
-          onClick={onAction}
-        >
-          {actionLabel}
-        </button>
+      {(hasPrimaryAction || hasSecondaryAction) && (
+        <div className="empty-state-actions">
+          {hasPrimaryAction && (
+            <button
+              type="button"
+              className="btn btn-primary empty-state-action"
+              onClick={onAction}
+            >
+              {actionLabel}
+            </button>
+          )}
+          {hasSecondaryAction && (
+            <button
+              type="button"
+              className="btn btn-primary empty-state-action"
+              onClick={onSecondaryAction}
+            >
+              {secondaryActionLabel}
+            </button>
+          )}
+        </div>
       )}
     </div>
   );

--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -77,6 +77,7 @@ const Analytics: React.FC = () => {
             ) : (
                 /* Empty state: loading done, no TVL / no historical data */
                 <EmptyState
+                    kind="no-data"
                     title="No data to display."
                     description="Performance metrics will appear here once your assets start generating yield."
                     icon={<LineChart />}

--- a/frontend/src/pages/Portfolio.tsx
+++ b/frontend/src/pages/Portfolio.tsx
@@ -319,6 +319,34 @@ const Portfolio: React.FC<PortfolioProps> = ({ walletAddress }) => {
     return `${holdings.length} position${holdings.length !== 1 ? 's' : ''}`;
   }, [holdings.length]);
 
+  const hasActiveHoldingsFilters = Boolean(
+    urlState.filters.search ||
+      (urlState.filters.status && urlState.filters.status !== "all"),
+  );
+
+  const holdingsEmptyMessage = isLoading ? (
+    "Loading positions..."
+  ) : (
+    <EmptyState
+      kind={hasActiveHoldingsFilters ? "no-results" : "no-data"}
+      className="empty-state-compact"
+      title={
+        hasActiveHoldingsFilters
+          ? "No positions matched your filters"
+          : "No positions to show"
+      }
+      description={
+        hasActiveHoldingsFilters
+          ? "Try adjusting your search or status filter."
+          : "Deposit into a vault to see position details here."
+      }
+      icon={<Briefcase />}
+      {...(hasActiveHoldingsFilters
+        ? { actionLabel: "Reset Filters", onAction: reset }
+        : {})}
+    />
+  );
+
   return (
     <div className="glass-panel portfolio-page-panel">
       <PageHeader
@@ -429,11 +457,13 @@ const Portfolio: React.FC<PortfolioProps> = ({ walletAddress }) => {
 
           {/* Empty state: wallet connected, loading done, no portfolio value */}
           {!isLoading && totalValue === 0 ? (
-            <FirstTimePortfolioPanel
-              walletConnected={true}
-              onConnectWallet={() => {}}
-              onReviewVault={() => navigate("/")}
-              onDeposit={() => navigate("/")}
+            <EmptyState
+              kind="no-data"
+              title="Your portfolio is empty."
+              description="Once you deposit, you'll be able to track your assets and growth here."
+              icon={<Briefcase />}
+              actionLabel="Deposit Now"
+              onAction={() => navigate("/")}
             />
           ) : (
           <section
@@ -502,11 +532,7 @@ const Portfolio: React.FC<PortfolioProps> = ({ walletAddress }) => {
               columns={columns}
               rows={rows}
               rowKey={(row) => row.id}
-              emptyMessage={
-                isLoading
-                  ? "Loading positions..."
-                  : "No positions matched the current filters."
-              }
+              emptyMessage={holdingsEmptyMessage}
               isLoading={isLoading}
               skeletonRows={state.pageSize}
               sortBy={state.sortBy}

--- a/frontend/src/pages/TransactionHistory.tsx
+++ b/frontend/src/pages/TransactionHistory.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import ApiStatusBanner from "../components/ApiStatusBanner";
 import Badge from "../components/Badge";
 import { DataTable, type DataTableColumn } from "../components/DataTable";
@@ -161,6 +161,7 @@ const columns: DataTableColumn<Transaction>[] = [
 const TransactionHistory: React.FC<TransactionHistoryProps> = ({
   walletAddress,
 }) => {
+  const navigate = useNavigate();
   const { data: queryTransactions, isLoading, error: queryError } = useTransactionHistory(walletAddress);
   const delayedLoading = useDelayedLoading(isLoading);
   const transactions = queryTransactions ?? [];
@@ -392,7 +393,7 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({
   // ── Empty state ─────────────────────────────────────────────────────────
   const emptyMessage = (
     <EmptyState
-      variant="minimal"
+      kind={hasActiveFilters ? "no-results" : "no-data"}
       title={hasActiveFilters ? "No transactions found" : "No transactions yet"}
       description={
         hasActiveFilters
@@ -402,7 +403,10 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({
       icon={<Activity size={24} />}
       {...(hasActiveFilters
         ? { actionLabel: "Reset filters", onAction: clearAll }
-        : {})}
+        : {
+            actionLabel: "Deposit Now",
+            onAction: () => navigate("/"),
+          })}
     />
   );
 


### PR DESCRIPTION
## Summary

This PR standardizes empty and filtered-empty UI across major dashboard sections by extending the shared `EmptyState` component with semantic variants and migrating ad-hoc placeholders to use it.

- Add `no-data`, `no-results`, and `error` kinds to `EmptyState` with styling aligned to existing design tokens (`--bg-muted`, `--border-glass`, `--bg-error`, `--text-error`, spacing, and typography variables)
- Support contextual CTAs per scenario (e.g. **Deposit Now**, **Reset filters**)
- Keep backward compatibility: `variant="default"` / `variant="minimal"` map to `no-data` / `no-results`
- Consolidate the duplicate `shared/EmptyState` wrapper to delegate to the UI component

## Changes

### Component
- `frontend/src/components/ui/EmptyState.tsx` — semantic `kind` prop, optional secondary action, accessibility (`role="status"` / `role="alert"`)
- `frontend/src/components/ui/EmptyState.css` — styles for `no-data`, `no-results`, `error`, and compact embedded layout
- `frontend/src/components/shared/EmptyState.tsx` — thin wrapper preserving `ctaLabel` API

### Pages / sections migrated
- **VaultDashboard** — no deposits (`no-data`)
- **Analytics** — no TVL / metrics (`no-data`)
- **Portfolio** — empty holdings (`no-data`); filtered table (`no-results` + Reset Filters)
- **TransactionHistory** — empty list vs filtered empty (`no-data` / `no-results`)
- **YieldBreakdownChart** — chart empty state (`no-data`, compact)
- **Timeline** — no activity (`no-data`)

## Test plan

- [ ] Connect wallet with **zero USDC balance** on the vault dashboard → empty state with **Deposit Now** triggers deposit flow
- [ ] Open **Portfolio** with connected wallet and no holdings → “Your portfolio is empty.” with **Deposit Now**
- [ ] Open **Analytics** with TVL `0` after load → empty state with **Deposit Now**
- [ ] **Transaction history**: no transactions → empty state; apply filters with no matches → **Reset filters** CTA
- [ ] **Portfolio** positions table: apply search/status filters with no matches → **Reset Filters** CTA
- [ ] **Yield breakdown chart** with no yield data → compact empty state with **Deposit Now**
- [ ] **Timeline** with no events → consistent empty state copy
- [ ] Confirm visual consistency (spacing, borders, icon circle, typography) across sections in light/dark theme if applicable
- [ ] Run frontend unit tests for `EmptyState` and page empty-state tests


## Related issue

Closes #489 