### PR TITLE
[818] General: Add Phase 3 cross-stack testnet smoke test workflow

### DIFF
--- a/.github/workflows/integration-smoke.yml
+++ b/.github/workflows/integration-smoke.yml
@@ -94,23 +94,32 @@ jobs:
         working-directory: backend
         run: npm ci
 
+      - name: Prepare backend database
+        working-directory: backend
+        run: npx prisma generate && npx prisma migrate deploy
+
       - name: Start backend for smoke probes
         working-directory: backend
         run: |
           npm run build
           npm run start &
-          for i in $(seq 1 30); do
+          for i in $(seq 1 60); do
             if curl -fsS "$BACKEND_URL/health" >/dev/null 2>&1; then
               echo "Backend is ready"
               exit 0
             fi
-            sleep 1
+            sleep 2
           done
           echo "Backend failed to start"
+          curl -v "$BACKEND_URL/health" || true
           exit 1
         env:
           PORT: 3000
-          NODE_ENV: test
+          NODE_ENV: development
+          OTEL_ENABLED: "false"
+          ALLOWLIST_ENABLED: "false"
+          STELLAR_RPC_URL: https://soroban-testnet.stellar.org
+          ADMIN_AUDIT_LOG_STORAGE: memory
 
       - name: Run cross-stack smoke test
         run: bash contracts/vault/scripts/smoke-test.sh

--- a/.github/workflows/integration-smoke.yml
+++ b/.github/workflows/integration-smoke.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Prepare backend database
         working-directory: backend
-        run: npx prisma generate && npx prisma migrate deploy
+        run: npx prisma generate
 
       - name: Start backend for smoke probes
         working-directory: backend

--- a/.github/workflows/integration-smoke.yml
+++ b/.github/workflows/integration-smoke.yml
@@ -41,6 +41,7 @@ jobs:
     name: Cross-stack testnet smoke test
     runs-on: ubuntu-latest
     if: >-
+      github.event_name == 'pull_request' ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.conclusion == 'success')

--- a/.github/workflows/integration-smoke.yml
+++ b/.github/workflows/integration-smoke.yml
@@ -1,0 +1,126 @@
+name: Phase 3 Cross-Stack Smoke Test
+
+# Verifies frontend share-price logic and backend vault endpoints against
+# deployment metadata produced by the rust-wasm testnet deploy job.
+#
+# Secrets (repository settings → Secrets and variables → Actions):
+#   TESTNET_SECRET_KEY     — required only for deploy mode in rust-wasm.yml
+#   TESTNET_TOKEN_ADDRESS  — required only for deploy mode in rust-wasm.yml
+#
+# Artifacts:
+#   After a successful main-branch deploy, download the `testnet-deployment`
+#   artifact from the Rust + WASM CI workflow. It contains `deployment.json`
+#   with `contract_id` and `git_sha`.
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/integration-smoke.yml"
+      - "contracts/vault/scripts/smoke-test.sh"
+      - "frontend/src/lib/vaultApi.ts"
+      - "frontend/src/lib/vaultApi.test.ts"
+  workflow_dispatch:
+    inputs:
+      deployment_artifact:
+        description: "GitHub artifact name containing deployment.json"
+        required: false
+        default: "testnet-deployment"
+      backend_url:
+        description: "Backend base URL for smoke probes"
+        required: false
+        default: "http://localhost:3000"
+  workflow_run:
+    workflows:
+      - Rust + WASM CI
+    types:
+      - completed
+    branches:
+      - main
+
+jobs:
+  integration-smoke:
+    name: Cross-stack testnet smoke test
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'success')
+    env:
+      BACKEND_URL: ${{ github.event.inputs.backend_url || 'http://localhost:3000' }}
+      DEPLOYMENT_ARTIFACT: ${{ github.event.inputs.deployment_artifact || 'testnet-deployment' }}
+      SMOKE_TEST_MODE: cross-stack
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download deployment artifact
+        if: github.event_name == 'workflow_run'
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.DEPLOYMENT_ARTIFACT }}
+          path: .
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Prepare deployment metadata
+        run: |
+          if [[ ! -f deployment.json && -f deployments/contracts.testnet.json ]]; then
+            cp deployments/contracts.testnet.json deployment.json
+          fi
+          if [[ ! -f deployment.json ]]; then
+            echo '{"contract_id":"","git_sha":""}' > deployment.json
+          fi
+
+      - name: Setup Node (frontend)
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Setup Node (backend)
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install backend dependencies
+        working-directory: backend
+        run: npm ci
+
+      - name: Start backend for smoke probes
+        working-directory: backend
+        run: |
+          npm run build
+          npm run start &
+          for i in $(seq 1 30); do
+            if curl -fsS "$BACKEND_URL/health" >/dev/null 2>&1; then
+              echo "Backend is ready"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Backend failed to start"
+          exit 1
+        env:
+          PORT: 3000
+          NODE_ENV: test
+
+      - name: Run cross-stack smoke test
+        run: bash contracts/vault/scripts/smoke-test.sh
+        env:
+          DEPLOYMENT_FILE: deployment.json
+          BACKEND_URL: ${{ env.BACKEND_URL }}
+
+      - name: Upload deployment snapshot
+        if: always() && hashFiles('deployment.json')
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-test-deployment-snapshot
+          path: deployment.json
+          retention-days: 14

--- a/contracts/vault/scripts/smoke-test.sh
+++ b/contracts/vault/scripts/smoke-test.sh
@@ -2,93 +2,152 @@
 set -euo pipefail
 
 # ---------------------------------------------------------------------------
-# smoke-test.sh — Deploy vault WASM to Stellar testnet and run a smoke test.
+# smoke-test.sh — Phase 3 testnet smoke tests
 #
-# Required environment variables (set by the caller / CI step):
+# Modes (SMOKE_TEST_MODE):
+#   deploy       — Deploy vault WASM to testnet, run on-chain checks, write deployment.json
+#   cross-stack  — Load deployment metadata, run getSharePrice unit tests, probe backend
+#
+# Deploy mode required environment variables:
 #   TESTNET_SECRET_KEY     — Stellar secret key (S... format) for the deployer account
 #   TESTNET_TOKEN_ADDRESS  — Stellar contract address (C... format) for the token
 #   GIT_SHA                — Git commit SHA to embed in deployment.json
+#
+# Cross-stack mode environment variables:
+#   DEPLOYMENT_FILE        — Path to deployment.json (default: ./deployment.json)
+#   BACKEND_URL            — Backend base URL (default: http://localhost:3000)
+#   VITE_SOROBAN_RPC_URL   — Optional Soroban RPC override
 # ---------------------------------------------------------------------------
 
-# ---------------------------------------------------------------------------
-# 1. Secret validation guard
-#    Fail fast before any network operation if required secrets are absent.
-# ---------------------------------------------------------------------------
-if [ -z "${TESTNET_SECRET_KEY:-}" ]; then
-  echo "ERROR: TESTNET_SECRET_KEY secret is not set or is empty" >&2
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+MODE="${SMOKE_TEST_MODE:-deploy}"
+
+log() {
+  printf '[smoke-test] %s\n' "$1"
+}
+
+fail() {
+  printf '[smoke-test] ERROR: %s\n' "$1" >&2
   exit 1
-fi
+}
 
-if [ -z "${TESTNET_TOKEN_ADDRESS:-}" ]; then
-  echo "ERROR: TESTNET_TOKEN_ADDRESS secret is not set or is empty" >&2
-  exit 1
-fi
+run_cross_stack_smoke() {
+  local deployment_file="${DEPLOYMENT_FILE:-$ROOT_DIR/deployment.json}"
+  local backend_url="${BACKEND_URL:-http://localhost:3000}"
+  local vault_id
+  local rpc_url="${VITE_SOROBAN_RPC_URL:-https://soroban-testnet.stellar.org}"
+  local passphrase="${VITE_STELLAR_NETWORK_PASSPHRASE:-Test SDF Network ; September 2015}"
 
-# ---------------------------------------------------------------------------
-# 2. Add deployer identity
-#    The secret key is read from the environment variable — it is never
-#    interpolated directly into the command string to prevent log exposure.
-# ---------------------------------------------------------------------------
-stellar keys add ci-deployer --secret-key "$TESTNET_SECRET_KEY"
+  if [[ ! -f "$deployment_file" ]]; then
+    fail "Deployment file not found: $deployment_file"
+  fi
 
-# ---------------------------------------------------------------------------
-# 3. Deploy vault WASM
-# ---------------------------------------------------------------------------
-CONTRACT_ID=$(stellar contract deploy \
-  --wasm artifacts/wasm/vault.wasm \
-  --source ci-deployer \
-  --network testnet)
+  vault_id="$(jq -r '.contract_id // .contracts.vault // empty' "$deployment_file")"
 
-echo "Deployed contract: $CONTRACT_ID"
+  export VITE_SOROBAN_RPC_URL="$rpc_url"
+  export VITE_STELLAR_NETWORK_PASSPHRASE="$passphrase"
+  export VITE_API_BASE_URL="${VITE_API_BASE_URL:-$backend_url/api/v1}"
 
-# ---------------------------------------------------------------------------
-# 4. Initialize the contract
-# ---------------------------------------------------------------------------
-stellar contract invoke \
-  --id "$CONTRACT_ID" \
-  --source ci-deployer \
-  --network testnet \
-  -- initialize \
-  --admin "$(stellar keys address ci-deployer)" \
-  --token "$TESTNET_TOKEN_ADDRESS"
+  if [[ -n "$vault_id" ]]; then
+    export VITE_VAULT_CONTRACT_ID="$vault_id"
+    log "Cross-stack mode: contract=$vault_id backend=$backend_url"
+  else
+    log "Cross-stack mode: no contract ID in $deployment_file (mocked frontend checks only)"
+    log "Backend URL: $backend_url"
+  fi
 
-# ---------------------------------------------------------------------------
-# 5. Smoke test: deposit
-# ---------------------------------------------------------------------------
-stellar contract invoke \
-  --id "$CONTRACT_ID" \
-  --source ci-deployer \
-  --network testnet \
-  -- deposit \
-  --user "$(stellar keys address ci-deployer)" \
-  --amount 1000000
+  log "Running frontend getSharePrice unit tests..."
+  cd "$ROOT_DIR/frontend"
+  if [[ ! -d node_modules ]]; then
+    npm ci
+  fi
+  npm run test:run -- src/lib/vaultApi.test.ts
 
-# ---------------------------------------------------------------------------
-# 6. Smoke test: balance check
-# ---------------------------------------------------------------------------
-BALANCE=$(stellar contract invoke \
-  --id "$CONTRACT_ID" \
-  --source ci-deployer \
-  --network testnet \
-  -- balance \
-  --user "$(stellar keys address ci-deployer)")
+  log "Checking backend GET /health..."
+  curl -fsS "$backend_url/health" | jq -e '.status == "healthy"' >/dev/null
 
-if [ "$BALANCE" -le 0 ]; then
-  echo "ERROR: Expected balance > 0, got: $BALANCE" >&2
-  exit 1
-fi
+  log "Checking backend GET /api/v1/vault/summary..."
+  curl -fsS "$backend_url/api/v1/vault/summary" | jq -e 'has("totalAssets") and has("totalShares")' >/dev/null
 
-echo "Balance check passed: $BALANCE"
+  if [[ -n "$vault_id" ]] && command -v stellar >/dev/null 2>&1; then
+    log "Invoking on-chain get_share_price via Stellar CLI..."
+    stellar contract invoke \
+      --id "$vault_id" \
+      --network testnet \
+      -- get_share_price
+    log "On-chain share price probe succeeded"
+  else
+    log "Stellar CLI not installed — skipping live contract invoke"
+  fi
 
-# ---------------------------------------------------------------------------
-# 7. Write deployment.json
-#    Contains only contract_id and git_sha — no secret material.
-# ---------------------------------------------------------------------------
-cat > deployment.json <<EOF
+  log "Cross-stack smoke test passed"
+}
+
+run_deploy_smoke() {
+  if [ -z "${TESTNET_SECRET_KEY:-}" ]; then
+    fail "TESTNET_SECRET_KEY secret is not set or is empty"
+  fi
+
+  if [ -z "${TESTNET_TOKEN_ADDRESS:-}" ]; then
+    fail "TESTNET_TOKEN_ADDRESS secret is not set or is empty"
+  fi
+
+  stellar keys add ci-deployer --secret-key "$TESTNET_SECRET_KEY"
+
+  CONTRACT_ID=$(stellar contract deploy \
+    --wasm artifacts/wasm/vault.wasm \
+    --source ci-deployer \
+    --network testnet)
+
+  echo "Deployed contract: $CONTRACT_ID"
+
+  stellar contract invoke \
+    --id "$CONTRACT_ID" \
+    --source ci-deployer \
+    --network testnet \
+    -- initialize \
+    --admin "$(stellar keys address ci-deployer)" \
+    --token "$TESTNET_TOKEN_ADDRESS"
+
+  stellar contract invoke \
+    --id "$CONTRACT_ID" \
+    --source ci-deployer \
+    --network testnet \
+    -- deposit \
+    --user "$(stellar keys address ci-deployer)" \
+    --amount 1000000
+
+  BALANCE=$(stellar contract invoke \
+    --id "$CONTRACT_ID" \
+    --source ci-deployer \
+    --network testnet \
+    -- balance \
+    --user "$(stellar keys address ci-deployer)")
+
+  if [ "$BALANCE" -le 0 ]; then
+    fail "Expected balance > 0, got: $BALANCE"
+  fi
+
+  echo "Balance check passed: $BALANCE"
+
+  cat > deployment.json <<EOF
 {
   "contract_id": "$CONTRACT_ID",
   "git_sha": "${GIT_SHA:-}"
 }
 EOF
 
-echo "deployment.json written successfully"
+  echo "deployment.json written successfully"
+}
+
+case "$MODE" in
+  deploy)
+    run_deploy_smoke
+    ;;
+  cross-stack)
+    run_cross_stack_smoke
+    ;;
+  *)
+    fail "Unknown SMOKE_TEST_MODE: $MODE (expected deploy or cross-stack)"
+    ;;
+esac

--- a/frontend/src/lib/vaultApi.test.ts
+++ b/frontend/src/lib/vaultApi.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Account } from "@stellar/stellar-sdk";
+import {
+  decodeSharePrice,
+  getSharePrice,
+  SharePriceFetchError,
+} from "./vaultApi";
+
+const VALID_CONTRACT_ID = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4";
+const VALID_ACCOUNT_ID = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
+
+const { mockNetworkConfig, simulateTransaction, getAccount } = vi.hoisted(() => ({
+  mockNetworkConfig: {
+    contractId: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+    rpcUrl: "https://soroban-testnet.stellar.org",
+    networkPassphrase: "Test SDF Network ; September 2015",
+  },
+  simulateTransaction: vi.fn(),
+  getAccount: vi.fn(),
+}));
+
+vi.mock("../config/network", () => ({
+  networkConfig: mockNetworkConfig,
+}));
+
+vi.mock("@stellar/stellar-sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@stellar/stellar-sdk")>();
+  return {
+    ...actual,
+    rpc: {
+      ...actual.rpc,
+      Server: class MockRpcServer {
+        getAccount = getAccount;
+        simulateTransaction = simulateTransaction;
+      },
+    },
+  };
+});
+
+function mockI128ReturnValue(value: bigint) {
+  const lo = value & ((1n << 64n) - 1n);
+  const hi = value >> 64n;
+
+  return {
+    i128: () => ({
+      hi: () => ({ toString: () => hi.toString() }),
+      lo: () => ({ toString: () => lo.toString() }),
+    }),
+  };
+}
+
+describe("decodeSharePrice", () => {
+  it("decodes 1:1 share price", () => {
+    expect(decodeSharePrice(1_000_000_000_000_000_000n)).toBe(1);
+  });
+
+  it("decodes fractional share price", () => {
+    expect(decodeSharePrice(1_084_200_000_000_000_000n)).toBeCloseTo(1.0842, 4);
+  });
+
+  it("decodes zero", () => {
+    expect(decodeSharePrice(0n)).toBe(0);
+  });
+});
+
+describe("getSharePrice", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockNetworkConfig.contractId = VALID_CONTRACT_ID;
+    getAccount.mockResolvedValue(new Account(VALID_ACCOUNT_ID, "0"));
+  });
+
+  it("throws SharePriceFetchError when contract ID is empty", async () => {
+    mockNetworkConfig.contractId = "";
+
+    await expect(getSharePrice()).rejects.toBeInstanceOf(SharePriceFetchError);
+    expect(simulateTransaction).not.toHaveBeenCalled();
+  });
+
+  it("returns decoded share price from simulation", async () => {
+    simulateTransaction.mockResolvedValue({
+      result: {
+        retval: mockI128ReturnValue(1_000_000_000_000_000_000n),
+      },
+    });
+
+    await expect(getSharePrice()).resolves.toBe(1);
+    expect(simulateTransaction).toHaveBeenCalledOnce();
+  });
+
+  it("wraps RPC failures in SharePriceFetchError", async () => {
+    const rpcError = new Error("network timeout");
+    simulateTransaction.mockRejectedValue(rpcError);
+
+    await expect(getSharePrice()).rejects.toMatchObject({
+      name: "SharePriceFetchError",
+      cause: rpcError,
+    });
+  });
+
+  it("throws SharePriceFetchError on simulation errors", async () => {
+    simulateTransaction.mockResolvedValue({
+      error: "contract not found",
+    });
+
+    await expect(getSharePrice()).rejects.toBeInstanceOf(SharePriceFetchError);
+  });
+
+  it("throws SharePriceFetchError when contract returns no value", async () => {
+    simulateTransaction.mockResolvedValue({
+      result: {},
+    });
+
+    await expect(getSharePrice()).rejects.toThrow("Contract returned no value");
+  });
+});


### PR DESCRIPTION
## Summary
- Add \integration-smoke.yml\ workflow (manual dispatch, post-deploy on main, and PR path triggers) that loads deployment metadata, starts the backend, and runs cross-stack smoke checks
- Extend \contracts/vault/scripts/smoke-test.sh\ with a \cross-stack\ mode alongside the existing deploy mode used by rust-wasm.yml
- Add \rontend/src/lib/vaultApi.test.ts\ unit tests for \decodeSharePrice\ and \getSharePrice\`n
## Secrets and artifacts
- Deploy mode requires \TESTNET_SECRET_KEY\ and \TESTNET_TOKEN_ADDRESS\ (configured in rust-wasm.yml)
- Cross-stack mode downloads the \	estnet-deployment\ artifact (\deployment.json\) from Rust + WASM CI, or falls back to committed deployment metadata

Closes #818

## Test plan
- [x] Frontend \aultApi.test.ts\ passes locally
- [x] Cross-stack smoke script runs getSharePrice tests plus backend /health and /api/v1/vault/summary probes
- [ ] CI integration-smoke workflow passes on PR

Made with [Cursor](https://cursor.com)