### PR TITLE
feat(rpc): replace Soroban stub with real stellar-sdk contract invocation (#438)

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -35,5 +35,10 @@ module.exports = {
   moduleNameMapper: {
     '^@prisma/instrumentation$': '<rootDir>/src/__tests__/mocks/prismainstrumentation.js',
     '^@opentelemetry/(.*)$': '<rootDir>/src/__tests__/mocks/opentelemetry.js',
+    // Redirect the sorobanClient module that vaultEndpoints imports (./sorobanClient)
+    // so existing integration tests keep passing without a live Stellar RPC.
+    // The sorobanClient unit test imports ../sorobanClient (different specifier)
+    // and is therefore NOT redirected — it tests the real implementation.
+    '^\\.\/sorobanClient$': '<rootDir>/src/__tests__/mocks/sorobanClient.js',
   },
 };

--- a/backend/src/__tests__/mocks/sorobanClient.js
+++ b/backend/src/__tests__/mocks/sorobanClient.js
@@ -1,0 +1,21 @@
+/**
+ * Jest mock for src/sorobanClient.ts.
+ * Mapped via moduleNameMapper in jest.config.js so every test file that
+ * exercises vault endpoints gets a deterministic fake hash rather than
+ * attempting a real Stellar RPC call.
+ */
+
+class SorobanSimulationError extends Error {
+  constructor(message, code = 'SIMULATION_ERROR', statusCode = 502) {
+    super(message);
+    this.name = 'SorobanSimulationError';
+    this.code = code;
+    this.statusCode = statusCode;
+  }
+}
+
+const submitVaultOperation = jest.fn().mockResolvedValue('mock-soroban-tx-hash-abcd1234');
+
+const resolveContractId = jest.fn().mockReturnValue('MOCK_CONTRACT_ID');
+
+module.exports = { submitVaultOperation, SorobanSimulationError, resolveContractId };

--- a/backend/src/__tests__/sorobanClient.test.ts
+++ b/backend/src/__tests__/sorobanClient.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Unit tests for the real Soroban RPC client (Issue #438).
+ *
+ * Imports ../sorobanClient (not ./sorobanClient) so Jest's moduleNameMapper
+ * does NOT redirect this file to the mock — these tests exercise the real code.
+ * @stellar/stellar-sdk is mocked at the SDK level.
+ */
+
+// ─── Mock @stellar/stellar-sdk (via the shim-declared types) ─────────────────
+
+const mockSign = jest.fn();
+const mockBuild = jest.fn().mockReturnValue({ sign: mockSign });
+const mockAssembleTransaction = jest.fn().mockReturnValue({ build: mockBuild });
+
+const mockSendTransaction = jest.fn();
+const mockSimulateTransaction = jest.fn();
+const mockGetAccount = jest.fn();
+
+const MockServer = jest.fn().mockImplementation(() => ({
+  getAccount: mockGetAccount,
+  simulateTransaction: mockSimulateTransaction,
+  sendTransaction: mockSendTransaction,
+}));
+
+jest.mock('@stellar/stellar-sdk', () => ({
+  Keypair: {
+    fromSecret: jest.fn().mockReturnValue({
+      publicKey: () => 'GDUMMYSOURCE123456789012345678901234567890123456789012',
+      sign: jest.fn(),
+    }),
+  },
+  Contract: jest.fn().mockImplementation(() => ({
+    call: jest.fn().mockReturnValue('mock-op'),
+  })),
+  rpc: {
+    Server: MockServer,
+    assembleTransaction: mockAssembleTransaction,
+    Api: {
+      isSimulationError: jest.fn().mockReturnValue(false),
+      isSimulationRestore: jest.fn().mockReturnValue(false),
+    },
+  },
+  nativeToScVal: jest.fn().mockReturnValue('mock-scval'),
+  StrKey: {
+    isValidEd25519PublicKey: jest.fn().mockReturnValue(true),
+  },
+  TransactionBuilder: jest.fn().mockImplementation(() => ({
+    addOperation: jest.fn().mockReturnThis(),
+    setTimeout: jest.fn().mockReturnThis(),
+    build: jest.fn().mockReturnValue('mock-tx'),
+  })),
+  BASE_FEE: '100',
+}));
+
+// ─── Mock logger & tracing ────────────────────────────────────────────────────
+
+jest.mock('../middleware/structuredLogging', () => ({ logger: { log: jest.fn() } }));
+jest.mock('../tracing', () => ({ getCurrentTraceId: () => 'test-trace-id' }));
+
+// ─── Import SUT after mocks ───────────────────────────────────────────────────
+
+import { submitVaultOperation, SorobanSimulationError, resolveContractId } from '../sorobanClient';
+import { rpc } from '@stellar/stellar-sdk';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const VALID_WALLET = 'GABCDE1234567890ABCDE1234567890ABCDE1234567890ABCDE123456';
+const PENDING_RESPONSE = { status: 'PENDING', hash: 'real-tx-hash-abcdef1234567890' };
+
+function setEnv() {
+  process.env.STELLAR_SECRET_KEY = 'SCZANGBA5RLNIRHAASV3SUKWNZV3YJTVJBOTVOHFMKCHLJV2RDBUFXE';
+  process.env.VAULT_CONTRACT_ID = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4';
+  process.env.STELLAR_NETWORK_PASSPHRASE = 'Test SDF Network ; September 2015';
+  process.env.STELLAR_RPC_URL = 'https://soroban-testnet.stellar.org';
+}
+
+// ─── resolveContractId() ─────────────────────────────────────────────────────
+
+describe('resolveContractId()', () => {
+  afterEach(() => {
+    delete process.env.VAULT_CONTRACT_ID;
+  });
+
+  it('returns VAULT_CONTRACT_ID env var when set', () => {
+    process.env.VAULT_CONTRACT_ID = 'CONTRACT_FROM_ENV';
+    expect(resolveContractId()).toBe('CONTRACT_FROM_ENV');
+  });
+
+  it('throws when env var is missing and no deployments file has a vault id', () => {
+    // The testnet deployments file has an empty string for vault, so this throws.
+    expect(() => resolveContractId()).toThrow(/VAULT_CONTRACT_ID/);
+  });
+});
+
+// ─── submitVaultOperation() ───────────────────────────────────────────────────
+
+describe('submitVaultOperation()', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setEnv();
+    mockGetAccount.mockResolvedValue({ id: 'GDUMMY', sequence: '1' });
+    mockSimulateTransaction.mockResolvedValue({ results: [] });
+    mockSendTransaction.mockResolvedValue(PENDING_RESPONSE);
+    (rpc.Api.isSimulationError as jest.Mock).mockReturnValue(false);
+    (rpc.Api.isSimulationRestore as jest.Mock).mockReturnValue(false);
+    mockBuild.mockReturnValue({ sign: mockSign });
+  });
+
+  afterEach(() => {
+    delete process.env.STELLAR_SECRET_KEY;
+    delete process.env.VAULT_CONTRACT_ID;
+    delete process.env.STELLAR_NETWORK_PASSPHRASE;
+  });
+
+  // ── Success paths ───────────────────────────────────────────────────────────
+
+  it('returns the transaction hash on a successful deposit', async () => {
+    const hash = await submitVaultOperation('deposit', VALID_WALLET, '100', 'USDC');
+    expect(hash).toBe(PENDING_RESPONSE.hash);
+  });
+
+  it('returns the transaction hash on a successful withdrawal', async () => {
+    const hash = await submitVaultOperation('withdrawal', VALID_WALLET, '50', 'USDC');
+    expect(hash).toBe(PENDING_RESPONSE.hash);
+  });
+
+  it('signs the transaction before submitting', async () => {
+    await submitVaultOperation('deposit', VALID_WALLET, '100', 'USDC');
+    expect(mockSign).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls assembleTransaction to inject resource footprint', async () => {
+    await submitVaultOperation('deposit', VALID_WALLET, '100', 'USDC');
+    expect(mockAssembleTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes the operation type directly to contract.call()', async () => {
+    const { Contract } = await import('@stellar/stellar-sdk');
+    const contractInstance = (Contract as jest.Mock).mock.results[0]?.value;
+    await submitVaultOperation('withdrawal', VALID_WALLET, '200', 'USDC');
+    if (contractInstance) {
+      expect(contractInstance.call).toHaveBeenCalledWith(
+        'withdrawal',
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+      );
+    }
+  });
+
+  // ── Environment validation ──────────────────────────────────────────────────
+
+  it('throws SorobanSimulationError when STELLAR_SECRET_KEY is missing', async () => {
+    delete process.env.STELLAR_SECRET_KEY;
+    await expect(submitVaultOperation('deposit', VALID_WALLET, '100', 'USDC'))
+      .rejects.toBeInstanceOf(SorobanSimulationError);
+  });
+
+  it('throws SorobanSimulationError when VAULT_CONTRACT_ID is missing', async () => {
+    delete process.env.VAULT_CONTRACT_ID;
+    await expect(submitVaultOperation('deposit', VALID_WALLET, '100', 'USDC'))
+      .rejects.toBeInstanceOf(SorobanSimulationError);
+  });
+
+  // ── Input validation ────────────────────────────────────────────────────────
+
+  it('throws SorobanSimulationError with code INVALID_ADDRESS for a bad wallet', async () => {
+    (rpc.Api.isSimulationError as jest.Mock);
+    const { StrKey } = await import('@stellar/stellar-sdk');
+    (StrKey.isValidEd25519PublicKey as jest.Mock).mockReturnValueOnce(false);
+
+    const err = await submitVaultOperation('deposit', 'BAD_WALLET', '100', 'USDC')
+      .catch((e) => e);
+    expect(err).toBeInstanceOf(SorobanSimulationError);
+    expect(err.code).toBe('INVALID_ADDRESS');
+    expect(err.statusCode).toBe(422);
+  });
+
+  // ── Simulation errors ───────────────────────────────────────────────────────
+
+  it('throws SorobanSimulationError with code SIMULATION_ERROR when simulation fails', async () => {
+    (rpc.Api.isSimulationError as jest.Mock).mockReturnValueOnce(true);
+    mockSimulateTransaction.mockResolvedValue({ error: 'InsufficientFunds' });
+
+    const err = await submitVaultOperation('deposit', VALID_WALLET, '100', 'USDC').catch((e) => e);
+    expect(err).toBeInstanceOf(SorobanSimulationError);
+    expect(err.code).toBe('SIMULATION_ERROR');
+    expect(err.statusCode).toBe(502);
+  });
+
+  it('throws SorobanSimulationError with code RESTORE_REQUIRED when restore is needed', async () => {
+    (rpc.Api.isSimulationRestore as jest.Mock).mockReturnValueOnce(true);
+
+    const err = await submitVaultOperation('deposit', VALID_WALLET, '100', 'USDC').catch((e) => e);
+    expect(err).toBeInstanceOf(SorobanSimulationError);
+    expect(err.code).toBe('RESTORE_REQUIRED');
+    expect(err.statusCode).toBe(503);
+  });
+
+  // ── RPC-level errors ────────────────────────────────────────────────────────
+
+  it('throws SorobanSimulationError with code RPC_ERROR when sendTransaction returns ERROR', async () => {
+    mockSendTransaction.mockResolvedValue({ status: 'ERROR', errorResult: null });
+
+    const err = await submitVaultOperation('deposit', VALID_WALLET, '100', 'USDC').catch((e) => e);
+    expect(err).toBeInstanceOf(SorobanSimulationError);
+    expect(err.code).toBe('RPC_ERROR');
+    expect(err.statusCode).toBe(502);
+  });
+
+  it('throws SorobanSimulationError with code SUBMISSION_FAILED for unexpected tx status', async () => {
+    mockSendTransaction.mockResolvedValue({ status: 'DUPLICATE', errorResult: null });
+
+    const err = await submitVaultOperation('deposit', VALID_WALLET, '100', 'USDC').catch((e) => e);
+    expect(err).toBeInstanceOf(SorobanSimulationError);
+    expect(err.code).toBe('SUBMISSION_FAILED');
+  });
+
+  it('wraps unexpected network errors as INTERNAL_ERROR', async () => {
+    mockGetAccount.mockRejectedValue(new Error('connection refused'));
+
+    const err = await submitVaultOperation('deposit', VALID_WALLET, '100', 'USDC').catch((e) => e);
+    expect(err).toBeInstanceOf(SorobanSimulationError);
+    expect(err.code).toBe('INTERNAL_ERROR');
+    expect(err.message).toContain('connection refused');
+  });
+
+  it('uses testnet passphrase when STELLAR_NETWORK_PASSPHRASE is not set', async () => {
+    delete process.env.STELLAR_NETWORK_PASSPHRASE;
+    const { TransactionBuilder } = await import('@stellar/stellar-sdk');
+    await submitVaultOperation('deposit', VALID_WALLET, '100', 'USDC');
+    const builderCall = (TransactionBuilder as jest.Mock).mock.calls.at(-1);
+    expect(builderCall?.[1]?.networkPassphrase).toBe('Test SDF Network ; September 2015');
+  });
+});
+
+// ─── SorobanSimulationError ───────────────────────────────────────────────────
+
+describe('SorobanSimulationError', () => {
+  it('defaults to statusCode 502 and code SIMULATION_ERROR', () => {
+    const err = new SorobanSimulationError('test');
+    expect(err.statusCode).toBe(502);
+    expect(err.code).toBe('SIMULATION_ERROR');
+    expect(err.name).toBe('SorobanSimulationError');
+  });
+
+  it('accepts custom code and statusCode', () => {
+    const err = new SorobanSimulationError('bad input', 'INVALID_ADDRESS', 422);
+    expect(err.code).toBe('INVALID_ADDRESS');
+    expect(err.statusCode).toBe(422);
+  });
+
+  it('is an instance of Error', () => {
+    expect(new SorobanSimulationError('x')).toBeInstanceOf(Error);
+  });
+});

--- a/backend/src/sorobanClient.ts
+++ b/backend/src/sorobanClient.ts
@@ -3,10 +3,12 @@
  * Uses @stellar/stellar-sdk for contract invocation.
  */
 
+import fs from 'fs';
+import path from 'path';
 import {
   Keypair,
   Contract,
-  SorobanRpc as StellarRpc,
+  rpc,
   nativeToScVal,
   StrKey,
   TransactionBuilder,
@@ -15,39 +17,72 @@ import {
 import { logger } from './middleware/structuredLogging';
 import { getCurrentTraceId } from './tracing';
 
-// Initialize Soroban RPC client
-const getRpcClient = () => {
-  const rpcUrl = process.env.STELLAR_RPC_URL || 'https://soroban-testnet.stellar.org';
-  return new StellarRpc.Server(rpcUrl);
+// Well-known Stellar network passphrases (avoids importing Networks which is
+// not consistently re-exported across stellar-sdk minor versions).
+const NETWORK_PASSPHRASES: Record<string, string> = {
+  testnet: 'Test SDF Network ; September 2015',
+  mainnet: 'Public Global Stellar Network ; September 2015',
+  public: 'Public Global Stellar Network ; September 2015',
 };
 
-// Validate that required environment variables are set
+// ─── Config helpers ───────────────────────────────────────────────────────────
+
+const getRpcClient = () => {
+  const rpcUrl = process.env.STELLAR_RPC_URL || 'https://soroban-testnet.stellar.org';
+  return new rpc.Server(rpcUrl);
+};
+
+/**
+ * Returns the vault contract ID.
+ * Checks VAULT_CONTRACT_ID env var first, then falls back to the
+ * deployments/contracts.<network>.json file so the value is never hard-coded.
+ */
+export function resolveContractId(): string {
+  if (process.env.VAULT_CONTRACT_ID) return process.env.VAULT_CONTRACT_ID;
+
+  const network = process.env.STELLAR_NETWORK || 'testnet';
+  const deploymentFile = path.resolve(
+    __dirname,
+    `../../deployments/contracts.${network}.json`,
+  );
+  try {
+    const deployment = JSON.parse(fs.readFileSync(deploymentFile, 'utf-8'));
+    const id: string | undefined = deployment?.contracts?.vault;
+    if (id) return id;
+  } catch {
+    // deployments file missing or unreadable — fall through to error
+  }
+
+  throw new Error(
+    'VAULT_CONTRACT_ID is not set and no vault address found in the deployments file',
+  );
+}
+
+function resolveNetworkPassphrase(): string {
+  if (process.env.STELLAR_NETWORK_PASSPHRASE) return process.env.STELLAR_NETWORK_PASSPHRASE;
+  const network = process.env.STELLAR_NETWORK || 'testnet';
+  return NETWORK_PASSPHRASES[network] ?? NETWORK_PASSPHRASES.testnet;
+}
+
 function validateEnvironment(): void {
   if (!process.env.STELLAR_SECRET_KEY) {
     throw new Error('STELLAR_SECRET_KEY environment variable is not set');
   }
-  if (!process.env.VAULT_CONTRACT_ID) {
-    throw new Error('VAULT_CONTRACT_ID environment variable is not set');
-  }
-  if (!process.env.STELLAR_NETWORK_PASSPHRASE) {
-    throw new Error('STELLAR_NETWORK_PASSPHRASE environment variable is not set');
+  // Validate contract ID is resolvable early so the error message is clear.
+  resolveContractId();
+}
+
+function getSourceKeypair(): Keypair {
+  try {
+    return Keypair.fromSecret(process.env.STELLAR_SECRET_KEY!);
+  } catch (err) {
+    throw new Error(
+      `Invalid STELLAR_SECRET_KEY: ${err instanceof Error ? err.message : String(err)}`,
+    );
   }
 }
 
-// Get or validate keypair
-let cachedKeypair: Keypair | null = null;
-function getSourceKeypair(): Keypair {
-  if (!cachedKeypair) {
-    try {
-      cachedKeypair = Keypair.fromSecret(process.env.STELLAR_SECRET_KEY!);
-    } catch (err) {
-      throw new Error(
-        `Invalid STELLAR_SECRET_KEY: ${err instanceof Error ? err.message : String(err)}`
-      );
-    }
-  }
-  return cachedKeypair;
-}
+// ─── Error types ─────────────────────────────────────────────────────────────
 
 export interface SorobanTxError extends Error {
   code?: string;
@@ -55,26 +90,28 @@ export interface SorobanTxError extends Error {
 }
 
 export class SorobanSimulationError extends Error implements SorobanTxError {
-  public code: string;
-  public statusCode: number = 502;
+  public readonly code: string;
+  public readonly statusCode: number;
 
-  constructor(message: string, code: string = 'SIMULATION_ERROR') {
+  constructor(message: string, code: string = 'SIMULATION_ERROR', statusCode: number = 502) {
     super(message);
     this.name = 'SorobanSimulationError';
     this.code = code;
+    this.statusCode = statusCode;
   }
 }
 
+// ─── Core RPC call ────────────────────────────────────────────────────────────
+
 /**
- * Submit a Soroban contract invocation to the Stellar network.
- * Supports 'deposit' and 'withdrawal' operations on the vault contract.
+ * Submit a Soroban vault contract invocation (deposit or withdrawal) to the
+ * Stellar network. Steps:
+ *  1. Build the transaction with the correct contract arguments.
+ *  2. Simulate to validate inputs and obtain the resource footprint.
+ *  3. Assemble (inject footprint + auth entries), sign, and submit.
+ *  4. Return the on-chain transaction hash once the tx is PENDING.
  *
- * @param operationType - 'deposit' or 'withdrawal'
- * @param walletAddress - The Stellar wallet address making the operation
- * @param amount - The amount to deposit/withdraw
- * @param asset - The asset code (e.g., 'USDC')
- * @returns The transaction hash of the submitted transaction
- * @throws SorobanSimulationError if simulation or submission fails
+ * @throws SorobanSimulationError for any Stellar/RPC-level failure.
  */
 export async function submitVaultOperation(
   operationType: 'deposit' | 'withdrawal',
@@ -87,12 +124,15 @@ export async function submitVaultOperation(
 
     const rpcClient = getRpcClient();
     const sourceKeypair = getSourceKeypair();
-    const contractId = process.env.VAULT_CONTRACT_ID!;
-    const networkPassphrase = process.env.STELLAR_NETWORK_PASSPHRASE!;
+    const contractId = resolveContractId();
+    const networkPassphrase = resolveNetworkPassphrase();
 
-    // Validate Stellar address format
     if (!StrKey.isValidEd25519PublicKey(walletAddress)) {
-      throw new Error(`Invalid Stellar wallet address: ${walletAddress}`);
+      throw new SorobanSimulationError(
+        `Invalid Stellar wallet address: ${walletAddress}`,
+        'INVALID_ADDRESS',
+        422,
+      );
     }
 
     logger.log('debug', `Submitting Soroban ${operationType}`, {
@@ -103,53 +143,45 @@ export async function submitVaultOperation(
       traceId: getCurrentTraceId(),
     });
 
-    // Get account details for building the transaction
     const sourceAccount = await rpcClient.getAccount(sourceKeypair.publicKey());
-
-    // Create contract instance
     const contract = new Contract(contractId);
 
-    // Build contract invocation based on operation type
-    let method: string;
-    if (operationType === 'deposit') {
-      method = 'deposit';
-    } else if (operationType === 'withdrawal') {
-      method = 'withdrawal';
-    } else {
-      throw new Error(`Unsupported operation type: ${operationType}`);
+    // Convert the amount string to BigInt so nativeToScVal produces a valid i128.
+    let amountBigInt: bigint;
+    try {
+      amountBigInt = BigInt(Math.round(Number(amount)));
+    } catch {
+      throw new SorobanSimulationError(
+        `Invalid amount value: ${amount}`,
+        'INVALID_AMOUNT',
+        422,
+      );
     }
 
-    // Build the contract invocation operation
-    const toScVal = nativeToScVal as (...args: unknown[]) => unknown;
-
     const op = contract.call(
-      method,
-      toScVal(walletAddress, { type: 'address' }),
-      toScVal(amount, { type: 'i128' }),
-      toScVal(asset, { type: 'string' }),
+      operationType,
+      nativeToScVal(walletAddress, { type: 'address' }),
+      nativeToScVal(amountBigInt, { type: 'i128' }),
+      nativeToScVal(asset, { type: 'string' }),
     );
 
-    // Create transaction
     const tx = new TransactionBuilder(sourceAccount, {
       fee: BASE_FEE,
       networkPassphrase,
     })
       .addOperation(op)
-      .setTimeout(300) // 5 minute timeout
+      .setTimeout(300)
       .build();
 
-    // Simulate the transaction to validate it and get resource requirements
     logger.log('debug', `Simulating Soroban transaction for ${operationType}`, {
       traceId: getCurrentTraceId(),
     });
 
     const simulated = await rpcClient.simulateTransaction(tx);
 
-    const rpcApi = (StellarRpc as any).Api ?? (StellarRpc as any);
-
-    if (typeof rpcApi.isSimulationError === 'function' && rpcApi.isSimulationError(simulated)) {
-      const errorMessage = `Soroban simulation error: ${
-        'error' in simulated ? String(simulated.error) : 'Unknown error'
+    if (rpc.Api.isSimulationError(simulated)) {
+      const errorMessage = `Soroban simulation failed: ${
+        'error' in simulated ? String(simulated.error) : 'unknown simulation error'
       }`;
       logger.log('error', errorMessage, {
         operationType,
@@ -159,31 +191,33 @@ export async function submitVaultOperation(
       throw new SorobanSimulationError(errorMessage, 'SIMULATION_ERROR');
     }
 
-    if (typeof rpcApi.isSimulationRestore === 'function' && rpcApi.isSimulationRestore(simulated)) {
-      logger.log('warn', 'Soroban transaction requires restore', {
+    if (rpc.Api.isSimulationRestore(simulated)) {
+      logger.log('warn', 'Soroban transaction requires ledger entry restore', {
         operationType,
         walletAddress,
         traceId: getCurrentTraceId(),
       });
       throw new SorobanSimulationError(
-        'Contract state requires restore. Please try again later.',
-        'RESTORE_REQUIRED'
+        'Contract state requires ledger restore. Please retry in a few minutes.',
+        'RESTORE_REQUIRED',
+        503,
       );
     }
 
-    // Assemble and submit the transaction
-    const prepared = StellarRpc.assembleTransaction(tx, simulated).build();
+    // assembleTransaction injects the resource footprint and auth entries.
+    // .build() gives a Transaction; it must be signed before submission.
+    const assembled = rpc.assembleTransaction(tx, simulated).build();
+    assembled.sign(sourceKeypair);
 
-    logger.log('debug', `Submitting Soroban transaction for ${operationType}`, {
+    logger.log('debug', `Submitting assembled Soroban transaction for ${operationType}`, {
       traceId: getCurrentTraceId(),
     });
 
-    const txResponse = await rpcClient.sendTransaction(prepared);
+    const txResponse = await rpcClient.sendTransaction(assembled);
 
     if (txResponse.status === 'ERROR') {
-      const errorMessage = `Soroban RPC error: ${
-        txResponse.errorResult?.toXDR?.('base64') || 'Unknown error'
-      }`;
+      const detail = txResponse.errorResult?.toXDR?.('base64') ?? 'unknown error';
+      const errorMessage = `Soroban RPC rejected transaction: ${detail}`;
       logger.log('error', errorMessage, {
         operationType,
         walletAddress,
@@ -193,9 +227,8 @@ export async function submitVaultOperation(
     }
 
     if (txResponse.status !== 'PENDING') {
-      const errorMessage = `Soroban transaction submission failed: ${
-        txResponse.errorResult?.toXDR?.('base64') || 'Unknown error'
-      }`;
+      const detail = txResponse.errorResult?.toXDR?.('base64') ?? txResponse.status;
+      const errorMessage = `Unexpected transaction status: ${detail}`;
       logger.log('error', errorMessage, {
         operationType,
         walletAddress,
@@ -204,19 +237,15 @@ export async function submitVaultOperation(
       throw new SorobanSimulationError(errorMessage, 'SUBMISSION_FAILED');
     }
 
-    // Transaction successfully submitted; return the hash
-    const transactionHash = txResponse.hash;
-    logger.log('info', `Soroban ${operationType} submitted successfully`, {
-      transactionHash,
+    logger.log('info', `Soroban ${operationType} submitted`, {
+      transactionHash: txResponse.hash,
       walletAddress,
       traceId: getCurrentTraceId(),
     });
 
-    return transactionHash;
+    return txResponse.hash;
   } catch (err) {
-    if (err instanceof SorobanSimulationError) {
-      throw err;
-    }
+    if (err instanceof SorobanSimulationError) throw err;
 
     const message = err instanceof Error ? err.message : String(err);
     logger.log('error', `Unexpected error in submitVaultOperation: ${message}`, {
@@ -224,10 +253,6 @@ export async function submitVaultOperation(
       walletAddress,
       traceId: getCurrentTraceId(),
     });
-
-    throw new SorobanSimulationError(
-      `Unexpected error: ${message}`,
-      'INTERNAL_ERROR'
-    );
+    throw new SorobanSimulationError(`Unexpected error: ${message}`, 'INTERNAL_ERROR');
   }
 }

--- a/backend/src/stellar-sdk-shim.d.ts
+++ b/backend/src/stellar-sdk-shim.d.ts
@@ -4,6 +4,7 @@ declare module '@stellar/stellar-sdk' {
   export class Keypair {
     static fromSecret(secret: string): Keypair;
     publicKey(): string;
+    sign(data: Buffer): Buffer;
   }
 
   export class Contract {
@@ -11,16 +12,24 @@ declare module '@stellar/stellar-sdk' {
     call(method: string, ...args: unknown[]): unknown;
   }
 
-  export namespace SorobanRpc {
-    function isSimulationError(input: unknown): boolean;
-    function isSimulationRestore(input: unknown): boolean;
-    function assembleTransaction(tx: unknown, sim: unknown): { build(): unknown };
+  /**
+   * The `rpc` namespace reflects the actual runtime structure of
+   * `@stellar/stellar-sdk` v13 (exported as `sdk.rpc.*`).
+   * Previously declared as `SorobanRpc` — corrected as part of issue #438.
+   */
+  export namespace rpc {
+    namespace Api {
+      function isSimulationError(input: unknown): boolean;
+      function isSimulationRestore(input: unknown): boolean;
+    }
+
+    function assembleTransaction(tx: unknown, sim: unknown): { build(): { sign(kp: Keypair): void } };
 
     class Server {
       constructor(url: string);
       getAccount(accountId: string): Promise<any>;
       simulateTransaction(tx: unknown): Promise<any>;
-      sendTransaction(tx: unknown): Promise<any>;
+      sendTransaction(tx: unknown): Promise<{ status: string; hash: string; errorResult?: any }>;
       getTransaction(hash: string): Promise<any>;
     }
   }

--- a/backend/src/vaultEndpoints.ts
+++ b/backend/src/vaultEndpoints.ts
@@ -7,6 +7,7 @@ import { writesLimiter } from './rateLimiter';
 import { idempotencyStore, IdempotencyConflictError } from './idempotency';
 import { sorobanCircuitBreaker, CircuitOpenError } from './circuitBreaker';
 import { withSpan, getCurrentTraceId } from './tracing';
+import { submitVaultOperation, SorobanSimulationError } from './sorobanClient';
 import { requireFlag } from './featureFlags';
 import { referralService } from './referralService';
 import { getPrismaClient } from './prismaClient';
@@ -15,6 +16,7 @@ import { validate, VaultOperationSchema } from './middleware/validate';
 import { withdrawalDailyLimitMiddleware } from './middleware/withdrawalDailyLimit';
 import { requireSignedWalletAction } from './middleware/walletSignedAction';
 import crypto from 'crypto';
+// crypto is still used below for generateFingerprint and body.id generation.
 import { tryAcquireWalletLock } from './walletLock';
 import { normalizeWalletAddress } from './walletUtils';
 
@@ -30,16 +32,20 @@ function generateFingerprint(body: any): string {
 }
 
 /**
- * Simulates a Soroban RPC call wrapped in the circuit breaker and a trace span.
- * Replace the body with the real stellar-sdk / soroban-client call.
+ * Submit a vault operation to the Stellar network via the real Soroban RPC,
+ * wrapped in the circuit breaker (opens after repeated RPC failures) and an
+ * OTel trace span.
  */
 async function submitSorobanTx(type: string, payload: Record<string, unknown>): Promise<string> {
   return sorobanCircuitBreaker.execute(() =>
     withSpan('soroban.rpc.submit', async (span) => {
       span.setAttributes({ 'rpc.type': type, 'rpc.wallet': String(payload.walletAddress ?? '') });
-      // Simulate network call – replace with real Soroban RPC invocation
-      await new Promise((resolve) => setTimeout(resolve, 10));
-      return `0x${crypto.randomBytes(4).toString('hex')}${crypto.randomBytes(4).toString('hex')}`;
+      return submitVaultOperation(
+        type as 'deposit' | 'withdrawal',
+        String(payload.walletAddress),
+        String(payload.amount),
+        String(payload.asset),
+      );
     }),
   );
 }
@@ -219,6 +225,15 @@ async function handleVaultOperation(
         status: 503,
         message: 'Soroban RPC is temporarily unavailable. Please retry later.',
         retryAfterMs: err.retryAfterMs,
+      });
+    }
+
+    if (err instanceof SorobanSimulationError) {
+      return res.status(err.statusCode).json({
+        error: err.statusCode === 422 ? 'Unprocessable Entity' : 'Bad Gateway',
+        status: err.statusCode,
+        code: err.code,
+        message: err.message,
       });
     }
 


### PR DESCRIPTION
closes #438 

## Summary

- Replaces the `submitSorobanTx` sleep+fake-hash stub in `vaultEndpoints.ts` with a real Stellar network call via `submitVaultOperation` from `sorobanClient.ts`
- Fixes two pre-existing bugs in `sorobanClient.ts`: missing `transaction.sign()` before submission, and `String` instead of `BigInt` for the i128 amount argument
- Corrects `stellar-sdk-shim.d.ts` to declare the actual `rpc` namespace (`sdk.rpc.*`) instead of the non-existent `SorobanRpc` namespace
- Adds `resolveContractId()` which reads from `VAULT_CONTRACT_ID` env var first, then falls back to `deployments/contracts.<network>.json` — secret keys are never hard-coded
- `SorobanSimulationError` is surfaced as structured 502/422/503 responses in the vault handler
- Circuit breaker and OTel trace span remain wrapping every RPC call
- Adds a Jest mock + `moduleNameMapper` entry so all existing integration tests pass without a live Stellar RPC

## Test plan

- [ ] 19 new unit tests in `sorobanClient.test.ts` — all passing (`npx jest --testPathPattern="sorobanClient"`)
- [ ] Existing deposit/idempotency/governance tests continue to return 201 via the mock (`npx jest --testPathPattern="governance"`)
- [ ] Set `STELLAR_SECRET_KEY`, `VAULT_CONTRACT_ID`, and `STELLAR_RPC_URL` in `.env` and send a deposit to verify a real transaction hash is returned from testnet
- [ ] Trigger repeated RPC failures to confirm the circuit breaker opens and returns 503 with `Retry-After`
- [ ] Send a deposit with an invalid wallet address and confirm a 422 response with `code: INVALID_ADDRESS`