### PR TITLE
[625] Frontend: Add wallet disconnect recovery modal with safe draft preservation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import * as Sentry from "@sentry/react";
 import Navbar from "./components/Navbar";
 import SessionExpiredModal from "./components/SessionExpiredModal";
 import SessionExpiryWarning from "./components/SessionExpiryWarning";
+import WalletDisconnectRecoveryModal from "./components/WalletDisconnectRecoveryModal";
 import type { DisconnectReason } from "./components/WalletConnect";
 import { KeyboardShortcutProvider } from "./context/KeyboardShortcutContext";
 import ShortcutHelpModal from "./components/ShortcutHelpModal";
@@ -16,6 +17,12 @@ import { PreferencesProvider } from "./context/PreferencesContext";
 import { useUsdcBalance, useXlmBalance } from "./hooks/useBalanceData";
 import { queryClient } from "./lib/queryClient";
 import { clearWalletSessionState } from "./lib/sessionCleanup";
+import {
+  clearVaultFormDraft,
+  hasMeaningfulDraft,
+  loadVaultFormDraft,
+  type VaultFormDraft,
+} from "./lib/formDraftStorage";
 import ErrorFallback from "./components/ErrorFallback";
 import RouteLoadingFallback from "./components/RouteLoadingFallback";
 import NetworkWarningBanner from "./components/NetworkWarningBanner";
@@ -36,6 +43,7 @@ const TransactionReceipt = lazy(() => import("./pages/TransactionReceipt"));
 
 function AppContent() {
   const [walletAddress, setWalletAddress] = useState<string | null>(null);
+  const [pendingDraft, setPendingDraft] = useState<VaultFormDraft | null>(null);
   const navigate = useNavigate();
   const location = useLocation();
   const { sessionState, intendedPath, setSessionExpired, clearSessionExpired, dismissSessionWarning } = useAuth();
@@ -59,6 +67,7 @@ function AppContent() {
   const handleConnect = useCallback((address: string) => {
     clearSessionExpired();
     setWalletAddress(address);
+    setPendingDraft(null);
   }, [clearSessionExpired]);
 
   const handleDisconnect = useCallback((reason: DisconnectReason = "manual") => {
@@ -68,10 +77,40 @@ function AppContent() {
       clearSessionExpired();
     }
 
+    if (reason === "manual") {
+      clearVaultFormDraft();
+      setPendingDraft(null);
+    } else {
+      const draft = loadVaultFormDraft();
+      if (hasMeaningfulDraft(draft)) {
+        setPendingDraft(draft);
+      } else {
+        clearVaultFormDraft();
+        setPendingDraft(null);
+      }
+    }
+
     clearWalletSessionState(queryClient);
     setWalletAddress(null);
     navigate("/", { replace: true });
   }, [clearSessionExpired, location.pathname, navigate, setSessionExpired]);
+
+  const handleRestoreDraft = useCallback(() => {
+    if (!pendingDraft) return;
+    const params = new URLSearchParams();
+    params.set("tab", pendingDraft.tab);
+    params.set("step", pendingDraft.step);
+    if (pendingDraft.amount) {
+      params.set("amount", pendingDraft.amount);
+    }
+    navigate(`/?${params.toString()}`, { replace: true });
+    setPendingDraft(null);
+  }, [navigate, pendingDraft]);
+
+  const handleDiscardDraft = useCallback(() => {
+    clearVaultFormDraft();
+    setPendingDraft(null);
+  }, []);
 
   const handleReconnect = useCallback(() => {
     clearSessionExpired();
@@ -148,6 +187,14 @@ function AppContent() {
               intendedPath={intendedPath}
               onReconnect={handleReconnect}
               onDismiss={() => handleDisconnect("manual")}
+            />
+          )}
+          {pendingDraft && !walletAddress && (
+            <WalletDisconnectRecoveryModal
+              draft={pendingDraft}
+              onReconnect={handleReconnect}
+              onRestore={handleRestoreDraft}
+              onDiscard={handleDiscardDraft}
             />
           )}
         </div>

--- a/frontend/src/components/VaultDashboard.tsx
+++ b/frontend/src/components/VaultDashboard.tsx
@@ -41,6 +41,11 @@ import { usePolling } from "../hooks/usePolling";
 import { useStaleIndicator } from "../hooks/useStaleIndicator";
 import { useNetworkStatus } from "../hooks/useNetworkStatus";
 import { useTransactionConfirmation } from "../hooks/useTransactionConfirmation";
+import { useOfflineRetryCountdown } from "../hooks/useOfflineRetryCountdown";
+import {
+  clearVaultFormDraft,
+  saveVaultFormDraft,
+} from "../lib/formDraftStorage";
 import { buildDepositSummary, buildWithdrawalSummary } from "../lib/transactionConfirmationBuilder";
 
 /**
@@ -221,6 +226,22 @@ const VaultDashboard: React.FC<VaultDashboardProps> = ({
 
   const amount = values.amount;
 
+  useEffect(() => {
+    if (!walletAddress) return;
+    if (!amount.trim() && dashboardUrl.state.step === "amount") return;
+
+    saveVaultFormDraft({
+      tab: dashboardUrl.state.tab,
+      step: dashboardUrl.state.step,
+      amount,
+    });
+  }, [
+    walletAddress,
+    dashboardUrl.state.tab,
+    dashboardUrl.state.step,
+    amount,
+  ]);
+
   // Handle deep link parameters
   useEffect(() => {
     const action = dashboardUrl.state.tab;
@@ -247,6 +268,7 @@ const VaultDashboard: React.FC<VaultDashboardProps> = ({
     dashboardUrl.setStep("amount");
     dashboardUrl.setAmount("");
     setTransactionResult(null);
+    clearVaultFormDraft();
   };
 
   const goToReview = () => {

--- a/frontend/src/components/WalletDisconnectRecoveryModal.tsx
+++ b/frontend/src/components/WalletDisconnectRecoveryModal.tsx
@@ -1,0 +1,120 @@
+import React from "react";
+import { Wallet, FileText, Trash2 } from "lucide-react";
+import { Modal } from "./Modal";
+import { useTranslation } from "../i18n";
+import type { VaultFormDraft } from "../lib/formDraftStorage";
+
+interface WalletDisconnectRecoveryModalProps {
+  draft: VaultFormDraft;
+  onReconnect: () => void;
+  onRestore: () => void;
+  onDiscard: () => void;
+}
+
+const WalletDisconnectRecoveryModal: React.FC<WalletDisconnectRecoveryModalProps> = ({
+  draft,
+  onReconnect,
+  onRestore,
+  onDiscard,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <Modal
+      isOpen
+      onClose={onDiscard}
+      size="sm"
+      closeOnBackdropClick={false}
+      aria-labelledby="wallet-disconnect-recovery-title"
+      aria-describedby="wallet-disconnect-recovery-desc"
+    >
+      <div style={{ textAlign: "center" }}>
+        <div
+          style={{
+            background: "rgba(0, 240, 255, 0.1)",
+            color: "var(--accent-cyan)",
+            padding: "16px",
+            borderRadius: "50%",
+            display: "inline-flex",
+            marginBottom: "16px",
+          }}
+        >
+          <Wallet size={40} />
+        </div>
+
+        <h2
+          id="wallet-disconnect-recovery-title"
+          style={{ margin: "0 0 12px", fontSize: "1.5rem" }}
+        >
+          {t("walletRecovery.title")}
+        </h2>
+        <p
+          id="wallet-disconnect-recovery-desc"
+          style={{ color: "var(--text-secondary)", margin: "0 0 16px", lineHeight: 1.6 }}
+        >
+          {t("walletRecovery.description")}
+        </p>
+
+        <div
+          className="glass-panel"
+          style={{
+            padding: "14px 16px",
+            marginBottom: "20px",
+            textAlign: "left",
+            display: "flex",
+            gap: "12px",
+            alignItems: "flex-start",
+          }}
+        >
+          <FileText size={18} color="var(--accent-cyan)" style={{ flexShrink: 0, marginTop: 2 }} />
+          <div>
+            <div style={{ fontWeight: 600, marginBottom: "4px" }}>
+              {t("walletRecovery.draftLabel")}
+            </div>
+            <div style={{ fontSize: "0.875rem", color: "var(--text-secondary)" }}>
+              {t(`walletRecovery.tab.${draft.tab}`)} · {draft.step} ·{" "}
+              {draft.amount ? `${draft.amount} USDC` : t("walletRecovery.noAmount")}
+            </div>
+          </div>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: "10px" }}>
+          <button
+            type="button"
+            className="btn btn-primary"
+            onClick={onReconnect}
+            style={{ width: "100%", padding: "14px" }}
+          >
+            {t("walletRecovery.reconnect")}
+          </button>
+          <button
+            type="button"
+            className="btn btn-secondary"
+            onClick={onRestore}
+            style={{ width: "100%", padding: "14px" }}
+          >
+            {t("walletRecovery.restore")}
+          </button>
+          <button
+            type="button"
+            className="btn btn-outline"
+            onClick={onDiscard}
+            style={{
+              width: "100%",
+              padding: "14px",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: "8px",
+            }}
+          >
+            <Trash2 size={16} />
+            {t("walletRecovery.discard")}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default WalletDisconnectRecoveryModal;

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -198,6 +198,20 @@ export const en = {
     reconnect: "Reconnect Wallet",
     goHome: "Go to Home",
   },
+  walletRecovery: {
+    title: "Wallet Disconnected",
+    description:
+      "Your wallet disconnected unexpectedly. You can reconnect and restore your in-progress transaction draft.",
+    draftLabel: "Saved draft",
+    noAmount: "No amount entered",
+    reconnect: "Reconnect Wallet",
+    restore: "Restore Draft",
+    discard: "Discard Draft",
+    tab: {
+      deposit: "Deposit",
+      withdraw: "Withdraw",
+    },
+  },
   onboarding: {
     title: "Get Started with YieldVault",
     subtitle: "Follow these steps to start earning institutional-grade yield on your USDC.",

--- a/frontend/src/lib/formDraftStorage.test.ts
+++ b/frontend/src/lib/formDraftStorage.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import {
+  clearVaultFormDraft,
+  hasMeaningfulDraft,
+  loadVaultFormDraft,
+  saveVaultFormDraft,
+} from "./formDraftStorage";
+
+describe("formDraftStorage", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("saves and loads a vault form draft", () => {
+    saveVaultFormDraft({
+      tab: "deposit",
+      step: "review",
+      amount: "125.5",
+    });
+
+    expect(loadVaultFormDraft()).toMatchObject({
+      tab: "deposit",
+      step: "review",
+      amount: "125.5",
+    });
+  });
+
+  it("detects meaningful drafts", () => {
+    expect(hasMeaningfulDraft(null)).toBe(false);
+    expect(
+      hasMeaningfulDraft({
+        tab: "deposit",
+        step: "amount",
+        amount: "",
+        savedAt: Date.now(),
+      }),
+    ).toBe(false);
+    expect(
+      hasMeaningfulDraft({
+        tab: "withdraw",
+        step: "amount",
+        amount: "10",
+        savedAt: Date.now(),
+      }),
+    ).toBe(true);
+  });
+
+  it("clears stored drafts", () => {
+    saveVaultFormDraft({ tab: "deposit", step: "amount", amount: "1" });
+    clearVaultFormDraft();
+    expect(loadVaultFormDraft()).toBeNull();
+  });
+});

--- a/frontend/src/lib/formDraftStorage.ts
+++ b/frontend/src/lib/formDraftStorage.ts
@@ -1,0 +1,48 @@
+import type { TransactionTab, TransactionStep } from "../hooks/useDashboardUrlState";
+
+export const FORM_DRAFT_STORAGE_KEY = "yieldvault_vault_form_draft";
+
+export interface VaultFormDraft {
+  tab: TransactionTab;
+  step: TransactionStep;
+  amount: string;
+  slippage?: string;
+  savedAt: number;
+}
+
+export function saveVaultFormDraft(draft: Omit<VaultFormDraft, "savedAt">): void {
+  if (typeof window === "undefined") return;
+  try {
+    const payload: VaultFormDraft = { ...draft, savedAt: Date.now() };
+    sessionStorage.setItem(FORM_DRAFT_STORAGE_KEY, JSON.stringify(payload));
+  } catch {
+    // sessionStorage unavailable
+  }
+}
+
+export function loadVaultFormDraft(): VaultFormDraft | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = sessionStorage.getItem(FORM_DRAFT_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as VaultFormDraft;
+    if (!parsed?.tab || typeof parsed.amount !== "string") return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function clearVaultFormDraft(): void {
+  if (typeof window === "undefined") return;
+  try {
+    sessionStorage.removeItem(FORM_DRAFT_STORAGE_KEY);
+  } catch {
+    // sessionStorage unavailable
+  }
+}
+
+export function hasMeaningfulDraft(draft: VaultFormDraft | null): boolean {
+  if (!draft) return false;
+  return draft.amount.trim().length > 0 || draft.step !== "amount";
+}


### PR DESCRIPTION
## Summary
- Persist in-progress vault form drafts to session storage
- Show recovery modal on unexpected wallet disconnect with reconnect, restore, and discard actions
- Integrate draft save/clear lifecycle in `VaultDashboard` and `App`

## Test plan
- [x] `formDraftStorage` unit tests
- [x] Manual disconnect recovery flow verification

Closes #625

Made with [Cursor](https://cursor.com)