### PR TITLE
[714] Backend: Add structured maintenance window scheduler and status endpoint

### DIFF
--- a/backend/src/__tests__/issues714.test.ts
+++ b/backend/src/__tests__/issues714.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for Issue #714 - maintenance window scheduler and status endpoint.
+ */
+
+import request from 'supertest';
+import app from '../index';
+import {
+  resetMaintenanceModeState,
+  getMaintenanceModeState,
+  updateMaintenanceModeState,
+} from '../maintenanceMode';
+import {
+  buildMaintenanceStatusPayload,
+  cancelMaintenanceWindow,
+  getActiveMaintenanceWindow,
+  getNextMaintenanceWindow,
+  resetMaintenanceWindowsForTests,
+  scheduleMaintenanceWindow,
+  startMaintenanceWindowScheduler,
+  syncMaintenanceModeWithWindows,
+} from '../maintenanceWindow';
+
+const ADMIN_KEY = process.env.ADMIN_API_KEY || 'test-admin-key';
+const AUTH_HEADER = { Authorization: `ApiKey ${ADMIN_KEY}` };
+
+describe('#714 Maintenance window scheduler', () => {
+  beforeEach(() => {
+    resetMaintenanceModeState();
+    resetMaintenanceWindowsForTests();
+    updateMaintenanceModeState({ enabled: false });
+  });
+
+  afterEach(() => {
+    resetMaintenanceModeState();
+    resetMaintenanceWindowsForTests();
+  });
+
+  it('schedules windows and reports active/next in status payload', () => {
+    const now = new Date('2026-06-24T12:00:00.000Z');
+    const active = scheduleMaintenanceWindow({
+      title: 'DB migration',
+      reason: 'Index rebuild',
+      startsAt: '2026-06-24T11:30:00.000Z',
+      endsAt: '2026-06-24T12:30:00.000Z',
+    });
+    scheduleMaintenanceWindow({
+      title: 'Follow-up patch',
+      startsAt: '2026-06-25T02:00:00.000Z',
+      endsAt: '2026-06-25T03:00:00.000Z',
+    });
+
+    expect(getActiveMaintenanceWindow(now)?.id).toBe(active.id);
+    expect(getNextMaintenanceWindow(now)?.title).toBe('Follow-up patch');
+
+    const status = buildMaintenanceStatusPayload(now);
+    expect(status.activeWindow?.title).toBe('DB migration');
+    expect(status.nextWindow?.title).toBe('Follow-up patch');
+    expect(status.serverTime).toBe(now.toISOString());
+  });
+
+  it('enables maintenance mode while an active window is in progress', () => {
+    const now = new Date('2026-06-24T15:00:00.000Z');
+    scheduleMaintenanceWindow({
+      title: 'Planned outage',
+      startsAt: '2026-06-24T14:00:00.000Z',
+      endsAt: '2026-06-24T16:00:00.000Z',
+    });
+
+    syncMaintenanceModeWithWindows(now);
+    expect(getMaintenanceModeState().enabled).toBe(true);
+    expect(getMaintenanceModeState().reason).toContain('Planned outage');
+  });
+
+  it('disables scheduler-driven maintenance after the window ends', () => {
+    scheduleMaintenanceWindow({
+      title: 'Short window',
+      startsAt: '2026-06-24T10:00:00.000Z',
+      endsAt: '2026-06-24T10:30:00.000Z',
+    });
+
+    syncMaintenanceModeWithWindows(new Date('2026-06-24T10:15:00.000Z'));
+    expect(getMaintenanceModeState().enabled).toBe(true);
+
+    syncMaintenanceModeWithWindows(new Date('2026-06-24T10:45:00.000Z'));
+    expect(getMaintenanceModeState().enabled).toBe(false);
+  });
+
+  it('rejects windows where endsAt is not after startsAt', () => {
+    expect(() =>
+      scheduleMaintenanceWindow({
+        title: 'Invalid',
+        startsAt: '2026-06-25T12:00:00.000Z',
+        endsAt: '2026-06-25T11:00:00.000Z',
+      }),
+    ).toThrow(/endsAt must be after startsAt/);
+  });
+
+  it('cancels a scheduled window by id', () => {
+    const window = scheduleMaintenanceWindow({
+      title: 'Cancel me',
+      startsAt: '2026-07-01T00:00:00.000Z',
+      endsAt: '2026-07-01T01:00:00.000Z',
+    });
+
+    expect(cancelMaintenanceWindow(window.id)).toBe(true);
+    expect(cancelMaintenanceWindow('missing')).toBe(false);
+    expect(getNextMaintenanceWindow(new Date('2026-06-24T00:00:00.000Z'))).toBeNull();
+  });
+
+  describe('HTTP endpoints', () => {
+    it('GET /maintenance/status is public and returns active/next windows', async () => {
+      const res = await request(app).get('/maintenance/status');
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('maintenanceMode');
+      expect(res.body).toHaveProperty('activeWindow');
+      expect(res.body).toHaveProperty('nextWindow');
+      expect(res.body).toHaveProperty('serverTime');
+    });
+
+    it('POST /admin/maintenance/windows schedules a window', async () => {
+      const res = await request(app)
+        .post('/admin/maintenance/windows')
+        .set(AUTH_HEADER)
+        .send({
+          title: 'Upgrade',
+          reason: 'Node bump',
+          startsAt: '2026-08-01T01:00:00.000Z',
+          endsAt: '2026-08-01T02:00:00.000Z',
+        });
+
+      expect(res.status).toBe(201);
+      expect(res.body.window.title).toBe('Upgrade');
+    });
+
+    it('GET /admin/maintenance/windows lists scheduled windows', async () => {
+      await request(app)
+        .post('/admin/maintenance/windows')
+        .set(AUTH_HEADER)
+        .send({
+          title: 'Listed window',
+          startsAt: '2026-09-01T01:00:00.000Z',
+          endsAt: '2026-09-01T02:00:00.000Z',
+        });
+
+      const res = await request(app).get('/admin/maintenance/windows').set(AUTH_HEADER);
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body.windows)).toBe(true);
+      expect(res.body.windows.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('allows GET /maintenance/status during active maintenance', async () => {
+      updateMaintenanceModeState({ enabled: true });
+      const res = await request(app).get('/maintenance/status');
+      expect(res.status).toBe(200);
+    });
+  });
+
+  it('starts and stops the background scheduler', () => {
+    const stop = startMaintenanceWindowScheduler(60_000);
+    expect(typeof stop).toBe('function');
+    stop();
+  });
+});

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -121,6 +121,13 @@ import {
   logMaintenanceTransition,
 } from './maintenanceMode';
 import {
+  buildMaintenanceStatusPayload,
+  cancelMaintenanceWindow,
+  listMaintenanceWindows,
+  scheduleMaintenanceWindow,
+  startMaintenanceWindowScheduler,
+} from './maintenanceWindow';
+import {
   buildExportMetadataHeaderValue,
   getExportJobById,
   listExportJobs,
@@ -623,6 +630,14 @@ app.get('/ready', async (_req: Request, res: Response) => {
   res.status(isReady ? 200 : 503).json(readiness);
 });
 
+/**
+ * GET /maintenance/status
+ * Public read-only maintenance window visibility (Issue #714).
+ */
+app.get('/maintenance/status', (_req: Request, res: Response) => {
+  res.status(200).json(buildMaintenanceStatusPayload());
+});
+
 // ─── Versioned API v1 Router ──────────────────────────────────────────────
 const apiV1 = express.Router();
 app.use('/api/v1', apiV1);
@@ -1044,6 +1059,78 @@ app.post('/admin/maintenance', validateApiKey, async (req: Request, res: Respons
     maintenance: next,
     timestamp: new Date().toISOString(),
     receipt,
+  });
+});
+
+/**
+ * GET /admin/maintenance/windows - list scheduled maintenance windows
+ */
+app.get('/admin/maintenance/windows', validateApiKey, (_req: Request, res: Response) => {
+  res.status(200).json({
+    windows: listMaintenanceWindows(),
+    timestamp: new Date().toISOString(),
+  });
+});
+
+/**
+ * POST /admin/maintenance/windows - schedule a maintenance window
+ * Body: { title: string, reason?: string, startsAt: string, endsAt: string }
+ */
+app.post('/admin/maintenance/windows', validateApiKey, (req: Request, res: Response) => {
+  const { title, reason, startsAt, endsAt } = req.body;
+  if (typeof title !== 'string' || !title.trim()) {
+    res.status(400).json({
+      error: 'Bad Request',
+      status: 400,
+      message: '`title` (string) is required',
+    });
+    return;
+  }
+  if (typeof startsAt !== 'string' || typeof endsAt !== 'string') {
+    res.status(400).json({
+      error: 'Bad Request',
+      status: 400,
+      message: '`startsAt` and `endsAt` (ISO strings) are required',
+    });
+    return;
+  }
+
+  try {
+    const actor = resolveActingAdminAddress(req);
+    const window = scheduleMaintenanceWindow({
+      title,
+      reason: typeof reason === 'string' ? reason : undefined,
+      startsAt,
+      endsAt,
+      actor,
+    });
+    res.status(201).json({ window, timestamp: new Date().toISOString() });
+  } catch (error) {
+    res.status(400).json({
+      error: 'Bad Request',
+      status: 400,
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+});
+
+/**
+ * DELETE /admin/maintenance/windows/:windowId - cancel a scheduled window
+ */
+app.delete('/admin/maintenance/windows/:windowId', validateApiKey, (req: Request, res: Response) => {
+  const cancelled = cancelMaintenanceWindow(req.params.windowId);
+  if (!cancelled) {
+    res.status(404).json({
+      error: 'Not Found',
+      status: 404,
+      message: 'Maintenance window not found',
+    });
+    return;
+  }
+  res.status(200).json({
+    cancelled: true,
+    windowId: req.params.windowId,
+    timestamp: new Date().toISOString(),
   });
 });
 
@@ -3245,6 +3332,11 @@ if (process.env.NODE_ENV !== 'test') {
   const stopApyScheduler = startApySnapshotScheduler();
   shutdownHandler.onShutdown(async () => {
     stopApyScheduler();
+  });
+
+  const stopMaintenanceWindowScheduler = startMaintenanceWindowScheduler();
+  shutdownHandler.onShutdown(async () => {
+    stopMaintenanceWindowScheduler();
   });
 
   // ─── Database Backup Scheduler (Issue #376) ──────────────────────────────────

--- a/backend/src/maintenanceMode.ts
+++ b/backend/src/maintenanceMode.ts
@@ -76,6 +76,7 @@ function isMaintenanceBypassPath(pathname: string): boolean {
     pathname === '/health' ||
     pathname === '/ready' ||
     pathname === '/metrics' ||
+    pathname === '/maintenance/status' ||
     pathname.startsWith('/admin/maintenance')
   );
 }

--- a/backend/src/maintenanceWindow.ts
+++ b/backend/src/maintenanceWindow.ts
@@ -1,0 +1,230 @@
+/**
+ * Structured maintenance window scheduler (Issue #714).
+ *
+ * Schedules future maintenance windows and exposes active/next visibility via a
+ * read-only status endpoint. When a window is active, maintenance mode is
+ * enabled automatically.
+ */
+
+import {
+  getMaintenanceModeState,
+  updateMaintenanceModeState,
+  logMaintenanceTransition,
+} from './maintenanceMode';
+import { logger } from './middleware/structuredLogging';
+
+export interface MaintenanceWindow {
+  id: string;
+  title: string;
+  reason?: string;
+  startsAt: string;
+  endsAt: string;
+  createdAt: string;
+  createdBy?: string;
+}
+
+export interface MaintenanceWindowInput {
+  title: string;
+  reason?: string;
+  startsAt: string;
+  endsAt: string;
+  actor?: string;
+}
+
+export interface MaintenanceStatusPayload {
+  maintenanceMode: {
+    enabled: boolean;
+    reason?: string;
+    updatedAt: string;
+    retryAfterSeconds: number;
+  };
+  activeWindow: MaintenanceWindow | null;
+  nextWindow: MaintenanceWindow | null;
+  serverTime: string;
+}
+
+const windows: MaintenanceWindow[] = [];
+let schedulerHandle: ReturnType<typeof setInterval> | null = null;
+let lastAppliedWindowId: string | null = null;
+
+const DEFAULT_POLL_INTERVAL_MS = parseInt(
+  process.env.MAINTENANCE_WINDOW_POLL_MS || '30000',
+  10,
+);
+
+function parseIso(value: string): Date {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`Invalid ISO timestamp: ${value}`);
+  }
+  return parsed;
+}
+
+function generateWindowId(): string {
+  return `mw_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export function resetMaintenanceWindowsForTests(): void {
+  windows.length = 0;
+  lastAppliedWindowId = null;
+}
+
+export function listMaintenanceWindows(): MaintenanceWindow[] {
+  return [...windows].sort((a, b) => a.startsAt.localeCompare(b.startsAt));
+}
+
+export function scheduleMaintenanceWindow(input: MaintenanceWindowInput): MaintenanceWindow {
+  const startsAt = parseIso(input.startsAt);
+  const endsAt = parseIso(input.endsAt);
+
+  if (endsAt.getTime() <= startsAt.getTime()) {
+    throw new Error('endsAt must be after startsAt');
+  }
+
+  const window: MaintenanceWindow = {
+    id: generateWindowId(),
+    title: input.title.trim(),
+    reason: input.reason?.trim() || undefined,
+    startsAt: startsAt.toISOString(),
+    endsAt: endsAt.toISOString(),
+    createdAt: new Date().toISOString(),
+    createdBy: input.actor,
+  };
+
+  windows.push(window);
+  windows.sort((a, b) => a.startsAt.localeCompare(b.startsAt));
+  return window;
+}
+
+export function cancelMaintenanceWindow(windowId: string): boolean {
+  const index = windows.findIndex((entry) => entry.id === windowId);
+  if (index === -1) {
+    return false;
+  }
+  windows.splice(index, 1);
+  if (lastAppliedWindowId === windowId) {
+    lastAppliedWindowId = null;
+  }
+  return true;
+}
+
+function isWindowActive(window: MaintenanceWindow, now: Date): boolean {
+  const start = parseIso(window.startsAt).getTime();
+  const end = parseIso(window.endsAt).getTime();
+  const ts = now.getTime();
+  return ts >= start && ts < end;
+}
+
+export function getActiveMaintenanceWindow(now = new Date()): MaintenanceWindow | null {
+  return listMaintenanceWindows().find((window) => isWindowActive(window, now)) ?? null;
+}
+
+export function getNextMaintenanceWindow(now = new Date()): MaintenanceWindow | null {
+  const ts = now.getTime();
+  return (
+    listMaintenanceWindows().find((window) => parseIso(window.startsAt).getTime() > ts) ?? null
+  );
+}
+
+export function buildMaintenanceStatusPayload(now = new Date()): MaintenanceStatusPayload {
+  const mode = getMaintenanceModeState();
+  return {
+    maintenanceMode: {
+      enabled: mode.enabled,
+      reason: mode.reason,
+      updatedAt: mode.updatedAt,
+      retryAfterSeconds: mode.retryAfterSeconds,
+    },
+    activeWindow: getActiveMaintenanceWindow(now),
+    nextWindow: getNextMaintenanceWindow(now),
+    serverTime: now.toISOString(),
+  };
+}
+
+function retryAfterSecondsForWindow(window: MaintenanceWindow, now: Date): number {
+  const endMs = parseIso(window.endsAt).getTime();
+  const remaining = Math.max(1, Math.ceil((endMs - now.getTime()) / 1000));
+  return remaining;
+}
+
+/** Apply scheduled window state to maintenance mode. */
+export function syncMaintenanceModeWithWindows(now = new Date()): void {
+  const active = getActiveMaintenanceWindow(now);
+  const previous = getMaintenanceModeState();
+
+  if (active) {
+    const reason = active.reason || `Scheduled maintenance: ${active.title}`;
+    const retryAfterSeconds = retryAfterSecondsForWindow(active, now);
+
+    if (!previous.enabled || lastAppliedWindowId !== active.id) {
+      updateMaintenanceModeState({
+        enabled: true,
+        reason,
+        retryAfterSeconds,
+        actor: 'maintenance-window-scheduler',
+      });
+      logMaintenanceTransition({
+        enabled: true,
+        actor: 'maintenance-window-scheduler',
+        reason,
+        retryAfterSeconds,
+        previousEnabled: previous.enabled,
+      });
+      lastAppliedWindowId = active.id;
+      logger.log('info', 'Maintenance window activated', {
+        windowId: active.id,
+        title: active.title,
+        endsAt: active.endsAt,
+      });
+    } else if (previous.retryAfterSeconds !== retryAfterSeconds) {
+      updateMaintenanceModeState({ retryAfterSeconds, actor: 'maintenance-window-scheduler' });
+    }
+    return;
+  }
+
+  if (lastAppliedWindowId && previous.enabled && previous.updatedBy === 'maintenance-window-scheduler') {
+    updateMaintenanceModeState({
+      enabled: false,
+      reason: undefined,
+      actor: 'maintenance-window-scheduler',
+    });
+    logMaintenanceTransition({
+      enabled: false,
+      actor: 'maintenance-window-scheduler',
+      retryAfterSeconds: previous.retryAfterSeconds,
+      previousEnabled: true,
+    });
+    logger.log('info', 'Maintenance window ended', { windowId: lastAppliedWindowId });
+    lastAppliedWindowId = null;
+  }
+}
+
+export function startMaintenanceWindowScheduler(
+  pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
+): () => void {
+  if (schedulerHandle) {
+    clearInterval(schedulerHandle);
+  }
+
+  syncMaintenanceModeWithWindows();
+  schedulerHandle = setInterval(() => {
+    try {
+      syncMaintenanceModeWithWindows();
+    } catch (error) {
+      logger.log('error', 'Maintenance window scheduler tick failed', {
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }, pollIntervalMs);
+
+  if (schedulerHandle.unref) {
+    schedulerHandle.unref();
+  }
+
+  return () => {
+    if (schedulerHandle) {
+      clearInterval(schedulerHandle);
+      schedulerHandle = null;
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- Adds structured maintenance window scheduling with admin CRUD endpoints
- Automatically enables maintenance mode during active windows via background scheduler
- Exposes public `GET /maintenance/status` with active/next window visibility

## Test plan
- [x] `npm test -- src/__tests__/issues714.test.ts`

Closes #714