### PR TITLE
docs(runbooks): add replay procedures for operators and developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,9 @@ YieldVault has comprehensive disaster recovery procedures to ensure system resil
 
 - **RTO (Recovery Time Objective):** 1 hour for critical systems
 - **RPO (Recovery Point Objective):** 15 minutes maximum data loss
-- **Runbooks:** Step-by-step recovery procedures for all failure scenarios
-
-See [Disaster Recovery Runbooks](./docs/runbooks/README.md) for detailed procedures.
+- **Runbooks:** Step-by-step recovery procedures for all failure scenarios. Key runbooks include:
+  - [Disaster Recovery Runbooks Overview](./docs/runbooks/README.md)
+  - [Replay and State Recovery Procedures](./docs/runbooks/REPLAY_PROCEDURES.md)
 
 ## Roadmap (Phases)
 

--- a/docs/runbooks/QUICK_REFERENCE.md
+++ b/docs/runbooks/QUICK_REFERENCE.md
@@ -93,6 +93,26 @@ journalctl -u yieldvault-backend -f
 docker logs -f yieldvault-backend
 ```
 
+### Replay & State Recovery
+
+```bash
+# Trigger manual ledger events replay (dry-run)
+curl -X POST http://localhost:3000/admin/events/replay \
+  -H "Authorization: ApiKey YOUR_ADMIN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"fromLedger": 152000, "toLedger": 152500, "dryRun": true}'
+
+# Execute manual ledger events replay
+curl -X POST http://localhost:3000/admin/events/replay \
+  -H "Authorization: ApiKey YOUR_ADMIN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"fromLedger": 152000, "toLedger": 152500}'
+
+# Replay failed email queue item by UUID
+curl -X POST http://localhost:3000/admin/emails/replay/YOUR_EMAIL_UUID \
+  -H "Authorization: ApiKey YOUR_ADMIN_API_KEY"
+```
+
 ---
 
 ## Backup Locations
@@ -115,6 +135,7 @@ All runbooks: `docs/runbooks/`
 - [Backend Redeploy](./BACKEND_REDEPLOY.md)
 - [RPC Failover](./RPC_FAILOVER.md)
 - [Full DR](./FULL_DR_PROCEDURE.md)
+- [Replay Procedures](./REPLAY_PROCEDURES.md)
 
 ---
 

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -14,6 +14,7 @@ This directory contains operational runbooks for disaster recovery and incident 
 | [Contract Upgrade & Migration](./CONTRACT_UPGRADE_PLAYBOOK.md) | N/A | N/A | Smart contract upgrade deployment and rollback |
 | [RPC Failover](./RPC_FAILOVER.md) | 5 min | N/A | Stellar RPC node failure |
 | [Full DR Procedure](./FULL_DR_PROCEDURE.md) | 4 hours | 15 min | Complete infrastructure failure |
+| [Replay & State Recovery](./REPLAY_PROCEDURES.md) | N/A | N/A | Recovering/syncing ledger events or email queue |
 
 ---
 
@@ -245,6 +246,28 @@ Runbooks are step-by-step operational guides that enable any engineer to execute
 
 ---
 
+### 7. Replay & State Recovery
+
+**File:** [REPLAY_PROCEDURES.md](./REPLAY_PROCEDURES.md)
+
+**Purpose:** Manually replay Stellar blockchain events or requeue failed email queue jobs.
+
+**RTO:** N/A  
+**RPO:** N/A
+
+**Use Cases:**
+- Recovering missed ledger events after a database restore or sync lag
+- Re-processing block ranges after bug fixes or state changes
+- Manually triggering delivery of failed system/transaction emails
+
+**Key Steps:**
+1. Retrieve API credentials
+2. Execute dry-run preview to verify range
+3. Trigger replay endpoint with desired parameters
+4. Verify success via database queries and logs
+
+---
+
 ## Decision Tree
 
 Use this decision tree to select the appropriate runbook:
@@ -264,7 +287,9 @@ Is the backend service down or malfunctioning?
 
 Is the Stellar RPC node failing?
 ├─ YES → Use RPC Failover
-└─ NO → Check component-specific documentation
+└─ NO → Are ledger events lagging or email queue jobs failing?
+        ├─ YES → Use Replay & State Recovery
+        └─ NO → Check component-specific documentation
 ```
 
 ---
@@ -281,6 +306,7 @@ All runbooks must be tested according to this schedule:
 | Backend Redeploy | Weekly | ⚠️ Never | TBD |
 | RPC Failover | Monthly | ⚠️ Never | TBD |
 | Full DR Procedure | Annually | ⚠️ Never | TBD |
+| Replay & State Recovery | Monthly | ⚠️ Never | TBD |
 
 ### Testing Types
 

--- a/docs/runbooks/REPLAY_PROCEDURES.md
+++ b/docs/runbooks/REPLAY_PROCEDURES.md
@@ -1,0 +1,133 @@
+# Operational Runbook: Replay and State Recovery Procedures
+
+This runbook documents the procedures for manually replaying **ledger events** and **email queue items** in the YieldVault platform. Manual replays are typically performed during recovery from database restoration, RPC node sync lag, queue delivery failure, or to fix data inconsistencies.
+
+---
+
+## 1. Ledger Event Replay Procedure
+
+Stellar blockchain event ingestion is handled automatically by the [EventPollingService](file:///Users/apple/YieldVault-RWA/backend/src/eventPollingService.ts). If the service is restarted, it automatically replays missed events from the last recorded cursor sequence to the current network ledger. 
+
+However, if there is a data corruption event or database restore, operators can trigger a manual range replay.
+
+### 1.1 Prerequisites
+- **Admin API Key:** You must have an API key with the `admin` or `super-admin` role.
+- **Ledger Sequence Numbers:** You need to know the target `fromLedger` and `toLedger` sequences.
+- **Maximum Range Limit:** By default, manual replays are limited to `1000` ledgers per request to prevent overloading (configured via `EVENT_REPLAY_MAX_RANGE_SIZE`).
+
+### 1.2 Step 1: Run a Dry-Run Preview
+Always perform a dry-run first to validate your request schema and preview the range boundaries.
+
+```bash
+curl -X POST http://localhost:3000/admin/events/replay \
+  -H "Authorization: ApiKey YOUR_ADMIN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "fromLedger": 152000,
+    "toLedger": 152500,
+    "dryRun": true
+  }'
+```
+
+**Expected Response (200 OK):**
+```json
+{
+  "dryRun": true,
+  "message": "Event replay dry-run preview",
+  "fromLedger": 152000,
+  "toLedger": 152500,
+  "ledgerCount": 501,
+  "wouldReplay": true,
+  "timestamp": "2026-06-26T18:00:00.000Z"
+}
+```
+
+### 1.3 Step 2: Execute the Replay
+Omit the `dryRun` flag or set it to `false` to execute the actual database updates and event reprocessing.
+
+```bash
+curl -X POST http://localhost:3000/admin/events/replay \
+  -H "Authorization: ApiKey YOUR_ADMIN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "fromLedger": 152000,
+    "toLedger": 152500
+  }'
+```
+
+**Expected Response (200 OK):**
+```json
+{
+  "message": "Event replay completed successfully",
+  "fromLedger": 152000,
+  "toLedger": 152500,
+  "processedCount": 12,
+  "duplicateCount": 489
+}
+```
+*Note: `processedCount` tracks newly processed events; `duplicateCount` tracks events already processed and skipped due to idempotency verification.*
+
+### 1.4 Step 3: Verification
+1. **Monitor Server Logs:** Check the server logs for processed event logs:
+   ```bash
+   tail -n 100 /var/log/yieldvault/backend.log | grep -i "Event processed"
+   ```
+2. **Verify in Database:** Query the database using `psql` to check the updated events cursor and processed events count:
+   ```sql
+   -- Verify the current cursor
+   SELECT * FROM "EventCursor" WHERE id = 1;
+
+   -- Check recently processed events in range
+   SELECT COUNT(*), "eventType" FROM "ProcessedEvent" 
+   WHERE "ledgerSeq" >= 152000 AND "ledgerSeq" <= 152500 
+   GROUP BY "eventType";
+   ```
+
+### 1.5 Troubleshooting Ledger Replays
+* **API_400_EVENT_REPLAY (HTTP 400 Bad Request):** Occurs if `fromLedger` > `toLedger`, values are negative, or parameters are missing.
+* **Ledger Range Too Large:** If you exceed the maximum allowed size (e.g. 1000 ledgers), split the request into smaller chunks (e.g., 152000–152499, and 152500–152999).
+
+---
+
+## 2. Email Queue Replay Procedure
+
+When the system fails to deliver system notifications (such as deposit confirmations), failed jobs are placed in a queue. If an email fails repeatedly, it can be manually replayed.
+
+### 2.1 Prerequisites
+- **Admin API Key:** Authorization via `Authorization: ApiKey <api-key>`.
+- **Email ID:** The UUID of the failed email record in the database.
+
+### 2.2 Step 1: Identify Failed Emails
+Find the IDs of failed emails that need recovery:
+```bash
+# Get failed emails via local query
+psql $DATABASE_URL -c "SELECT id, recipient, subject, status, \"retryCount\" FROM \"EmailQueue\" WHERE status = 'failed' LIMIT 10;"
+```
+
+### 2.3 Step 2: Trigger Replay
+Send a POST request to the replay endpoint using the specific email ID:
+
+```bash
+curl -X POST http://localhost:3000/admin/emails/replay/YOUR_EMAIL_UUID \
+  -H "Authorization: ApiKey YOUR_ADMIN_API_KEY"
+```
+
+**Expected Response (200 OK):**
+```json
+{
+  "message": "Email requeued successfully",
+  "email": {
+    "id": "YOUR_EMAIL_UUID",
+    "status": "pending",
+    "retryCount": 0,
+    "lastError": null
+  }
+}
+```
+
+### 2.4 Step 3: Verification
+Check the queue worker status or query the database to ensure the email was picked up and sent:
+```sql
+SELECT status, "retryCount", "lastError" FROM "EmailQueue" WHERE id = 'YOUR_EMAIL_UUID';
+```
+If successfully sent, the status changes to `sent`.


### PR DESCRIPTION
##close #614 

## Description

This PR adds a dedicated replay runbook describing how operators and developers can perform ledger event replay and email queue replay.

It also updates the project documentation so the new runbook is discoverable from the existing README and runbook index.

Closes #<issue_number>

## Changes

- Add `docs/runbooks/REPLAY_PROCEDURES.md`
- Link the replay runbook from the root `README.md`
- Update `docs/runbooks/README.md`
- Update `docs/runbooks/QUICK_REFERENCE.md`

## Notes

- Documentation only.
- No source code changes.
- No API changes.
- No configuration changes.