### PR TITLE
docs(api): add deterministic pagination behavior examples for API consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,13 @@ npm run docs:api
 
 See `docs/api/README.md` for output locations. Integrators should also read
 [`docs/api/ERROR_CODE_CATALOG.md`](docs/api/ERROR_CODE_CATALOG.md) for error codes
-and remediation guidance.
+and remediation guidance, and [`docs/api/PAGINATION.md`](docs/api/PAGINATION.md) for
+deterministic cursor paging examples.
+
+**Pagination consumer examples:**
+
+- [TypeScript](./docs/examples/api_pagination_consumer.ts)
+- [Python](./docs/examples/api_pagination_consumer.py)
 
 ## Webhook Integration
 

--- a/docs/api/PAGINATION.md
+++ b/docs/api/PAGINATION.md
@@ -6,6 +6,175 @@ This document describes the standardized pagination conventions used across all 
 
 All list endpoints follow consistent pagination patterns to make API consumption predictable and easy to use.
 
+For runnable consumer examples, see:
+
+- [TypeScript pagination consumer](../examples/api_pagination_consumer.ts)
+- [Python pagination consumer](../examples/api_pagination_consumer.py)
+
+## Deterministic Paging Behavior
+
+YieldVault list endpoints use **stable sort keys** and **opaque cursors** so API consumers can page through results without duplicates or gaps when the underlying dataset is unchanged.
+
+### Guarantees
+
+| Behavior | What it means for consumers |
+|----------|-----------------------------|
+| Stable ordering | Repeating the same query (same filters, `limit`, `sortBy`, `sortOrder`, and no `cursor`) returns the same item order. |
+| Cursor advancement | `nextCursor` always refers to the **last item on the current page**. The next request starts immediately after that anchor. |
+| No page overlap | IDs returned on page *N* never appear again on page *N+1* when you only advance with `nextCursor`. |
+| Opaque cursors | Treat `nextCursor` as an opaque token. Do not parse or construct cursors manually. |
+| Invalid cursors | Malformed or unknown cursors return an empty page (`data: []`, `hasNextPage: false`) on public list routes, or `400 Bad Request` on strict admin routes such as webhook delivery history. |
+
+### Sort keys by endpoint
+
+| Endpoint | Default sort | Cursor anchor |
+|----------|--------------|---------------|
+| `GET /api/transactions` | `timestamp` desc | Base64url-encoded transaction `id` |
+| `GET /api/portfolio/holdings` | `valueUsd` desc | Base64url-encoded holding `id` |
+| `GET /api/vault/history` | `date` desc | Base64url-encoded history point `id` |
+| `GET /admin/webhooks/deliveries` | `createdAt` desc, then `id` desc | Base64url-encoded JSON `{ createdAt, id }` |
+
+### Worked example: three-page walkthrough
+
+Assume seven transactions sorted by `timestamp` descending. Request `limit=3`:
+
+**Request 1 — first page**
+
+```http
+GET /api/transactions?limit=3&sortBy=timestamp&sortOrder=desc
+```
+
+```json
+{
+  "data": [
+    { "id": "tx-7", "timestamp": "2026-06-26T15:00:00.000Z" },
+    { "id": "tx-6", "timestamp": "2026-06-26T14:00:00.000Z" },
+    { "id": "tx-5", "timestamp": "2026-06-26T13:00:00.000Z" }
+  ],
+  "pagination": {
+    "count": 3,
+    "limit": 3,
+    "total": 7,
+    "nextCursor": "dHgtNQ",
+    "prevCursor": null,
+    "currentPage": null,
+    "totalPages": null,
+    "hasNextPage": true,
+    "hasPrevPage": false
+  },
+  "timestamp": "2026-06-26T16:00:00.000Z"
+}
+```
+
+`nextCursor` is the base64url encoding of the last row's `id` (`tx-5` → `dHgtNQ`).
+
+**Request 2 — forward one page**
+
+```http
+GET /api/transactions?limit=3&sortBy=timestamp&sortOrder=desc&cursor=dHgtNQ
+```
+
+```json
+{
+  "data": [
+    { "id": "tx-4", "timestamp": "2026-06-26T12:00:00.000Z" },
+    { "id": "tx-3", "timestamp": "2026-06-26T11:00:00.000Z" },
+    { "id": "tx-2", "timestamp": "2026-06-26T10:00:00.000Z" }
+  ],
+  "pagination": {
+    "count": 3,
+    "limit": 3,
+    "total": 7,
+    "nextCursor": "dHgtMg",
+    "prevCursor": null,
+    "currentPage": null,
+    "totalPages": null,
+    "hasNextPage": true,
+    "hasPrevPage": true
+  },
+  "timestamp": "2026-06-26T16:00:01.000Z"
+}
+```
+
+**Request 3 — final page**
+
+```http
+GET /api/transactions?limit=3&sortBy=timestamp&sortOrder=desc&cursor=dHgtMg
+```
+
+```json
+{
+  "data": [
+    { "id": "tx-1", "timestamp": "2026-06-26T09:00:00.000Z" }
+  ],
+  "pagination": {
+    "count": 1,
+    "limit": 3,
+    "total": 7,
+    "nextCursor": null,
+    "prevCursor": null,
+    "currentPage": null,
+    "totalPages": null,
+    "hasNextPage": false,
+    "hasPrevPage": true
+  },
+  "timestamp": "2026-06-26T16:00:02.000Z"
+}
+```
+
+Across all three pages the union of IDs is `{tx-7, tx-6, tx-5, tx-4, tx-3, tx-2, tx-1}` with **no duplicates**.
+
+### Sequence diagram
+
+```mermaid
+sequenceDiagram
+  participant Client
+  participant API as YieldVault API
+
+  Client->>API: GET /api/transactions?limit=3
+  API-->>Client: data=[tx-7,tx-6,tx-5], nextCursor=dHgtNQ
+
+  Client->>API: GET /api/transactions?limit=3&cursor=dHgtNQ
+  API-->>Client: data=[tx-4,tx-3,tx-2], nextCursor=dHgtMg
+
+  Client->>API: GET /api/transactions?limit=3&cursor=dHgtMg
+  API-->>Client: data=[tx-1], hasNextPage=false
+```
+
+### Consumer loop (TypeScript)
+
+```typescript
+let cursor: string | undefined;
+
+while (true) {
+  const url = new URL("/api/transactions", "http://localhost:3000");
+  url.searchParams.set("limit", "20");
+  if (cursor) url.searchParams.set("cursor", cursor);
+
+  const page = await fetch(url).then((res) => res.json());
+
+  for (const row of page.data) {
+    processTransaction(row);
+  }
+
+  if (!page.pagination.hasNextPage || !page.pagination.nextCursor) {
+    break;
+  }
+
+  cursor = page.pagination.nextCursor;
+}
+```
+
+See the full runnable example in [`docs/examples/api_pagination_consumer.ts`](../examples/api_pagination_consumer.ts).
+
+### When data changes between requests
+
+Cursor paging is **stable for a fixed dataset**, but new rows can appear while you page:
+
+- **New rows inserted at the top** (newer `timestamp`): already-fetched pages remain valid; you may see new rows only if you restart from the first page.
+- **Do not mix `page` and `cursor`** on the same traversal. Pick one strategy per export job.
+- **Persist the last `nextCursor`** if you need to resume a long export after a network failure.
+
 ## Query Parameters
 
 ### Standard Pagination Parameters
@@ -202,6 +371,11 @@ curl "http://localhost:3000/api/vault/history?from=2026-01-01&to=2026-03-31&limi
 All list endpoints are subject to API rate limiting. See [RATE_LIMITING.md](./RATE_LIMITING.md) for details.
 
 ## Changelog
+
+### Version 1.1.0 (2026-06-26)
+- Add deterministic paging behavior walkthrough with concrete request/response examples
+- Add cursor usage sequence diagram and consumer loop patterns
+- Add runnable TypeScript and Python pagination consumer examples
 
 ### Version 1.0.0 (2026-03-28)
 - Initial pagination conventions

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -98,7 +98,7 @@ User session authentication uses JWT access tokens and refresh tokens.
 
 ### Pagination
 
-All list endpoints support standardized pagination. See [PAGINATION.md](./PAGINATION.md) for detailed documentation.
+All list endpoints support standardized pagination. See [PAGINATION.md](./PAGINATION.md) for detailed documentation, including deterministic paging walkthroughs and cursor usage examples.
 
 **Quick Example:**
 ```bash
@@ -108,6 +108,11 @@ curl "http://localhost:3000/api/transactions?limit=20"
 # Get next page using cursor
 curl "http://localhost:3000/api/transactions?limit=20&cursor=base64encodedcursor"
 ```
+
+**Complete examples:**
+
+- [TypeScript pagination consumer](../examples/api_pagination_consumer.ts)
+- [Python pagination consumer](../examples/api_pagination_consumer.py)
 
 ### Rate Limiting
 

--- a/docs/examples/api_pagination_consumer.py
+++ b/docs/examples/api_pagination_consumer.py
@@ -1,0 +1,113 @@
+"""
+YieldVault API Pagination Consumer Example (Python)
+
+Demonstrates deterministic cursor-based paging against list endpoints such as:
+- GET /api/transactions
+- GET /api/portfolio/holdings
+- GET /api/vault/history
+
+Usage:
+    API_BASE_URL=http://localhost:3000 python docs/examples/api_pagination_consumer.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+API_BASE_URL = os.environ.get("API_BASE_URL", "http://localhost:3000")
+
+
+def build_url(path: str, params: dict[str, Any] | None = None) -> str:
+    query = urllib.parse.urlencode({k: v for k, v in (params or {}).items() if v not in (None, "")})
+    return f"{API_BASE_URL.rstrip('/')}{path}" + (f"?{query}" if query else "")
+
+
+def fetch_page(path: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+    request = urllib.request.Request(build_url(path, params or {}), method="GET")
+    with urllib.request.urlopen(request) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def fetch_all_with_cursor(path: str, params: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    cursor: str | None = None
+
+    while True:
+        page_params = dict(params or {})
+        if cursor:
+            page_params["cursor"] = cursor
+
+        page = fetch_page(path, page_params)
+        for item in page.get("data", []):
+            item_id = item["id"]
+            if item_id in seen_ids:
+                raise RuntimeError(f"Duplicate item detected while paging: {item_id}")
+            seen_ids.add(item_id)
+            items.append(item)
+
+        pagination = page.get("pagination", {})
+        if not pagination.get("hasNextPage") or not pagination.get("nextCursor"):
+            break
+
+        cursor = pagination["nextCursor"]
+
+    return items
+
+
+def assert_deterministic_first_page(path: str, params: dict[str, Any] | None = None) -> None:
+    first = fetch_page(path, params)
+    second = fetch_page(path, params)
+
+    first_ids = [item["id"] for item in first.get("data", [])]
+    second_ids = [item["id"] for item in second.get("data", [])]
+
+    if first_ids != second_ids:
+        raise RuntimeError("First page ordering changed between identical requests")
+
+
+def demonstrate_transaction_paging(limit: int = 5) -> None:
+    print(f"\n=== Cursor paging demo (limit={limit}) ===")
+
+    page1 = fetch_page("/api/transactions", {"limit": limit})
+    page1_ids = [item["id"] for item in page1.get("data", [])]
+    print("Page 1 IDs:", ", ".join(page1_ids))
+    print("nextCursor:", page1.get("pagination", {}).get("nextCursor") or "(none)")
+
+    next_cursor = page1.get("pagination", {}).get("nextCursor")
+    if not next_cursor:
+        print("No additional pages available.")
+        return
+
+    page2 = fetch_page("/api/transactions", {"limit": limit, "cursor": next_cursor})
+    page2_ids = {item["id"] for item in page2.get("data", [])}
+    overlap = [item_id for item_id in page1_ids if item_id in page2_ids]
+    if overlap:
+        raise RuntimeError(f"Pages overlapped: {', '.join(overlap)}")
+
+    print("Page 2 IDs:", ", ".join(sorted(page2_ids)))
+    print("No overlap between page 1 and page 2.")
+
+
+def main() -> None:
+    print(f"Using API base URL: {API_BASE_URL}")
+
+    assert_deterministic_first_page("/api/transactions", {"limit": 5})
+    print("Deterministic first-page check passed.")
+
+    demonstrate_transaction_paging(5)
+
+    items = fetch_all_with_cursor("/api/transactions", {"limit": 20})
+    print(f"Fetched {len(items)} transactions across all pages.")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except urllib.error.URLError as error:
+        raise SystemExit(f"Request failed: {error}") from error

--- a/docs/examples/api_pagination_consumer.ts
+++ b/docs/examples/api_pagination_consumer.ts
@@ -1,0 +1,174 @@
+/**
+ * YieldVault API Pagination Consumer Example (TypeScript)
+ *
+ * Demonstrates deterministic cursor-based paging against list endpoints such as:
+ * - GET /api/transactions
+ * - GET /api/portfolio/holdings
+ * - GET /api/vault/history
+ *
+ * Features:
+ * - Cursor-forward iteration with no duplicate IDs across pages
+ * - Stable replay of the first page for the same query parameters
+ * - Graceful handling of invalid or expired cursors
+ *
+ * Usage:
+ *   API_BASE_URL=http://localhost:3000 npx ts-node docs/examples/api_pagination_consumer.ts
+ */
+
+const API_BASE_URL = process.env.API_BASE_URL ?? "http://localhost:3000";
+
+interface PaginationMeta {
+  count: number;
+  limit: number;
+  total: number | null;
+  nextCursor: string | null;
+  prevCursor: string | null;
+  currentPage: number | null;
+  totalPages: number | null;
+  hasNextPage: boolean;
+  hasPrevPage: boolean;
+}
+
+interface PaginatedResponse<T> {
+  data: T[];
+  pagination: PaginationMeta;
+  timestamp: string;
+}
+
+interface Transaction {
+  id: string;
+  type: string;
+  amount: string;
+  asset: string;
+  timestamp: string;
+  transactionHash: string;
+  walletAddress: string;
+}
+
+type QueryParams = Record<string, string | number | undefined>;
+
+function buildUrl(path: string, params: QueryParams = {}): string {
+  const url = new URL(path, API_BASE_URL);
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== "") {
+      url.searchParams.set(key, String(value));
+    }
+  }
+  return url.toString();
+}
+
+async function fetchPage<T>(
+  path: string,
+  params: QueryParams = {},
+): Promise<PaginatedResponse<T>> {
+  const response = await fetch(buildUrl(path, params));
+  if (!response.ok) {
+    throw new Error(`Request failed (${response.status}): ${await response.text()}`);
+  }
+  return (await response.json()) as PaginatedResponse<T>;
+}
+
+/**
+ * Walk every page using nextCursor until hasNextPage is false.
+ * Returns all collected IDs so callers can verify there are no duplicates.
+ */
+export async function fetchAllWithCursor<T extends { id: string }>(
+  path: string,
+  params: QueryParams = {},
+): Promise<{ items: T[]; ids: string[] }> {
+  const items: T[] = [];
+  const seenIds = new Set<string>();
+  let cursor: string | undefined;
+
+  while (true) {
+    const page = await fetchPage<T>(path, {
+      ...params,
+      ...(cursor ? { cursor } : {}),
+    });
+
+    for (const item of page.data) {
+      if (seenIds.has(item.id)) {
+        throw new Error(`Duplicate item detected while paging: ${item.id}`);
+      }
+      seenIds.add(item.id);
+      items.push(item);
+    }
+
+    if (!page.pagination.hasNextPage || !page.pagination.nextCursor) {
+      break;
+    }
+
+    cursor = page.pagination.nextCursor;
+  }
+
+  return { items, ids: [...seenIds] };
+}
+
+/**
+ * Prove deterministic behavior: two identical first-page requests return the same IDs.
+ */
+export async function assertDeterministicFirstPage(
+  path: string,
+  params: QueryParams = {},
+): Promise<void> {
+  const first = await fetchPage<{ id: string }>(path, params);
+  const second = await fetchPage<{ id: string }>(path, params);
+
+  const firstIds = first.data.map((item) => item.id);
+  const secondIds = second.data.map((item) => item.id);
+
+  if (JSON.stringify(firstIds) !== JSON.stringify(secondIds)) {
+    throw new Error("First page ordering changed between identical requests");
+  }
+}
+
+/**
+ * Demonstrate cursor usage on /api/transactions with a small page size.
+ */
+export async function demonstrateTransactionPaging(limit = 5): Promise<void> {
+  console.log(`\n=== Cursor paging demo (limit=${limit}) ===`);
+
+  const page1 = await fetchPage<Transaction>("/api/transactions", { limit });
+  console.log("Page 1 IDs:", page1.data.map((tx) => tx.id).join(", "));
+  console.log("nextCursor:", page1.pagination.nextCursor ?? "(none)");
+  console.log("hasNextPage:", page1.pagination.hasNextPage);
+
+  if (!page1.pagination.nextCursor) {
+    console.log("No additional pages available.");
+    return;
+  }
+
+  const page2 = await fetchPage<Transaction>("/api/transactions", {
+    limit,
+    cursor: page1.pagination.nextCursor,
+  });
+  console.log("Page 2 IDs:", page2.data.map((tx) => tx.id).join(", "));
+
+  const overlap = page1.data.filter((tx) => page2.data.some((other) => other.id === tx.id));
+  if (overlap.length > 0) {
+    throw new Error(`Pages overlapped: ${overlap.map((tx) => tx.id).join(", ")}`);
+  }
+
+  console.log("No overlap between page 1 and page 2.");
+}
+
+async function main(): Promise<void> {
+  console.log(`Using API base URL: ${API_BASE_URL}`);
+
+  await assertDeterministicFirstPage("/api/transactions", { limit: 5 });
+  console.log("Deterministic first-page check passed.");
+
+  await demonstrateTransactionPaging(5);
+
+  const { ids, items } = await fetchAllWithCursor<Transaction>("/api/transactions", {
+    limit: 20,
+  });
+  console.log(`Fetched ${items.length} transactions across all pages (${ids.length} unique IDs).`);
+}
+
+if (require.main === module) {
+  main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

- Add deterministic paging behavior section to `docs/api/PAGINATION.md` with concrete request/response walkthrough, sequence diagram, and cursor usage guidance
- Add runnable TypeScript and Python pagination consumer examples under `docs/examples/`
- Link the new examples from `docs/api/README.md` and the root `README.md`

## Test plan

- [x] Verified base64url cursor examples (`tx-5` → `dHgtNQ`, `tx-2` → `dHgtMg`)
- [x] Documentation-only change; no runtime code modified
- [ ] Maintainer review of example accuracy against live list endpoints

Closes #764