### PR TITLE
[711] Backend: Add API contract schema snapshots for backward-compatibility checks

### DIFF
--- a/.github/workflows/backend-governance.yml
+++ b/.github/workflows/backend-governance.yml
@@ -50,5 +50,8 @@ jobs:
             exit 1
           fi
 
+      - name: Check API contract schema snapshots
+        run: npm run snapshots:check
+
       - name: Check for database schema drift
         run: npm run db:check-drift

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,7 +13,9 @@
     "format": "prettier --write src",
     "audit": "npm audit",
     "generate:openapi": "tsx scripts/generate-openapi.ts",
-    "ci:governance": "npm run lint && npm run test && node scripts/check-migrations.js",
+    "ci:governance": "npm run lint && npm run test && node scripts/check-migrations.js && npm run snapshots:check",
+    "snapshots:write": "tsx scripts/check-schema-snapshots.ts --write",
+    "snapshots:check": "tsx scripts/check-schema-snapshots.ts",
     "db:check-drift": "prisma migrate diff --from-schema-datamodel prisma/schema.prisma --to-migrations prisma/migrations --exit-code"
   },
   "keywords": [

--- a/backend/schema-snapshots/get-_health.json
+++ b/backend/schema-snapshots/get-_health.json
@@ -1,0 +1,124 @@
+{
+  "type": "object",
+  "properties": {
+    "status": {
+      "type": "string"
+    },
+    "timestamp": {
+      "type": "string"
+    },
+    "uptime": {
+      "type": "number"
+    },
+    "environment": {
+      "type": "string"
+    },
+    "checks": {
+      "type": "object",
+      "properties": {
+        "api": {
+          "type": "string",
+          "enum": [
+            "up",
+            "down",
+            "degraded",
+            "unknown"
+          ]
+        },
+        "cache": {
+          "type": "string",
+          "enum": [
+            "up",
+            "down",
+            "degraded",
+            "unknown"
+          ]
+        },
+        "stellarRpc": {
+          "type": "string",
+          "enum": [
+            "up",
+            "down",
+            "degraded",
+            "unknown"
+          ]
+        },
+        "databasePrimary": {
+          "type": "string",
+          "enum": [
+            "up",
+            "down",
+            "degraded",
+            "unknown"
+          ]
+        },
+        "databaseReplica": {
+          "type": "string",
+          "enum": [
+            "up",
+            "down",
+            "degraded",
+            "unknown"
+          ]
+        },
+        "prisma": {
+          "type": "string",
+          "enum": [
+            "up",
+            "down",
+            "degraded",
+            "unknown"
+          ]
+        },
+        "jobs": {
+          "type": "string",
+          "enum": [
+            "up",
+            "down",
+            "degraded",
+            "unknown"
+          ]
+        }
+      },
+      "required": [
+        "api",
+        "cache",
+        "stellarRpc",
+        "databasePrimary",
+        "databaseReplica",
+        "prisma",
+        "jobs"
+      ],
+      "additionalProperties": false
+    },
+    "sorobanCircuitBreaker": {
+      "type": "object",
+      "properties": {
+        "state": {
+          "type": "string"
+        },
+        "failures": {
+          "type": "number"
+        },
+        "retryAfterMs": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "state",
+        "failures",
+        "retryAfterMs"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "status",
+    "timestamp",
+    "uptime",
+    "environment",
+    "checks",
+    "sorobanCircuitBreaker"
+  ],
+  "additionalProperties": false
+}

--- a/backend/schema-snapshots/get-_ready.json
+++ b/backend/schema-snapshots/get-_ready.json
@@ -1,0 +1,41 @@
+{
+  "type": "object",
+  "properties": {
+    "ready": {
+      "type": "boolean"
+    },
+    "timestamp": {
+      "type": "string"
+    },
+    "dependencies": {
+      "type": "object",
+      "properties": {
+        "cache": {
+          "type": "boolean"
+        },
+        "stellarRpc": {
+          "type": "boolean"
+        },
+        "database": {
+          "type": "boolean"
+        },
+        "prisma": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "cache",
+        "stellarRpc",
+        "database",
+        "prisma"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "ready",
+    "timestamp",
+    "dependencies"
+  ],
+  "additionalProperties": false
+}

--- a/backend/scripts/check-schema-snapshots.ts
+++ b/backend/scripts/check-schema-snapshots.ts
@@ -1,0 +1,33 @@
+#!/usr/bin/env tsx
+/**
+ * Verify API contract schema snapshots remain backward-compatible (Issue #711).
+ *
+ * Usage:
+ *   tsx scripts/check-schema-snapshots.ts          # fail on breaking changes
+ *   tsx scripts/check-schema-snapshots.ts --write  # regenerate snapshot files
+ */
+
+import {
+  checkSnapshotCompatibility,
+  writeAllSnapshots,
+} from '../src/apiContractSnapshots';
+
+const shouldWrite = process.argv.includes('--write');
+
+if (shouldWrite) {
+  writeAllSnapshots();
+  console.log('✅ Wrote API contract schema snapshots.');
+  process.exit(0);
+}
+
+const issues = checkSnapshotCompatibility();
+if (issues.length > 0) {
+  console.error('❌ API contract schema compatibility check failed:');
+  for (const issue of issues) {
+    console.error(`  - ${issue.path}: ${issue.message}`);
+  }
+  console.error('\nIf the breaking change is intentional, run: npm run snapshots:write');
+  process.exit(1);
+}
+
+console.log('✅ API contract schema snapshots are backward-compatible.');

--- a/backend/src/__tests__/issues711.test.ts
+++ b/backend/src/__tests__/issues711.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for Issue #711 - API contract schema snapshots.
+ */
+
+import {
+  CRITICAL_ENDPOINTS,
+  checkSnapshotCompatibility,
+  diffSchemaShapes,
+  generateSnapshotFor,
+  loadSnapshot,
+  validateResponseAgainstSchema,
+  writeAllSnapshots,
+  zodToJsonShape,
+  HealthResponseSchema,
+} from '../apiContractSnapshots';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const SNAPSHOT_DIR = path.join(__dirname, '..', '..', 'schema-snapshots');
+
+describe('#711 API contract schema snapshots', () => {
+  beforeAll(() => {
+    writeAllSnapshots();
+  });
+
+  it('defines snapshots for all critical public endpoints', () => {
+    expect(CRITICAL_ENDPOINTS.length).toBeGreaterThanOrEqual(2);
+    for (const endpoint of CRITICAL_ENDPOINTS) {
+      const snapshot = loadSnapshot(endpoint);
+      expect(snapshot).not.toBeNull();
+      expect(snapshot?.type).toBe('object');
+    }
+  });
+
+  it('passes backward-compatibility check against committed snapshots', () => {
+    const issues = checkSnapshotCompatibility();
+    expect(issues).toEqual([]);
+  });
+
+  it('detects removed fields as breaking changes', () => {
+    const baseline = zodToJsonShape(HealthResponseSchema);
+    const current = JSON.parse(JSON.stringify(baseline)) as typeof baseline;
+    delete current.properties?.status;
+
+    const issues = diffSchemaShapes(baseline, current, 'GET /health');
+    expect(issues.some((issue) => issue.message === 'field removed')).toBe(true);
+  });
+
+  it('validates a conforming health payload', () => {
+    const result = validateResponseAgainstSchema('GET /health', {
+      status: 'healthy',
+      timestamp: new Date().toISOString(),
+      uptime: 12.5,
+      environment: 'test',
+      checks: {
+        api: 'up',
+        cache: 'up',
+        stellarRpc: 'up',
+        databasePrimary: 'up',
+        databaseReplica: 'up',
+        prisma: 'up',
+        jobs: 'up',
+      },
+      sorobanCircuitBreaker: {
+        state: 'closed',
+        failures: 0,
+        retryAfterMs: 0,
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects health payloads missing required fields', () => {
+    const result = validateResponseAgainstSchema('GET /health', {
+      status: 'healthy',
+      timestamp: new Date().toISOString(),
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('writes snapshot files under schema-snapshots/', () => {
+    for (const endpoint of CRITICAL_ENDPOINTS) {
+      const filename = endpoint.replace(/\s+/g, '-').replace(/\//g, '_').toLowerCase() + '.json';
+      expect(fs.existsSync(path.join(SNAPSHOT_DIR, filename))).toBe(true);
+    }
+  });
+
+  it('generates stable snapshot shapes for each endpoint', () => {
+    for (const endpoint of CRITICAL_ENDPOINTS) {
+      const first = generateSnapshotFor(endpoint);
+      const second = generateSnapshotFor(endpoint);
+      expect(first).toEqual(second);
+    }
+  });
+});

--- a/backend/src/apiContractSnapshots.ts
+++ b/backend/src/apiContractSnapshots.ts
@@ -1,0 +1,239 @@
+/**
+ * API contract schema snapshots for backward-compatibility checks (Issue #711).
+ *
+ * Committed JSON snapshots describe the shape of critical public endpoint responses.
+ * CI fails when a required field is removed or its type changes.
+ */
+
+import { z } from 'zod';
+import * as fs from 'fs';
+import * as path from 'path';
+
+export const SNAPSHOT_DIR = path.join(__dirname, '..', 'schema-snapshots');
+
+/** Critical public endpoints whose response contracts must remain backward-compatible. */
+export const CRITICAL_ENDPOINTS = [
+  'GET /health',
+  'GET /ready',
+] as const;
+
+export type CriticalEndpoint = (typeof CRITICAL_ENDPOINTS)[number];
+
+const HealthCheckValueSchema = z.enum(['up', 'down', 'degraded', 'unknown']);
+
+export const HealthResponseSchema = z
+  .object({
+    status: z.string(),
+    timestamp: z.string(),
+    uptime: z.number(),
+    environment: z.string(),
+    checks: z.object({
+      api: HealthCheckValueSchema,
+      cache: HealthCheckValueSchema,
+      stellarRpc: HealthCheckValueSchema,
+      databasePrimary: HealthCheckValueSchema,
+      databaseReplica: HealthCheckValueSchema,
+      prisma: HealthCheckValueSchema,
+      jobs: HealthCheckValueSchema,
+    }),
+    sorobanCircuitBreaker: z.object({
+      state: z.string(),
+      failures: z.number(),
+      retryAfterMs: z.number(),
+    }),
+  })
+  .strict();
+
+export const ReadyResponseSchema = z
+  .object({
+    ready: z.boolean(),
+    timestamp: z.string(),
+    dependencies: z.object({
+      cache: z.boolean(),
+      stellarRpc: z.boolean(),
+      database: z.boolean(),
+      prisma: z.boolean(),
+    }),
+  })
+  .strict();
+
+export const ENDPOINT_SCHEMAS: Record<CriticalEndpoint, z.ZodTypeAny> = {
+  'GET /health': HealthResponseSchema,
+  'GET /ready': ReadyResponseSchema,
+};
+
+export function endpointToFilename(endpoint: CriticalEndpoint): string {
+  return endpoint.replace(/\s+/g, '-').replace(/\//g, '_').toLowerCase() + '.json';
+}
+
+export function snapshotPathFor(endpoint: CriticalEndpoint): string {
+  return path.join(SNAPSHOT_DIR, endpointToFilename(endpoint));
+}
+
+export interface JsonSchemaShape {
+  type?: string;
+  properties?: Record<string, JsonSchemaShape>;
+  required?: string[];
+  items?: JsonSchemaShape;
+  enum?: unknown[];
+  additionalProperties?: boolean;
+}
+
+/** Convert a Zod object schema into a simplified JSON-schema-like shape for snapshots. */
+export function zodToJsonShape(schema: z.ZodTypeAny): JsonSchemaShape {
+  if (schema instanceof z.ZodObject) {
+    const shape = schema.shape;
+    const properties: Record<string, JsonSchemaShape> = {};
+    const required: string[] = [];
+
+    for (const [key, value] of Object.entries(shape)) {
+      properties[key] = zodToJsonShape(value as z.ZodTypeAny);
+      if (!(value instanceof z.ZodOptional)) {
+        required.push(key);
+      }
+    }
+
+    return {
+      type: 'object',
+      properties,
+      required,
+      additionalProperties: false,
+    };
+  }
+
+  if (schema instanceof z.ZodOptional) {
+    return zodToJsonShape(schema._def.innerType);
+  }
+
+  if (schema instanceof z.ZodNullable) {
+    return zodToJsonShape(schema._def.innerType);
+  }
+
+  if (schema instanceof z.ZodEnum) {
+    return { type: 'string', enum: schema._def.values };
+  }
+
+  if (schema instanceof z.ZodString) {
+    return { type: 'string' };
+  }
+
+  if (schema instanceof z.ZodNumber) {
+    return { type: 'number' };
+  }
+
+  if (schema instanceof z.ZodBoolean) {
+    return { type: 'boolean' };
+  }
+
+  return { type: 'unknown' };
+}
+
+export function generateSnapshotFor(endpoint: CriticalEndpoint): JsonSchemaShape {
+  return zodToJsonShape(ENDPOINT_SCHEMAS[endpoint]);
+}
+
+export function writeAllSnapshots(): void {
+  fs.mkdirSync(SNAPSHOT_DIR, { recursive: true });
+  for (const endpoint of CRITICAL_ENDPOINTS) {
+    const snapshot = generateSnapshotFor(endpoint);
+    fs.writeFileSync(snapshotPathFor(endpoint), JSON.stringify(snapshot, null, 2) + '\n');
+  }
+}
+
+export interface SchemaCompatibilityIssue {
+  path: string;
+  message: string;
+}
+
+function isObjectShape(value: JsonSchemaShape | undefined): value is JsonSchemaShape {
+  return value?.type === 'object' && typeof value.properties === 'object';
+}
+
+/** Detect breaking changes: removed fields, type changes, or newly required fields. */
+export function diffSchemaShapes(
+  baseline: JsonSchemaShape,
+  current: JsonSchemaShape,
+  prefix = '',
+): SchemaCompatibilityIssue[] {
+  const issues: SchemaCompatibilityIssue[] = [];
+  const at = (segment: string) => (prefix ? `${prefix}.${segment}` : segment);
+
+  if (baseline.type !== current.type) {
+    issues.push({
+      path: prefix || '(root)',
+      message: `type changed from ${baseline.type ?? 'unknown'} to ${current.type ?? 'unknown'}`,
+    });
+    return issues;
+  }
+
+  if (isObjectShape(baseline) && isObjectShape(current)) {
+    const baselineProps = baseline.properties ?? {};
+    const currentProps = current.properties ?? {};
+    const baselineRequired = new Set(baseline.required ?? []);
+    const currentRequired = new Set(current.required ?? []);
+
+    for (const key of Object.keys(baselineProps)) {
+      const childPath = at(key);
+      if (!(key in currentProps)) {
+        issues.push({ path: childPath, message: 'field removed' });
+        continue;
+      }
+      issues.push(...diffSchemaShapes(baselineProps[key], currentProps[key], childPath));
+    }
+
+    for (const key of baselineRequired) {
+      if (!currentRequired.has(key)) {
+        issues.push({ path: at(key), message: 'field is no longer required (may be breaking for strict clients)' });
+      }
+    }
+  }
+
+  if (baseline.enum && current.enum) {
+    const removed = baseline.enum.filter((value) => !current.enum?.includes(value));
+    if (removed.length > 0) {
+      issues.push({
+        path: prefix || '(root)',
+        message: `enum values removed: ${removed.join(', ')}`,
+      });
+    }
+  }
+
+  return issues;
+}
+
+export function loadSnapshot(endpoint: CriticalEndpoint): JsonSchemaShape | null {
+  const filePath = snapshotPathFor(endpoint);
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+  return JSON.parse(fs.readFileSync(filePath, 'utf8')) as JsonSchemaShape;
+}
+
+export function checkSnapshotCompatibility(): SchemaCompatibilityIssue[] {
+  const issues: SchemaCompatibilityIssue[] = [];
+
+  for (const endpoint of CRITICAL_ENDPOINTS) {
+    const baseline = loadSnapshot(endpoint);
+    if (!baseline) {
+      issues.push({ path: endpoint, message: 'missing committed snapshot file' });
+      continue;
+    }
+
+    const current = generateSnapshotFor(endpoint);
+    issues.push(...diffSchemaShapes(baseline, current, endpoint));
+  }
+
+  return issues;
+}
+
+export function validateResponseAgainstSchema(
+  endpoint: CriticalEndpoint,
+  payload: unknown,
+): { success: boolean; error?: string } {
+  const schema = ENDPOINT_SCHEMAS[endpoint];
+  const result = schema.safeParse(payload);
+  if (result.success) {
+    return { success: true };
+  }
+  return { success: false, error: result.error.message };
+}


### PR DESCRIPTION
## Summary
- Adds Zod-derived JSON schema snapshots for critical public endpoints (`GET /health`, `GET /ready`)
- Introduces `npm run snapshots:check` in backend governance CI to detect breaking response shape changes
- Includes unit tests for snapshot generation, validation, and breaking-change detection

## Test plan
- [x] `npm run snapshots:write`
- [x] `npm run snapshots:check`
- [x] `npm test -- src/__tests__/issues711.test.ts`

Closes #711