### PR TITLE
feat: add reusable empty state components

### DIFF
--- a/frontend/src/components/ApiStatusBanner.tsx
+++ b/frontend/src/components/ApiStatusBanner.tsx
@@ -1,6 +1,7 @@
 import type { ApiError, ValidationError } from "../lib/api";
 import type { FC } from "react";
 import { useTranslation } from "../i18n";
+import EmptyState from "./ui/EmptyState";
 
 interface ApiStatusBannerProps {
   error: ApiError | ValidationError;
@@ -8,27 +9,18 @@ interface ApiStatusBannerProps {
 
 const ApiStatusBanner: FC<ApiStatusBannerProps> = ({ error }) => {
   const { t } = useTranslation();
+  const description =
+    error.userMessage === "Failed to load vault data"
+      ? error.userMessage
+      : `Failed to load vault data. ${error.userMessage}`;
+
   return (
-    <div
-      role="alert"
-      className="glass-panel"
-      style={{
-        padding: "16px 18px",
-        marginBottom: "20px",
-        background: "rgba(255, 107, 107, 0.12)",
-        border: "1px solid rgba(255, 107, 107, 0.25)",
-      }}
-    >
-      <div style={{ fontWeight: 600, marginBottom: "4px" }}>
-        {t("apiBanner.title")}
-      </div>
-      <div style={{ color: "var(--text-secondary)", fontSize: "0.9rem", marginBottom: "4px" }}>
-        Failed to load vault data
-      </div>
-      <div style={{ color: "var(--text-secondary)", fontSize: "0.9rem" }}>
-        {error.userMessage}
-      </div>
-    </div>
+    <EmptyState
+      kind="error"
+      title={t("apiBanner.title")}
+      description={description}
+      className="empty-state-compact api-status-banner"
+    />
   );
 };
 

--- a/frontend/src/components/ui/EmptyState.css
+++ b/frontend/src/components/ui/EmptyState.css
@@ -22,6 +22,7 @@
 }
 
 .empty-state-no-results,
+.empty-state-search,
 .empty-state-minimal {
   background: transparent;
   border: 1px dashed var(--border-glass);
@@ -30,7 +31,12 @@
 
 .empty-state-error {
   background: var(--bg-error);
-  border: 1px solid rgba(255, 107, 107, 0.25);
+  border: 1px solid var(--border-error);
+}
+
+.empty-state-permission {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-glass);
 }
 
 .empty-state-compact {
@@ -54,6 +60,10 @@
   font-size: var(--text-sm);
 }
 
+.api-status-banner {
+  margin-bottom: var(--space-5);
+}
+
 .empty-state-icon-wrapper {
   display: flex;
   align-items: center;
@@ -70,6 +80,7 @@
 }
 
 .empty-state-no-results .empty-state-icon-wrapper,
+.empty-state-search .empty-state-icon-wrapper,
 .empty-state-minimal .empty-state-icon-wrapper {
   width: 64px;
   height: 64px;
@@ -79,9 +90,15 @@
 
 .empty-state-error .empty-state-icon-wrapper {
   background: rgba(255, 107, 107, 0.12);
-  border: 1px solid rgba(255, 107, 107, 0.3);
+  border: 1px solid var(--border-error);
   box-shadow: none;
   color: var(--text-error);
+}
+
+.empty-state-permission .empty-state-icon-wrapper {
+  background: var(--accent-cyan-dim);
+  border: 1px solid rgba(0, 240, 255, 0.25);
+  box-shadow: none;
 }
 
 .empty-state-title {
@@ -101,6 +118,7 @@
 }
 
 .empty-state-no-results .empty-state-description,
+.empty-state-search .empty-state-description,
 .empty-state-minimal .empty-state-description {
   margin-bottom: var(--space-4);
 }

--- a/frontend/src/components/ui/EmptyState.test.tsx
+++ b/frontend/src/components/ui/EmptyState.test.tsx
@@ -10,6 +10,13 @@ const defaultProps = {
 };
 
 describe("EmptyState", () => {
+  it("renders the default no-data variant without custom copy", () => {
+    render(<EmptyState />);
+
+    expect(screen.getByRole("status", { name: "No data available" })).toBeInTheDocument();
+    expect(screen.getByText("There is nothing to show here yet.")).toBeInTheDocument();
+  });
+
   it("renders title and description", () => {
     render(<EmptyState {...defaultProps} />);
 
@@ -82,6 +89,14 @@ describe("EmptyState", () => {
     expect(container.firstChild).toHaveClass("empty-state-no-results");
   });
 
+  it("applies the search kind class and default copy", () => {
+    const { container } = render(<EmptyState kind="search" />);
+
+    expect(container.firstChild).toHaveClass("empty-state-search");
+    expect(screen.getByText("No results found")).toBeInTheDocument();
+    expect(screen.getByText("Try adjusting your search or filters.")).toBeInTheDocument();
+  });
+
   it("maps variant minimal to no-results", () => {
     const { container } = render(
       <EmptyState {...defaultProps} variant="minimal" />,
@@ -103,6 +118,53 @@ describe("EmptyState", () => {
     );
 
     expect(screen.getByRole("alert")).toHaveClass("empty-state-error");
+  });
+
+  it("renders the default error variant with alert role", () => {
+    render(<EmptyState kind="error" />);
+
+    expect(screen.getByRole("alert", { name: "Something went wrong" })).toBeInTheDocument();
+    expect(
+      screen.getByText("We could not load this information. Please try again."),
+    ).toBeInTheDocument();
+  });
+
+  it("applies the permission kind class", () => {
+    const { container } = render(<EmptyState kind="permission" />);
+
+    expect(container.firstChild).toHaveClass("empty-state-permission");
+    expect(screen.getByText("Access required")).toBeInTheDocument();
+  });
+
+  it("renders object CTA as a button when onClick is provided", () => {
+    const onClick = vi.fn();
+    render(<EmptyState action={{ label: "Try again", onClick }} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders object CTA as an internal link when href is provided", () => {
+    render(<EmptyState action={{ label: "Create vault", href: "/vaults/new" }} />);
+
+    expect(screen.getByRole("link", { name: "Create vault" })).toHaveAttribute(
+      "href",
+      "/vaults/new",
+    );
+  });
+
+  it("renders secondary object CTA with secondary styling", () => {
+    const onClick = vi.fn();
+    render(
+      <EmptyState
+        action={{ label: "Primary", onClick: vi.fn() }}
+        secondaryAction={{ label: "Reset", onClick }}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Reset" })).toHaveClass(
+      "btn-secondary",
+    );
   });
 
   it("forwards extra className to the root element", () => {

--- a/frontend/src/components/ui/EmptyState.tsx
+++ b/frontend/src/components/ui/EmptyState.tsx
@@ -1,12 +1,28 @@
 import React from "react";
+import type { LucideIcon } from "lucide-react";
+import { AlertCircle, Inbox, PackageSearch, ShieldCheck } from "../icons";
 import "./EmptyState.css";
 
-export type EmptyStateKind = "no-data" | "no-results" | "error";
+export type EmptyStateKind =
+  | "no-data"
+  | "no-results"
+  | "search"
+  | "error"
+  | "permission";
+
+export type EmptyStateAction = {
+  label: string;
+  href?: string;
+  onClick?: () => void;
+  variant?: "primary" | "secondary" | "danger" | "outline";
+};
 
 export interface EmptyStateProps {
-  title: string;
-  description: string;
-  icon: React.ReactNode;
+  title?: string;
+  description?: string;
+  icon?: React.ReactNode;
+  action?: EmptyStateAction;
+  secondaryAction?: EmptyStateAction;
   actionLabel?: string;
   onAction?: () => void;
   secondaryActionLabel?: string;
@@ -16,6 +32,41 @@ export interface EmptyStateProps {
   variant?: EmptyStateKind | "default" | "minimal";
   className?: string;
 }
+
+const variantDefaults: Record<
+  EmptyStateKind,
+  {
+    title: string;
+    description: string;
+    icon: LucideIcon;
+  }
+> = {
+  "no-data": {
+    title: "No data available",
+    description: "There is nothing to show here yet.",
+    icon: Inbox,
+  },
+  "no-results": {
+    title: "No results found",
+    description: "Try adjusting your search or filters.",
+    icon: PackageSearch,
+  },
+  search: {
+    title: "No results found",
+    description: "Try adjusting your search or filters.",
+    icon: PackageSearch,
+  },
+  error: {
+    title: "Something went wrong",
+    description: "We could not load this information. Please try again.",
+    icon: AlertCircle,
+  },
+  permission: {
+    title: "Access required",
+    description: "Connect your wallet or check your permissions to continue.",
+    icon: ShieldCheck,
+  },
+};
 
 function resolveKind(
   kind?: EmptyStateKind,
@@ -27,16 +78,67 @@ function resolveKind(
   if (variant === "minimal" || variant === "no-results") {
     return "no-results";
   }
+  if (variant === "search") {
+    return "search";
+  }
   if (variant === "error") {
     return "error";
   }
+  if (variant === "permission") {
+    return "permission";
+  }
   return "no-data";
+}
+
+function isExternalHref(href: string): boolean {
+  return /^(https?:|mailto:|tel:)/i.test(href);
+}
+
+function EmptyStateActionButton({
+  action,
+  defaultVariant = "primary",
+}: {
+  action: EmptyStateAction;
+  defaultVariant?: EmptyStateAction["variant"];
+}) {
+  const variant = action.variant ?? defaultVariant;
+  const className = `btn btn-${variant} empty-state-action`;
+
+  if (action.href) {
+    if (isExternalHref(action.href)) {
+      return (
+        <a
+          href={action.href}
+          className={className}
+          onClick={action.onClick}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {action.label}
+        </a>
+      );
+    }
+
+    return (
+      <a href={action.href} className={className} onClick={action.onClick}>
+        {action.label}
+      </a>
+    );
+  }
+
+  return (
+    <button type="button" className={className} onClick={action.onClick}>
+      {action.label}
+    </button>
+  );
 }
 
 export const EmptyState: React.FC<EmptyStateProps> = ({
   title,
   description,
   icon,
+  action,
+  secondaryAction,
   actionLabel,
   onAction,
   secondaryActionLabel,
@@ -46,51 +148,68 @@ export const EmptyState: React.FC<EmptyStateProps> = ({
   className = "",
 }) => {
   const resolvedKind = resolveKind(kind, variant);
+  const defaults = variantDefaults[resolvedKind];
+  const DefaultIcon = defaults.icon;
+  const stateTitle = title ?? defaults.title;
+  const stateDescription = description ?? defaults.description;
   const isError = resolvedKind === "error";
-  const hasPrimaryAction = Boolean(actionLabel && onAction);
-  const hasSecondaryAction = Boolean(
-    secondaryActionLabel && onSecondaryAction,
-  );
+  const primaryAction =
+    action ??
+    (actionLabel && onAction
+      ? { label: actionLabel, onClick: onAction }
+      : undefined);
+  const resolvedSecondaryAction =
+    secondaryAction ??
+    (secondaryActionLabel && onSecondaryAction
+      ? {
+          label: secondaryActionLabel,
+          onClick: onSecondaryAction,
+          variant: "secondary" as const,
+        }
+      : undefined);
 
   return (
-    <div
+    <section
       className={`empty-state-container empty-state-${resolvedKind} ${className}`.trim()}
       role={isError ? "alert" : "status"}
-      aria-label={title}
+      aria-label={stateTitle}
       aria-live={isError ? "assertive" : "polite"}
     >
       <div className="empty-state-icon-wrapper" aria-hidden="true">
         {React.isValidElement(icon)
           ? React.cloneElement(icon as React.ReactElement<{ size?: number }>, {
-              size: resolvedKind === "no-results" ? 32 : 40,
+              size:
+                resolvedKind === "no-results" || resolvedKind === "search"
+                  ? 32
+                  : 40,
             })
-          : icon}
+          : icon ?? (
+              <DefaultIcon
+                size={
+                  resolvedKind === "no-results" || resolvedKind === "search"
+                    ? 32
+                    : 40
+                }
+                aria-hidden
+              />
+            )}
       </div>
-      <h3 className="empty-state-title">{title}</h3>
-      <p className="empty-state-description">{description}</p>
-      {(hasPrimaryAction || hasSecondaryAction) && (
+      <h3 className="empty-state-title">{stateTitle}</h3>
+      <p className="empty-state-description">{stateDescription}</p>
+      {(primaryAction || resolvedSecondaryAction) && (
         <div className="empty-state-actions">
-          {hasPrimaryAction && (
-            <button
-              type="button"
-              className="btn btn-primary empty-state-action"
-              onClick={onAction}
-            >
-              {actionLabel}
-            </button>
+          {primaryAction && (
+            <EmptyStateActionButton action={primaryAction} />
           )}
-          {hasSecondaryAction && (
-            <button
-              type="button"
-              className="btn btn-primary empty-state-action"
-              onClick={onSecondaryAction}
-            >
-              {secondaryActionLabel}
-            </button>
+          {resolvedSecondaryAction && (
+            <EmptyStateActionButton
+              action={resolvedSecondaryAction}
+              defaultVariant="secondary"
+            />
           )}
         </div>
       )}
-    </div>
+    </section>
   );
 };
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2380,6 +2380,10 @@ button {
   color: var(--text-warning);
 }
 
+.receipt-empty-state {
+  max-width: 600px;
+}
+
 .receipt-back-link {
   display: inline-block;
   margin-top: 1rem;

--- a/frontend/src/pages/TransactionHistory.tsx
+++ b/frontend/src/pages/TransactionHistory.tsx
@@ -1,25 +1,23 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 import ApiStatusBanner from "../components/ApiStatusBanner";
 import Badge from "../components/Badge";
 import { DataTable, type DataTableColumn } from "../components/DataTable";
 import PageHeader from "../components/PageHeader";
+import { SkeletonText } from "../components/Skeleton";
 import TransactionFilterPanel from "../components/TransactionFilterPanel";
 import TransactionTimeline from "../components/TransactionTimeline";
 import EmptyState from "../components/ui/EmptyState";
-import { Activity, Loader2 } from "../components/icons";
+import { Activity, Loader2, Wallet } from "../components/icons";
 import { useTransactionTimeline } from "../hooks/useTransactionTimeline";
 import {
   normalizeApiError,
   isValidationError,
-  type ApiError,
-  type ValidationError,
 } from "../lib/api";
 import {
   formatAmount,
   formatTimestamp,
   truncateHash,
-  getTransactions,
   type Transaction,
 } from "../lib/transactionApi";
 import { useClientDataTable } from "../hooks/useClientDataTable";
@@ -36,7 +34,6 @@ interface TransactionHistoryProps {
   walletAddress: string | null;
 }
 
-type TxTypeFilter = "all" | "deposit" | "withdrawal";
 type ViewMode = "paginated" | "infinite";
 const DEFAULT_PAGE_SIZE = 10;
 const INFINITE_SCROLL_BATCH_SIZE = 20;
@@ -146,10 +143,12 @@ const PendingTimelinePanel: React.FC<{ txHash: string; onDismiss: () => void }> 
 const TransactionHistory: React.FC<TransactionHistoryProps> = ({
   walletAddress,
 }) => {
-  const navigate = useNavigate();
   const { data: queryTransactions, isLoading, error: queryError } = useTransactionHistory(walletAddress);
   const delayedLoading = useDelayedLoading(isLoading);
-  const transactions = queryTransactions ?? [];
+  const transactions = React.useMemo(
+    () => queryTransactions ?? [],
+    [queryTransactions],
+  );
 
   const [selectedPendingHash, setSelectedPendingHash] = useState<string | null>(null);
 
@@ -459,7 +458,7 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({
   // ── Empty state ─────────────────────────────────────────────────────────
   const emptyMessage = (
     <EmptyState
-      kind={hasActiveFilters ? "no-results" : "no-data"}
+      kind={hasActiveFilters ? "search" : "no-data"}
       title={hasActiveFilters ? "No transactions found" : "No transactions yet"}
       description={
         hasActiveFilters
@@ -467,12 +466,11 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({
           : "Once you make a deposit or withdrawal, it will appear here."
       }
       icon={<Activity size={24} />}
-      {...(hasActiveFilters
-        ? { actionLabel: "Reset filters", onAction: clearAll }
-        : {
-            actionLabel: "Deposit Now",
-            onAction: () => navigate("/"),
-          })}
+      action={
+        hasActiveFilters
+          ? { label: "Reset filters", onClick: clearAll, variant: "secondary" }
+          : { label: "Deposit Now", href: "/" }
+      }
     />
   );
 
@@ -506,11 +504,13 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({
       />
 
       {!walletAddress ? (
-        <div style={{ textAlign: "center", padding: "48px" }}>
-          <p style={{ color: "var(--text-secondary)" }}>
-            Please connect your wallet to view your transaction history.
-          </p>
-        </div>
+        <EmptyState
+          kind="permission"
+          title="Connect your wallet"
+          description="Connect your wallet to view your transaction history."
+          icon={<Wallet />}
+          action={{ label: "Go to dashboard", href: "/" }}
+        />
       ) : (
         <div className="flex flex-col gap-lg">
           {error && <ApiStatusBanner error={error} />}

--- a/frontend/src/pages/TransactionReceipt.tsx
+++ b/frontend/src/pages/TransactionReceipt.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { useParams, Link } from "react-router-dom";
+import EmptyState from "../components/ui/EmptyState";
 
 const HORIZON_BASE = "https://horizon-testnet.stellar.org";
 const EXPLORER_BASE = "https://stellar.expert/explorer/testnet/tx";
@@ -97,8 +98,13 @@ export default function TransactionReceipt() {
   if (error || !tx) {
     return (
       <div className="receipt-page">
-        <p className="receipt-error">{error ?? "Transaction not found."}</p>
-        <Link to="/" className="receipt-back-link">← Back to app</Link>
+        <EmptyState
+          kind="error"
+          title="Transaction not found"
+          description={error ?? "We could not find this transaction receipt."}
+          action={{ label: "Back to app", href: "/" }}
+          className="receipt-empty-state"
+        />
       </div>
     );
   }


### PR DESCRIPTION
## Summary 

This PR adds reusable empty-state UI components for no-data and error contexts to standardize empty/error visuals across the frontend. 

## Changes Made 
- Added reusable empty-state component variants for no-data and error contexts. 
- Added support for contextual CTA actions. 
- Applied token-consistent styling using existing design conventions. 
- Updated existing empty/error UI usages to use the reusable component. 
- Preserved accessibility with clear roles, labels, and readable messaging. 

## Testing 
- [ ] Ran lint 
- [ ] Ran build 
- [ ] Ran frontend tests, if available 
- [ ] Manually checked no-data and error states in affected pages 


Closes #507