### PR TITLE
[623] Frontend: Add deterministic empty and error placeholders for all chart widgets

### DIFF
--- a/frontend/src/components/APYTrendChart.tsx
+++ b/frontend/src/components/APYTrendChart.tsx
@@ -16,6 +16,7 @@ import { type TimeRange, getCutoffDate, getNow } from "../lib/dateUtils";
 import RefreshControl from "./RefreshControl";
 import { usePolling } from "../hooks/usePolling";
 import { useStaleIndicator } from "../hooks/useStaleIndicator";
+import ChartWidgetPlaceholder from "./ui/ChartWidgetPlaceholder";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -339,7 +340,14 @@ const APYTrendChart: React.FC<APYTrendChartProps> = ({ data = ALL_HISTORY }) => 
 
       {/* Chart */}
       <div style={{ height: "240px", position: "relative" }}>
-        {isTest ? (
+        {baseData.length === 0 ? (
+          <ChartWidgetPlaceholder
+            variant="empty"
+            title="No APY data available"
+            description="APY history will appear here once yield data is available."
+            height={240}
+          />
+        ) : isTest ? (
           <LineChart {...sharedChartProps} width={400} height={240}>
             <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.05)" vertical={false} />
             <XAxis

--- a/frontend/src/components/VaultPerformanceChart.tsx
+++ b/frontend/src/components/VaultPerformanceChart.tsx
@@ -20,6 +20,7 @@ import { formatChartNumber, createChartNumberTickFormatter } from "../lib/chartF
 import RefreshControl from "./RefreshControl";
 import { useQueryWithPolling, POLLING_INTERVALS } from "../hooks/useQueryWithPolling";
 import { useStaleIndicator } from "../hooks/useStaleIndicator";
+import ChartWidgetPlaceholder from "./ui/ChartWidgetPlaceholder";
 
 const VaultPerformanceTooltip = ({
   active,
@@ -58,7 +59,7 @@ const VaultPerformanceChart: React.FC = () => {
   const { query, polling, lastUpdated } = useQueryWithPolling(historyQuery, {
     interval: POLLING_INTERVALS.slow,
   });
-  const { data: rawData = [], isLoading, isFetching } = query;
+  const { data: rawData = [], isLoading, isFetching, error, refetch } = query;
   const { isStale, ageText } = useStaleIndicator(lastUpdated);
   const { preferences } = usePreferencesContext();
   const [timeRange, setTimeRange] = useState<TimeRange>("ALL");
@@ -154,7 +155,22 @@ const VaultPerformanceChart: React.FC = () => {
           </div>
 
           <div style={{ flex: 1, minHeight: "260px", position: "relative" }}>
-            {isTest ? (
+            {error ? (
+              <ChartWidgetPlaceholder
+                variant="error"
+                title="Unable to load performance data"
+                description="We could not fetch vault performance history. Please try again."
+                height={260}
+                onRetry={() => void refetch()}
+              />
+            ) : filteredData.length === 0 ? (
+              <ChartWidgetPlaceholder
+                variant="empty"
+                title="No performance data yet"
+                description="Vault performance history will appear after the first data points are recorded."
+                height={260}
+              />
+            ) : isTest ? (
               <AreaChart data={filteredData} width={400} height={260} margin={{ top: 10, right: 10, left: -20, bottom: 0 }}>
                 <defs>
                   <linearGradient id="colorValue" x1="0" y1="0" x2="0" y2="1">

--- a/frontend/src/components/YieldBreakdownChart.tsx
+++ b/frontend/src/components/YieldBreakdownChart.tsx
@@ -9,7 +9,7 @@ import {
   ResponsiveContainer,
 } from "recharts";
 import { TrendingUp } from "./icons";
-import EmptyState from "./ui/EmptyState";
+import ChartWidgetPlaceholder from "./ui/ChartWidgetPlaceholder";
 import { usePreferencesContext } from "../context/PreferencesContext";
 import { formatCurrency, formatDate } from "../lib/formatters";
 import { formatChartCurrency, createChartCurrencyTickFormatter } from "../lib/chartFormatters";
@@ -180,16 +180,16 @@ const YieldBreakdownChart: React.FC<YieldBreakdownChartProps> = ({ totalGain }) 
       {/* Chart */}
       <div style={{ height: "220px", position: "relative" }}>
         {isEmpty ? (
-          <EmptyState
-            kind="no-data"
-            className="empty-state-compact"
+          <ChartWidgetPlaceholder
+            variant="empty"
             title="No yield data yet"
             description="Deposit to start earning and track daily yield here."
             icon={<TrendingUp />}
-            actionLabel="Deposit Now"
-            onAction={() => {
+            height={220}
+            onRetry={() => {
               window.dispatchEvent(new Event("TRIGGER_DEPOSIT"));
             }}
+            retryLabel="Deposit Now"
           />
         ) : (
           <ResponsiveContainer width="100%" height="100%">

--- a/frontend/src/components/ui/ChartWidgetPlaceholder.css
+++ b/frontend/src/components/ui/ChartWidgetPlaceholder.css
@@ -1,0 +1,14 @@
+.chart-widget-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px dashed var(--border-glass);
+}
+
+.chart-widget-placeholder-content {
+  width: 100%;
+  max-width: 360px;
+}

--- a/frontend/src/components/ui/ChartWidgetPlaceholder.test.tsx
+++ b/frontend/src/components/ui/ChartWidgetPlaceholder.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ChartWidgetPlaceholder } from "./ChartWidgetPlaceholder";
+
+describe("ChartWidgetPlaceholder", () => {
+  it("renders deterministic empty placeholder content", () => {
+    render(
+      <ChartWidgetPlaceholder
+        variant="empty"
+        title="No chart data"
+        description="Data will appear here soon."
+        data-testid="chart-empty"
+      />,
+    );
+
+    expect(screen.getByTestId("chart-empty")).toBeInTheDocument();
+    expect(screen.getByText("No chart data")).toBeInTheDocument();
+    expect(screen.getByText("Data will appear here soon.")).toBeInTheDocument();
+  });
+
+  it("renders error placeholder with retry action", () => {
+    const onRetry = vi.fn();
+    render(
+      <ChartWidgetPlaceholder
+        variant="error"
+        title="Failed to load chart"
+        onRetry={onRetry}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/ui/ChartWidgetPlaceholder.tsx
+++ b/frontend/src/components/ui/ChartWidgetPlaceholder.tsx
@@ -1,0 +1,65 @@
+import type { ReactNode } from "react";
+import { AlertCircle, BarChart3 } from "lucide-react";
+import EmptyState from "./EmptyState";
+import "./ChartWidgetPlaceholder.css";
+
+export type ChartWidgetPlaceholderVariant = "empty" | "error";
+
+export interface ChartWidgetPlaceholderProps {
+  variant: ChartWidgetPlaceholderVariant;
+  title: string;
+  description?: string;
+  icon?: ReactNode;
+  onRetry?: () => void;
+  retryLabel?: string;
+  height?: number | string;
+  className?: string;
+  "data-testid"?: string;
+}
+
+/**
+ * Deterministic placeholder for chart widgets when data is unavailable or loading failed.
+ */
+export function ChartWidgetPlaceholder({
+  variant,
+  title,
+  description,
+  icon,
+  onRetry,
+  retryLabel = "Retry",
+  height = 220,
+  className = "",
+  "data-testid": testId,
+}: ChartWidgetPlaceholderProps) {
+  const defaultIcon =
+    variant === "error" ? (
+      <AlertCircle size={24} color="var(--text-error)" />
+    ) : (
+      icon ?? <BarChart3 size={24} />
+    );
+
+  return (
+    <div
+      className={`chart-widget-placeholder ${className}`.trim()}
+      style={{ height, minHeight: height }}
+      data-testid={testId ?? `chart-placeholder-${variant}`}
+      role={variant === "error" ? "alert" : "status"}
+      aria-live="polite"
+    >
+      <EmptyState
+        kind={variant === "error" ? "error" : "no-data"}
+        className="empty-state-compact chart-widget-placeholder-content"
+        title={title}
+        description={description}
+        icon={defaultIcon}
+        action={
+          onRetry
+            ? { label: retryLabel, onClick: onRetry, variant: "secondary" }
+            : undefined
+        }
+      />
+    </div>
+  );
+}
+
+export default ChartWidgetPlaceholder;


### PR DESCRIPTION
## Summary
- Add reusable `ChartWidgetPlaceholder` for empty and error chart states
- Apply consistent placeholders to APY trend, vault performance, and yield breakdown charts

## Test plan
- [x] `ChartWidgetPlaceholder` unit tests
- [x] Existing chart component tests

Closes #623

Made with [Cursor](https://cursor.com)