### PR TITLE
feat(frontend): column prefs, async buttons, route prefetch, and security offer

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,18 +25,21 @@ import {
 } from "./lib/formDraftStorage";
 import ErrorFallback from "./components/ErrorFallback";
 import RouteLoadingFallback from "./components/RouteLoadingFallback";
+import {
+  LazyAnalytics,
+  LazyHome,
+  LazyPortfolio,
+  LazySettings,
+  LazyTransactionHistory,
+  LazyUIPreview,
+  prefetchDashboardRoutes,
+} from "./lib/routePrefetch";
 import NetworkWarningBanner from "./components/NetworkWarningBanner";
 import OfflineBanner from "./components/OfflineBanner";
 import { useVault, VaultProvider } from "./context/VaultContext";
 
 const SentryRoutes = Sentry.withSentryReactRouterV6Routing(Routes);
 
-const Home = lazy(() => import("./pages/Home"));
-const Portfolio = lazy(() => import("./pages/Portfolio"));
-const Analytics = lazy(() => import("./pages/Analytics"));
-const UIPreview = lazy(() => import("./pages/UIPreview"));
-const TransactionHistory = lazy(() => import("./pages/TransactionHistory"));
-const Settings = lazy(() => import("./pages/Settings"));
 const TransactionReceipt = lazy(() => import("./pages/TransactionReceipt"));
 
 // Removed simple fallback in favor of components/ErrorFallback
@@ -63,6 +66,18 @@ function AppContent() {
         .catch((err) => console.error("[SW] Registration failed:", err));
     }
   }, []);
+
+  useEffect(() => {
+    const schedulePrefetch = () => prefetchDashboardRoutes(location.pathname);
+
+    if ("requestIdleCallback" in window) {
+      const idleId = window.requestIdleCallback(schedulePrefetch, { timeout: 2500 });
+      return () => window.cancelIdleCallback(idleId);
+    }
+
+    const timeoutId = window.setTimeout(schedulePrefetch, 1500);
+    return () => window.clearTimeout(timeoutId);
+  }, [location.pathname]);
 
   const handleConnect = useCallback((address: string) => {
     clearSessionExpired();
@@ -142,7 +157,7 @@ function AppContent() {
                 <Route
                   path="/"
                   element={
-                    <Home
+                    <LazyHome
                       walletAddress={walletAddress}
                       usdcBalance={usdcBalance}
                       xlmBalance={xlmBalance}
@@ -152,7 +167,7 @@ function AppContent() {
                 <Route
                   path="/portfolio"
                   element={
-                    <Portfolio
+                    <LazyPortfolio
                       walletAddress={walletAddress}
                     />
                   }
@@ -161,14 +176,14 @@ function AppContent() {
                   path="/analytics"
                   element={
                     <FeatureGate flag="ANALYTICS_PAGE">
-                      <Analytics />
+                      <LazyAnalytics />
                     </FeatureGate>
                   }
                 />
-                <Route path="/transactions" element={<TransactionHistory walletAddress={walletAddress} />} />
+                <Route path="/transactions" element={<LazyTransactionHistory walletAddress={walletAddress} />} />
                 <Route path="/receipt/:txHash" element={<TransactionReceipt />} />
-                <Route path="/settings" element={<Settings />} />
-                <Route path="/ui-kit" element={<UIPreview />} />
+                <Route path="/settings" element={<LazySettings />} />
+                <Route path="/ui-kit" element={<LazyUIPreview />} />
                 <Route path="*" element={<Navigate to="/" replace />} />
               </SentryRoutes>
             </Suspense>

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from "../i18n";
 import { useWalletNetwork } from "../hooks/useWalletNetwork";
 import Badge from "./Badge";
 import { usePendingTransactionCount } from "../hooks/usePendingTransactionCount";
+import { getRoutePrefetchHandlers } from "../lib/routePrefetch";
 
 interface NavbarProps {
   currentPath?: "/" | "/analytics" | "/portfolio";
@@ -105,16 +106,21 @@ const Navbar: FC<NavbarProps> = ({
 
           {/* Desktop links */}
           <div className="flex gap-lg nav-desktop-links" style={{ marginLeft: "32px" }}>
-            <NavLink to="/" className="nav-link">
+            <NavLink to="/" className="nav-link" {...getRoutePrefetchHandlers("/")}>
               {t("nav.vaults")}
             </NavLink>
-            <NavLink to="/portfolio" className="nav-link">
+            <NavLink to="/portfolio" className="nav-link" {...getRoutePrefetchHandlers("/portfolio")}>
               {t("nav.portfolio")}
             </NavLink>
-            <NavLink to="/analytics" className="nav-link">
+            <NavLink to="/analytics" className="nav-link" {...getRoutePrefetchHandlers("/analytics")}>
               {t("nav.analytics")}
             </NavLink>
-            <NavLink to="/transactions" className="nav-link" style={{ position: "relative" }}>
+            <NavLink
+              to="/transactions"
+              className="nav-link"
+              style={{ position: "relative" }}
+              {...getRoutePrefetchHandlers("/transactions")}
+            >
               {t("nav.transactions")}
               {pendingCount > 0 && (
                 <Badge variant="pill" color="warning" size="compact" style={{ marginLeft: "6px" }}>
@@ -185,16 +191,16 @@ const Navbar: FC<NavbarProps> = ({
       {/* Mobile Menu */}
       {isMobileMenuOpen && (
         <div className="nav-mobile-menu is-open">
-          <NavLink to="/" onClick={() => setIsMobileMenuOpen(false)}>
+          <NavLink to="/" onClick={() => setIsMobileMenuOpen(false)} {...getRoutePrefetchHandlers("/")}>
             {t("nav.vaults")}
           </NavLink>
-          <NavLink to="/portfolio" onClick={() => setIsMobileMenuOpen(false)}>
+          <NavLink to="/portfolio" onClick={() => setIsMobileMenuOpen(false)} {...getRoutePrefetchHandlers("/portfolio")}>
             {t("nav.portfolio")}
           </NavLink>
-          <NavLink to="/analytics" onClick={() => setIsMobileMenuOpen(false)}>
+          <NavLink to="/analytics" onClick={() => setIsMobileMenuOpen(false)} {...getRoutePrefetchHandlers("/analytics")}>
             {t("nav.analytics")}
           </NavLink>
-          <NavLink to="/transactions" onClick={() => setIsMobileMenuOpen(false)}>
+          <NavLink to="/transactions" onClick={() => setIsMobileMenuOpen(false)} {...getRoutePrefetchHandlers("/transactions")}>
             {t("nav.transactions")}
             {pendingCount > 0 && (
               <Badge variant="pill" color="warning" size="compact" style={{ marginLeft: "6px" }}>
@@ -213,16 +219,16 @@ const Navbar: FC<NavbarProps> = ({
       {/* Dropdown fallback menu */}
       {menuOpen && (
         <div className="nav-mobile-menu" role="menu">
-          <NavLink to="/" role="menuitem" onClick={() => setMenuOpen(false)}>
+          <NavLink to="/" role="menuitem" onClick={() => setMenuOpen(false)} {...getRoutePrefetchHandlers("/")}>
             {t("nav.vaults")}
           </NavLink>
-          <NavLink to="/portfolio" role="menuitem" onClick={() => setMenuOpen(false)}>
+          <NavLink to="/portfolio" role="menuitem" onClick={() => setMenuOpen(false)} {...getRoutePrefetchHandlers("/portfolio")}>
             {t("nav.portfolio")}
           </NavLink>
-          <NavLink to="/analytics" role="menuitem" onClick={() => setMenuOpen(false)}>
+          <NavLink to="/analytics" role="menuitem" onClick={() => setMenuOpen(false)} {...getRoutePrefetchHandlers("/analytics")}>
             {t("nav.analytics")}
           </NavLink>
-          <NavLink to="/transactions" role="menuitem" onClick={() => setMenuOpen(false)}>
+          <NavLink to="/transactions" role="menuitem" onClick={() => setMenuOpen(false)} {...getRoutePrefetchHandlers("/transactions")}>
             {t("nav.transactions")}
             {pendingCount > 0 && (
               <Badge variant="pill" color="warning" size="compact" style={{ marginLeft: "6px" }}>

--- a/frontend/src/components/SecurityAuditOfferBanner.tsx
+++ b/frontend/src/components/SecurityAuditOfferBanner.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import { ShieldCheck, ExternalLink } from "./icons";
+import { networkConfig } from "../config/network";
+import { useTranslation } from "../i18n";
+
+const AUDIT_CONTACT_EMAIL = "security@yieldvault.io";
+
+const SecurityAuditOfferBanner: React.FC = () => {
+  const { t } = useTranslation();
+
+  if (!networkConfig.isTestnet) {
+    return null;
+  }
+
+  const mailtoHref = `mailto:${AUDIT_CONTACT_EMAIL}?subject=${encodeURIComponent(
+    t("securityOffer.emailSubject"),
+  )}`;
+
+  return (
+    <aside
+      className="glass-panel security-audit-offer"
+      aria-labelledby="security-audit-offer-heading"
+      style={{
+        marginBottom: "32px",
+        padding: "20px 24px",
+        display: "flex",
+        alignItems: "flex-start",
+        gap: "16px",
+        border: "1px solid rgba(34, 197, 94, 0.25)",
+        background:
+          "linear-gradient(135deg, rgba(34, 197, 94, 0.06), rgba(0, 240, 255, 0.04))",
+      }}
+    >
+      <div
+        style={{
+          flexShrink: 0,
+          padding: "10px",
+          borderRadius: "12px",
+          background: "rgba(34, 197, 94, 0.12)",
+          color: "rgb(34, 197, 94)",
+        }}
+        aria-hidden="true"
+      >
+        <ShieldCheck size={22} />
+      </div>
+
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <p
+          className="tag"
+          style={{
+            marginBottom: "8px",
+            color: "rgb(34, 197, 94)",
+            fontSize: "0.7rem",
+            letterSpacing: "0.08em",
+            textTransform: "uppercase",
+          }}
+        >
+          {t("securityOffer.badge")}
+        </p>
+        <h2
+          id="security-audit-offer-heading"
+          style={{ marginBottom: "8px", fontSize: "1.1rem" }}
+        >
+          {t("securityOffer.title")}
+        </h2>
+        <p
+          className="text-body-sm"
+          style={{ color: "var(--text-secondary)", marginBottom: "14px" }}
+        >
+          {t("securityOffer.description")}
+        </p>
+        <div className="flex items-center gap-md" style={{ flexWrap: "wrap" }}>
+          <a
+            href={mailtoHref}
+            className="btn btn-primary btn-sm"
+            style={{ textDecoration: "none" }}
+          >
+            {t("securityOffer.cta")}
+            <ExternalLink size={14} />
+          </a>
+          <span
+            className="text-body-sm"
+            style={{ color: "var(--text-secondary)" }}
+          >
+            {t("securityOffer.disclaimer")}
+          </span>
+        </div>
+      </div>
+    </aside>
+  );
+};
+
+export default SecurityAuditOfferBanner;

--- a/frontend/src/components/TransactionConfirmationModal.tsx
+++ b/frontend/src/components/TransactionConfirmationModal.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Modal } from "./Modal";
-import { AlertTriangle, Check, Loader2, Copy } from "./icons";
+import { AlertTriangle, Check, Copy } from "./icons";
+import { Button } from "./ui/Button";
 import type { TransactionSummary } from "../types/transaction";
 import { copyTextToClipboard } from "../lib/clipboard";
 
@@ -229,34 +230,28 @@ export const TransactionConfirmationModal: React.FC<TransactionConfirmationModal
 
         {/* Action Buttons */}
         <div className="flex gap-md">
-          <button
+          <Button
             type="button"
-            className="btn btn-outline"
+            variant="outline"
             style={{ flex: 1 }}
             onClick={onCancel}
             disabled={isLoading}
           >
             Cancel
-          </button>
-          <button
+          </Button>
+          <Button
             type="button"
-            className={hasWarnings ? "btn btn-warning" : "btn btn-primary"}
-            style={{ flex: 2, display: "flex", alignItems: "center", justifyContent: "center", gap: "8px" }}
+            variant="primary"
+            className={hasWarnings ? "btn btn-warning" : ""}
+            style={{ flex: 2 }}
             onClick={onConfirm}
             disabled={isLoading}
+            status={isLoading ? "pending" : "idle"}
+            loadingLabel="Signing..."
+            leftIcon={!isLoading ? <Check size={18} /> : undefined}
           >
-            {isLoading ? (
-              <>
-                <Loader2 size={16} className="spin" style={{ animation: "spin 0.9s linear infinite" }} />
-                Signing...
-              </>
-            ) : (
-              <>
-                <Check size={18} />
-                {confirmButtonLabel}
-              </>
-            )}
-          </button>
+            {confirmButtonLabel}
+          </Button>
         </div>
       </div>
     </Modal>

--- a/frontend/src/components/VaultDashboard.tsx
+++ b/frontend/src/components/VaultDashboard.tsx
@@ -28,6 +28,7 @@ import { createDepositFormSchema, MIN_DEPOSIT_AMOUNT } from "../forms/schemas/de
 import { createWithdrawFormSchema } from "../forms/schemas/withdrawFormSchema";
 import { mapServerError } from "../lib/errorMappers";
 import CopyButton from "./CopyButton";
+import { Button } from "./ui/Button";
 import { copyTextToClipboard } from "../lib/clipboard";
 import { useFeeEstimate } from "../hooks/useFeeEstimate";
 import { useSlippage } from "../hooks/useSlippage";
@@ -1261,10 +1262,12 @@ const VaultDashboard: React.FC<VaultDashboardProps> = ({
                                 </div>
                               </div>
                               {approvalStatus !== "confirmed" && (
-                                <button
+                                <Button
                                   type="button"
-                                  className="btn btn-outline"
+                                  variant="outline"
                                   style={{ width: "100%", padding: "10px" }}
+                                  status={approvalStatus === "pending" ? "pending" : "idle"}
+                                  loadingLabel="Approving..."
                                   disabled={approvalStatus === "pending"}
                                   onClick={async () => {
                                     try {
@@ -1275,8 +1278,8 @@ const VaultDashboard: React.FC<VaultDashboardProps> = ({
                                     }
                                   }}
                                 >
-                                  {approvalStatus === "pending" ? "Approving..." : "Approve USDC"}
-                                </button>
+                                  Approve USDC
+                                </Button>
                               )}
                             </div>
                           )}
@@ -1306,11 +1309,13 @@ const VaultDashboard: React.FC<VaultDashboardProps> = ({
                           >
                             Back
                           </button>
-                          <button
+                          <Button
                             type="button"
                             id={`vault-${tab}-confirm`}
-                            className="btn btn-primary"
+                            variant="primary"
                             style={{ flex: 2 }}
+                            status={isBusy ? "pending" : "idle"}
+                            loadingLabel="Processing..."
                             onClick={() => void handleTransaction(tab)}
                             disabled={
                               isBusy || 
@@ -1318,15 +1323,8 @@ const VaultDashboard: React.FC<VaultDashboardProps> = ({
                               (tab === "deposit" && xlmBalance < feeXlm)
                             }
                           >
-                            {isBusy ? (
-                              <>
-                                <Loader2 size={16} className="spin" style={{ animation: "spin 0.9s linear infinite" }} />
-                                Processing...
-                              </>
-                            ) : (
-                              `Confirm ${tab}`
-                            )}
-                          </button>
+                            {`Confirm ${tab}`}
+                          </Button>
                         </div>
                       </div>
                     )}

--- a/frontend/src/components/WalletConnect.tsx
+++ b/frontend/src/components/WalletConnect.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback } from "react";
 import { setAllowed, isAllowed, getAddress } from "@stellar/freighter-api";
-import { Loader2, LogOut, Wallet, AlertCircle } from "./icons";
+import { LogOut, Wallet, AlertCircle } from "./icons";
 import { hasCustomRpcConfig, networkConfig } from "../config/network";
 import { useToast } from "../context/ToastContext";
 import { useTranslation } from "../i18n";
@@ -21,7 +21,7 @@ import {
   clearReconnectPromptDismissed,
   isProviderAvailable,
 } from "../lib/walletSession";
-import WalletReconnectPrompt from "./WalletReconnectPrompt";
+import { Button } from "./ui/Button";
 import WalletSessionIndicator from "./WalletSessionIndicator";
 
 const IS_AUTOMATED_TEST =
@@ -57,7 +57,6 @@ const WalletConnect: React.FC<WalletConnectProps> = ({
       !isWalletManualDisconnectSet(),
   );
   const [reconnectProvider, setReconnectProvider] = useState<ReturnType<typeof getLastWalletProvider>>(null);
-  const buttonRef = useRef<HTMLButtonElement>(null);
   const initialSyncDoneRef = useRef(false);
   const { preferences } = usePreferencesContext();
   const toast = useToast();
@@ -340,39 +339,29 @@ const WalletConnect: React.FC<WalletConnectProps> = ({
           }}
         />
       )}
-      <button
-        ref={buttonRef}
-        className={`btn ${connectionError ? "btn-error" : "btn-primary"} ${isConnecting || showDiscovering ? "animate-glow" : ""}`}
+      <Button
+        variant={connectionError ? "danger" : "primary"}
+        className={isConnecting || showDiscovering ? "animate-glow" : ""}
         onClick={handleConnect}
         disabled={isConnecting || showDiscovering}
-        aria-busy={isConnecting || showDiscovering}
+        status={isConnecting || showDiscovering ? "pending" : connectionError ? "error" : "idle"}
+        loadingLabel={
+          showDiscovering ? t("wallet.checkingFreighter") : t("wallet.connecting")
+        }
+        leftIcon={connectionError ? <AlertCircle size={18} /> : <Wallet size={18} />}
         onMouseEnter={() => setShowTooltip(true)}
         onMouseLeave={() => setShowTooltip(false)}
         onFocus={() => setShowTooltip(true)}
         onBlur={() => setShowTooltip(false)}
         title={getStatusTooltip()}
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: "8px",
-          position: "relative",
-        }}
+        style={{ position: "relative" }}
       >
-        {isConnecting || showDiscovering ? (
-          <Loader2 size={18} className="spin" style={{ animation: "spin 1s linear infinite" }} />
-        ) : connectionError ? (
-          <AlertCircle size={18} />
-        ) : (
-          <Wallet size={18} />
-        )}
-        <span>
-          {showDiscovering
-            ? t("wallet.checkingFreighter")
-            : isConnecting
-              ? t("wallet.connecting")
-              : t("wallet.connectFreighter")}
-        </span>
-      </button>
+        {showDiscovering
+          ? t("wallet.checkingFreighter")
+          : isConnecting
+            ? t("wallet.connecting")
+            : t("wallet.connectFreighter")}
+      </Button>
 
       {showTooltip && (
         <div

--- a/frontend/src/components/icons.ts
+++ b/frontend/src/components/icons.ts
@@ -33,4 +33,5 @@ export {
   PackageOpen,
   Inbox,
   PackageSearch,
+  Columns3,
 } from "lucide-react";

--- a/frontend/src/components/ui/AsyncActionButton.tsx
+++ b/frontend/src/components/ui/AsyncActionButton.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { Button, type ButtonStatus } from "./Button";
+import {
+  useAsyncActionButton,
+  type UseAsyncActionButtonOptions,
+} from "../../hooks/useAsyncActionButton";
+
+type AsyncActionButtonProps = Omit<
+  React.ComponentProps<typeof Button>,
+  "status" | "children" | "isLoading"
+> &
+  UseAsyncActionButtonOptions & {
+    className?: string;
+    variant?: React.ComponentProps<typeof Button>["variant"];
+    size?: React.ComponentProps<typeof Button>["size"];
+    type?: React.ButtonHTMLAttributes<HTMLButtonElement>["type"];
+    style?: React.CSSProperties;
+    id?: string;
+    onClick?: React.ButtonHTMLAttributes<HTMLButtonElement>["onClick"];
+    disabled?: boolean;
+  };
+
+/**
+ * Wallet/async action button with standardized pending, success, and error states.
+ */
+export const AsyncActionButton: React.FC<AsyncActionButtonProps> = ({
+  labels,
+  isPending,
+  isSuccess,
+  isError,
+  successResetMs,
+  errorResetMs,
+  disabled,
+  ...buttonProps
+}) => {
+  const { status, label, isDisabled } = useAsyncActionButton({
+    labels,
+    isPending,
+    isSuccess,
+    isError,
+    successResetMs,
+    errorResetMs,
+  });
+
+  const resolvedStatus: ButtonStatus = status;
+
+  return (
+    <Button
+      {...buttonProps}
+      status={resolvedStatus}
+      disabled={disabled || isDisabled}
+      loadingLabel={labels.pending}
+      successLabel={labels.success}
+      errorLabel={labels.error}
+    >
+      {label}
+    </Button>
+  );
+};

--- a/frontend/src/components/ui/Button.css
+++ b/frontend/src/components/ui/Button.css
@@ -87,7 +87,18 @@
 
 .btn.is-loading {
   position: relative;
+}
+
+.btn.is-loading .btn-content-hidden {
   color: transparent !important;
+}
+
+.btn.is-success {
+  border-color: rgba(34, 197, 94, 0.45);
+}
+
+.btn.is-error {
+  border-color: rgba(255, 80, 100, 0.45);
 }
 
 .btn-spinner {
@@ -102,6 +113,10 @@
 
 @keyframes btn-spin {
   to { transform: rotate(360deg); }
+}
+
+.btn-inline-spin {
+  animation: btn-spin 0.9s linear infinite;
 }
 
 .btn-icon-left, .btn-icon-right {

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -1,10 +1,17 @@
 import React from "react";
+import { AlertCircle, Check, Loader2 } from "../icons";
 import "./Button.css";
+
+export type ButtonStatus = "idle" | "pending" | "success" | "error";
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: "primary" | "secondary" | "danger" | "outline";
   size?: "sm" | "md" | "lg";
   isLoading?: boolean;
+  status?: ButtonStatus;
+  loadingLabel?: React.ReactNode;
+  successLabel?: React.ReactNode;
+  errorLabel?: React.ReactNode;
   leftIcon?: React.ReactNode;
   rightIcon?: React.ReactNode;
 }
@@ -14,24 +21,66 @@ export const Button: React.FC<ButtonProps> = ({
   variant = "primary",
   size = "md",
   isLoading = false,
+  status = "idle",
+  loadingLabel,
+  successLabel,
+  errorLabel,
   leftIcon,
   rightIcon,
   className = "",
   disabled,
+  "aria-busy": ariaBusy,
   ...props
 }) => {
-  const isDisabled = disabled || isLoading;
+  const resolvedStatus: ButtonStatus = isLoading ? "pending" : status;
+  const isPending = resolvedStatus === "pending";
+  const isSuccess = resolvedStatus === "success";
+  const isError = resolvedStatus === "error";
+  const isDisabled = disabled || isPending;
+
+  const content =
+    isPending && loadingLabel !== undefined
+      ? loadingLabel
+      : isSuccess && successLabel !== undefined
+        ? successLabel
+        : isError && errorLabel !== undefined
+          ? errorLabel
+          : children;
+
+  const showSpinner = isPending && loadingLabel === undefined;
+  const showSuccessIcon = isSuccess && successLabel === undefined;
+  const showErrorIcon = isError && errorLabel === undefined;
 
   return (
     <button
-      className={`btn btn-${variant} btn-${size} ${isLoading ? "is-loading" : ""} ${className}`}
+      className={`btn btn-${variant} btn-${size} ${isPending ? "is-loading" : ""} ${isSuccess ? "is-success" : ""} ${isError ? "is-error" : ""} ${className}`}
       disabled={isDisabled}
+      aria-busy={ariaBusy ?? isPending}
       {...props}
     >
-      {isLoading && <span className="btn-spinner" />}
-      {!isLoading && leftIcon && <span className="btn-icon-left">{leftIcon}</span>}
-      <span className="btn-content">{children}</span>
-      {!isLoading && rightIcon && <span className="btn-icon-right">{rightIcon}</span>}
+      {showSpinner && <span className="btn-spinner" />}
+      {isPending && loadingLabel !== undefined && (
+        <span className="btn-icon-left" aria-hidden="true">
+          <Loader2 size={16} className="btn-inline-spin" />
+        </span>
+      )}
+      {showSuccessIcon && (
+        <span className="btn-icon-left" aria-hidden="true">
+          <Check size={16} />
+        </span>
+      )}
+      {showErrorIcon && (
+        <span className="btn-icon-left" aria-hidden="true">
+          <AlertCircle size={16} />
+        </span>
+      )}
+      {!isPending && !isSuccess && !isError && leftIcon && (
+        <span className="btn-icon-left">{leftIcon}</span>
+      )}
+      <span className={`btn-content ${showSpinner ? "btn-content-hidden" : ""}`}>{content}</span>
+      {!isPending && !isSuccess && !isError && rightIcon && (
+        <span className="btn-icon-right">{rightIcon}</span>
+      )}
     </button>
   );
 };

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -1,4 +1,5 @@
 export * from "./Button";
+export * from "./AsyncActionButton";
 export * from "./Input";
 export * from "./Card";
 export * from "./Table";

--- a/frontend/src/context/KeyboardShortcutContext.tsx
+++ b/frontend/src/context/KeyboardShortcutContext.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useKeyboardShortcuts, formatShortcut } from '../hooks/useKeyboardShortcuts';
 import type { ShortcutDefinition } from '../hooks/useKeyboardShortcuts';
 import { useTranslation } from '../i18n';
+import { prefetchRoute, type PrefetchableRoute } from '../lib/routePrefetch';
 
 interface KeyboardShortcutContextValue {
   shortcuts: ShortcutDefinition[];
@@ -31,6 +32,11 @@ export const KeyboardShortcutProvider: React.FC<KeyboardShortcutProviderProps> =
   const [isHelpModalOpen, setIsHelpModalOpen] = useState(false);
   const [isPaletteOpen, setIsPaletteOpen] = useState(false);
 
+  const navigateWithPrefetch = useCallback((path: PrefetchableRoute) => {
+    prefetchRoute(path);
+    navigate(path);
+  }, [navigate]);
+
   const openHelpModal = useCallback(() => {
     setIsHelpModalOpen(true);
   }, []);
@@ -51,25 +57,25 @@ export const KeyboardShortcutProvider: React.FC<KeyboardShortcutProviderProps> =
     // ── Navigation ──
     {
       key: 'g',
-      action: () => navigate('/'),
+      action: () => navigateWithPrefetch('/'),
       description: t('commands.goToVaults'),
       scope: t('commands.scopes.navigation')
     },
     {
       key: 'p',
-      action: () => navigate('/portfolio'),
+      action: () => navigateWithPrefetch('/portfolio'),
       description: t('commands.goToPortfolio'),
       scope: t('commands.scopes.navigation')
     },
     {
       key: 'a',
-      action: () => navigate('/analytics'),
+      action: () => navigateWithPrefetch('/analytics'),
       description: t('commands.goToAnalytics'),
       scope: t('commands.scopes.navigation')
     },
     {
       key: 'h',
-      action: () => navigate('/transactions'),
+      action: () => navigateWithPrefetch('/transactions'),
       description: t('commands.goToHistory'),
       scope: t('commands.scopes.navigation')
     },
@@ -136,7 +142,7 @@ export const KeyboardShortcutProvider: React.FC<KeyboardShortcutProviderProps> =
       description: t('commands.closeModal'),
       scope: t('commands.scopes.general')
     }
-  ], [navigate, openHelpModal, closeHelpModal, openPalette, closePalette, walletAddress, t]);
+  ], [navigateWithPrefetch, openHelpModal, closeHelpModal, openPalette, closePalette, walletAddress, t]);
 
   useKeyboardShortcuts(shortcuts, true);
 

--- a/frontend/src/hooks/useAsyncActionButton.ts
+++ b/frontend/src/hooks/useAsyncActionButton.ts
@@ -1,0 +1,80 @@
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+
+export type AsyncActionStatus = "idle" | "pending" | "success" | "error";
+
+export interface AsyncActionLabels {
+  idle: ReactNode;
+  pending?: ReactNode;
+  success?: ReactNode;
+  error?: ReactNode;
+}
+
+export interface UseAsyncActionButtonOptions {
+  labels: AsyncActionLabels;
+  isPending?: boolean;
+  isSuccess?: boolean;
+  isError?: boolean;
+  successResetMs?: number;
+  errorResetMs?: number;
+}
+
+export interface AsyncActionButtonState {
+  status: AsyncActionStatus;
+  label: ReactNode;
+  isDisabled: boolean;
+  reset: () => void;
+}
+
+/**
+ * Maps async wallet/mutation state to standardized button status and labels.
+ */
+export function useAsyncActionButton({
+  labels,
+  isPending = false,
+  isSuccess = false,
+  isError = false,
+  successResetMs = 2000,
+  errorResetMs = 3000,
+}: UseAsyncActionButtonOptions): AsyncActionButtonState {
+  const [status, setStatus] = useState<AsyncActionStatus>("idle");
+
+  useEffect(() => {
+    if (isPending) {
+      setStatus("pending");
+      return;
+    }
+    if (isSuccess) {
+      setStatus("success");
+      const timer = window.setTimeout(() => setStatus("idle"), successResetMs);
+      return () => window.clearTimeout(timer);
+    }
+    if (isError) {
+      setStatus("error");
+      const timer = window.setTimeout(() => setStatus("idle"), errorResetMs);
+      return () => window.clearTimeout(timer);
+    }
+    if (!isPending && !isSuccess && !isError) {
+      setStatus("idle");
+    }
+  }, [isPending, isSuccess, isError, successResetMs, errorResetMs]);
+
+  const label = useMemo(() => {
+    switch (status) {
+      case "pending":
+        return labels.pending ?? labels.idle;
+      case "success":
+        return labels.success ?? labels.idle;
+      case "error":
+        return labels.error ?? labels.idle;
+      default:
+        return labels.idle;
+    }
+  }, [labels, status]);
+
+  return {
+    status,
+    label,
+    isDisabled: status === "pending",
+    reset: () => setStatus("idle"),
+  };
+}

--- a/frontend/src/hooks/useUserPreferenceStore.ts
+++ b/frontend/src/hooks/useUserPreferenceStore.ts
@@ -12,8 +12,11 @@ import {
   setTableDensity as persistTableDensity,
   setTransactionPageSize as persistTransactionPageSize,
   setTransactionViewMode as persistTransactionViewMode,
+  toggleTransactionColumnVisibility as persistToggleTransactionColumn,
+  setTransactionVisibleColumns as persistTransactionVisibleColumns,
   updateUserPreferenceStore,
 } from "../lib/userPreferenceStore";
+import type { TransactionColumnId, TransactionVisibleColumns } from "../lib/userPreferenceStore";
 
 export function useUserPreferenceStore(walletAddress?: string | null) {
   const [store, setStore] = useState<UserPreferenceStoreData>(() =>
@@ -52,6 +55,20 @@ export function useUserPreferenceStore(walletAddress?: string | null) {
     [walletAddress],
   );
 
+  const setTransactionVisibleColumns = useCallback(
+    (columns: TransactionVisibleColumns) => {
+      setStore(persistTransactionVisibleColumns(columns, walletAddress));
+    },
+    [walletAddress],
+  );
+
+  const toggleTransactionColumnVisibility = useCallback(
+    (columnId: TransactionColumnId) => {
+      setStore(persistToggleTransactionColumn(columnId, walletAddress));
+    },
+    [walletAddress],
+  );
+
   const updateStore = useCallback(
     (
       updater:
@@ -75,6 +92,8 @@ export function useUserPreferenceStore(walletAddress?: string | null) {
     setTableDensity,
     setTransactionViewMode,
     setTransactionPageSize,
+    setTransactionVisibleColumns,
+    toggleTransactionColumnVisibility,
     updateStore,
     resetStore,
   };

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -302,6 +302,15 @@ export const en = {
     headingAccent: "Decentralized Access.",
     description: "Deposit USDC to earn stable, predictable yield backed by tokenized Sovereign Debt and Real-World Assets.",
   },
+  securityOffer: {
+    badge: "Pre-mainnet security review",
+    title: "Free initial security audit before mainnet",
+    description:
+      "We are offering a complimentary initial smart-contract and frontend security review for early vault participants while YieldVault runs on testnet.",
+    cta: "Request free audit",
+    disclaimer: "Limited availability · No obligation",
+    emailSubject: "YieldVault pre-mainnet security audit request",
+  },
   withdrawal: {
     title: "Confirm Withdrawal",
     subtitle: "Please review the details before confirming your withdrawal.",
@@ -435,6 +444,11 @@ export const en = {
     liveStatus: "Live Status",
     dismissTimeline: "Dismiss timeline",
     tableCaption: "Transaction history",
+    columns: {
+      title: "Visible columns",
+      button: "Columns",
+      toggle: "Customize visible transaction table columns",
+    },
   },
   txDetail: {
     title: "Transaction Details",

--- a/frontend/src/i18n/locales/es.ts
+++ b/frontend/src/i18n/locales/es.ts
@@ -288,6 +288,15 @@ export const es = {
     headingAccent: "Acceso descentralizado.",
     description: "Deposita USDC para ganar rendimiento estable y predecible respaldado por deuda soberana tokenizada y activos del mundo real.",
   },
+  securityOffer: {
+    badge: "Revisión de seguridad pre-mainnet",
+    title: "Auditoría de seguridad inicial gratuita antes del mainnet",
+    description:
+      "Ofrecemos una revisión inicial gratuita de contratos inteligentes y frontend para participantes tempranos mientras YieldVault opera en testnet.",
+    cta: "Solicitar auditoría gratuita",
+    disclaimer: "Disponibilidad limitada · Sin obligación",
+    emailSubject: "Solicitud de auditoría de seguridad pre-mainnet de YieldVault",
+  },
   withdrawal: {
     title: "Confirmar retiro",
     subtitle: "Por favor, revisa los detalles antes de confirmar tu retiro.",
@@ -421,6 +430,11 @@ export const es = {
     liveStatus: "Estado en vivo",
     dismissTimeline: "Descartar línea de tiempo",
     tableCaption: "Historial de transacciones",
+    columns: {
+      title: "Columnas visibles",
+      button: "Columnas",
+      toggle: "Personalizar columnas visibles de la tabla de transacciones",
+    },
   },
   txDetail: {
     title: "Detalles de la transacción",

--- a/frontend/src/lib/routePrefetch.ts
+++ b/frontend/src/lib/routePrefetch.ts
@@ -1,0 +1,49 @@
+import { lazy } from "react";
+
+export const routeImports = {
+  "/": () => import("../pages/Home"),
+  "/portfolio": () => import("../pages/Portfolio"),
+  "/analytics": () => import("../pages/Analytics"),
+  "/transactions": () => import("../pages/TransactionHistory"),
+  "/settings": () => import("../pages/Settings"),
+  "/ui-kit": () => import("../pages/UIPreview"),
+} as const;
+
+export type PrefetchableRoute = keyof typeof routeImports;
+
+const prefetchedRoutes = new Set<string>();
+
+export function prefetchRoute(path: PrefetchableRoute): void {
+  if (prefetchedRoutes.has(path)) return;
+  prefetchedRoutes.add(path);
+  void routeImports[path]();
+}
+
+export function prefetchDashboardRoutes(excludePath?: string): void {
+  const primaryRoutes: PrefetchableRoute[] = [
+    "/",
+    "/portfolio",
+    "/analytics",
+    "/transactions",
+  ];
+
+  for (const path of primaryRoutes) {
+    if (path !== excludePath) {
+      prefetchRoute(path);
+    }
+  }
+}
+
+export function getRoutePrefetchHandlers(path: PrefetchableRoute) {
+  return {
+    onMouseEnter: () => prefetchRoute(path),
+    onFocus: () => prefetchRoute(path),
+  };
+}
+
+export const LazyHome = lazy(routeImports["/"]);
+export const LazyPortfolio = lazy(routeImports["/portfolio"]);
+export const LazyAnalytics = lazy(routeImports["/analytics"]);
+export const LazyTransactionHistory = lazy(routeImports["/transactions"]);
+export const LazySettings = lazy(routeImports["/settings"]);
+export const LazyUIPreview = lazy(routeImports["/ui-kit"]);

--- a/frontend/src/lib/userPreferenceStore.test.ts
+++ b/frontend/src/lib/userPreferenceStore.test.ts
@@ -10,6 +10,7 @@ import {
   setTransactionViewMode,
   setTransactionPageSize,
   resetUserPreferenceStore,
+  toggleTransactionColumnVisibility,
   getPreferenceStorageKey,
 } from "./userPreferenceStore";
 
@@ -94,6 +95,14 @@ describe("userPreferenceStore", () => {
           density: "invalid" as never,
           transactionViewMode: "paginated",
           transactionPageSize: 10,
+          transactionVisibleColumns: {
+            type: true,
+            status: true,
+            amount: true,
+            asset: true,
+            date: true,
+            hash: true,
+          },
         },
       },
       WALLET,
@@ -111,6 +120,29 @@ describe("userPreferenceStore", () => {
     const prefs = loadUserPreferenceStore(WALLET);
     expect(prefs.tables.transactionViewMode).toBe("infinite");
     expect(prefs.tables.transactionPageSize).toBe(50);
+  });
+
+  it("persists transaction column visibility and prevents hiding all columns", () => {
+    toggleTransactionColumnVisibility("hash", WALLET);
+    toggleTransactionColumnVisibility("asset", WALLET);
+
+    let prefs = loadUserPreferenceStore(WALLET);
+    expect(prefs.tables.transactionVisibleColumns.hash).toBe(false);
+    expect(prefs.tables.transactionVisibleColumns.asset).toBe(false);
+
+    for (const columnId of ["type", "status", "amount", "date"] as const) {
+      toggleTransactionColumnVisibility(columnId, WALLET);
+    }
+
+    prefs = loadUserPreferenceStore(WALLET);
+    expect(prefs.tables.transactionVisibleColumns).toEqual({
+      type: true,
+      status: true,
+      amount: true,
+      asset: true,
+      date: true,
+      hash: true,
+    });
   });
 
   it("resets preferences to defaults", () => {

--- a/frontend/src/lib/userPreferenceStore.ts
+++ b/frontend/src/lib/userPreferenceStore.ts
@@ -19,6 +19,26 @@ export const TABLE_DENSITY_VALUES: readonly TableDensity[] = [
 export const TRANSACTION_PAGE_SIZE_OPTIONS = [10, 25, 50] as const;
 export type TransactionPageSize = (typeof TRANSACTION_PAGE_SIZE_OPTIONS)[number];
 
+export const TRANSACTION_COLUMN_IDS = [
+  "type",
+  "status",
+  "amount",
+  "asset",
+  "date",
+  "hash",
+] as const;
+export type TransactionColumnId = (typeof TRANSACTION_COLUMN_IDS)[number];
+export type TransactionVisibleColumns = Record<TransactionColumnId, boolean>;
+
+export const DEFAULT_TRANSACTION_VISIBLE_COLUMNS: TransactionVisibleColumns = {
+  type: true,
+  status: true,
+  amount: true,
+  asset: true,
+  date: true,
+  hash: true,
+};
+
 export interface ChartModePreferences {
   /** Default visualization mode for vault performance charts */
   vaultPerformance: ChartMode;
@@ -32,6 +52,7 @@ export interface TablePreferences {
   density: TableDensity;
   transactionViewMode: TransactionViewMode;
   transactionPageSize: TransactionPageSize;
+  transactionVisibleColumns: TransactionVisibleColumns;
 }
 
 export interface UserPreferenceStoreData {
@@ -60,6 +81,7 @@ export const DEFAULT_TABLE_PREFERENCES: TablePreferences = {
   density: "comfortable",
   transactionViewMode: "paginated",
   transactionPageSize: 10,
+  transactionVisibleColumns: { ...DEFAULT_TRANSACTION_VISIBLE_COLUMNS },
 };
 
 export const DEFAULT_USER_PREFERENCE_STORE: UserPreferenceStoreData = {
@@ -89,6 +111,28 @@ function isTransactionPageSize(value: unknown): value is TransactionPageSize {
     typeof value === "number" &&
     (TRANSACTION_PAGE_SIZE_OPTIONS as readonly number[]).includes(value)
   );
+}
+
+function mergeTransactionVisibleColumns(
+  partial?: Partial<TransactionVisibleColumns>,
+): TransactionVisibleColumns {
+  const merged: TransactionVisibleColumns = {
+    ...DEFAULT_TRANSACTION_VISIBLE_COLUMNS,
+    ...partial,
+  };
+
+  for (const id of TRANSACTION_COLUMN_IDS) {
+    if (typeof merged[id] !== "boolean") {
+      merged[id] = DEFAULT_TRANSACTION_VISIBLE_COLUMNS[id];
+    }
+  }
+
+  const visibleCount = TRANSACTION_COLUMN_IDS.filter((id) => merged[id]).length;
+  if (visibleCount === 0) {
+    return { ...DEFAULT_TRANSACTION_VISIBLE_COLUMNS };
+  }
+
+  return merged;
 }
 
 function parsePageSize(raw: string | null): TransactionPageSize | undefined {
@@ -165,6 +209,9 @@ function mergeTablePreferences(
     transactionPageSize: isTransactionPageSize(merged.transactionPageSize)
       ? merged.transactionPageSize
       : DEFAULT_TABLE_PREFERENCES.transactionPageSize,
+    transactionVisibleColumns: mergeTransactionVisibleColumns(
+      merged.transactionVisibleColumns,
+    ),
   };
 }
 
@@ -323,6 +370,42 @@ export function setTransactionPageSize(
       ...prev,
       tables: { ...prev.tables, transactionPageSize: pageSize },
     }),
+    walletAddress,
+  );
+}
+
+export function setTransactionVisibleColumns(
+  columns: TransactionVisibleColumns,
+  walletAddress?: string | null,
+): UserPreferenceStoreData {
+  return updateUserPreferenceStore(
+    (prev) => ({
+      ...prev,
+      tables: {
+        ...prev.tables,
+        transactionVisibleColumns: mergeTransactionVisibleColumns(columns),
+      },
+    }),
+    walletAddress,
+  );
+}
+
+export function toggleTransactionColumnVisibility(
+  columnId: TransactionColumnId,
+  walletAddress?: string | null,
+): UserPreferenceStoreData {
+  return updateUserPreferenceStore(
+    (prev) => {
+      const current = prev.tables.transactionVisibleColumns;
+      const next = mergeTransactionVisibleColumns({
+        ...current,
+        [columnId]: !current[columnId],
+      });
+      return {
+        ...prev,
+        tables: { ...prev.tables, transactionVisibleColumns: next },
+      };
+    },
     walletAddress,
   );
 }

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import VaultDashboard from "../components/VaultDashboard";
+import SecurityAuditOfferBanner from "../components/SecurityAuditOfferBanner";
 import { usePageHeadingFocus } from "../hooks/usePageHeadingFocus";
 import { useTranslation } from "../i18n";
 
@@ -27,6 +28,8 @@ const Home: React.FC<HomeProps> = ({ walletAddress, usdcBalance, xlmBalance }) =
           {t("hero.description")}
         </p>
       </header>
+
+      <SecurityAuditOfferBanner />
 
       <VaultDashboard walletAddress={walletAddress} usdcBalance={usdcBalance} xlmBalance={xlmBalance} />
     </>

--- a/frontend/src/pages/TransactionHistory.tsx
+++ b/frontend/src/pages/TransactionHistory.tsx
@@ -12,7 +12,8 @@ import { SkeletonText } from "../components/Skeleton";
 import TransactionFilterPanel from "../components/TransactionFilterPanel";
 import TransactionDetailDrawer from "../components/TransactionDetailDrawer";
 import EmptyState from "../components/ui/EmptyState";
-import { Activity, Loader2, Wallet } from "../components/icons";
+import { Popover } from "../components/ui/Popover";
+import { Activity, Loader2, Wallet, Columns3 } from "../components/icons";
 import {
   normalizeApiError,
   isValidationError,
@@ -34,7 +35,8 @@ import { networkConfig } from "../config/network";
 import { useDelayedLoading } from "../hooks/useDelayedLoading";
 import { useTranslation } from "../i18n";
 import { useUserPreferenceStore } from "../hooks/useUserPreferenceStore";
-import type { TransactionPageSize } from "../lib/userPreferenceStore";
+import type { TransactionPageSize, TransactionColumnId } from "../lib/userPreferenceStore";
+import { TRANSACTION_COLUMN_IDS } from "../lib/userPreferenceStore";
 
 interface TransactionHistoryProps {
   walletAddress: string | null;
@@ -56,6 +58,7 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({
     tables: tablePreferences,
     setTransactionViewMode,
     setTransactionPageSize,
+    toggleTransactionColumnVisibility,
   } = useUserPreferenceStore(walletAddress);
   const { data: queryTransactions, isLoading, error: queryError } = useTransactionHistory(walletAddress);
   const delayedLoading = useDelayedLoading(isLoading);
@@ -138,6 +141,23 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({
       ),
     },
   ], [t]);
+
+  const visibleColumnIds = tablePreferences.transactionVisibleColumns;
+  const visibleColumns = React.useMemo(
+    () => columns.filter((column) => visibleColumnIds[column.id as TransactionColumnId]),
+    [columns, visibleColumnIds],
+  );
+
+  const columnLabelById: Record<TransactionColumnId, string> = {
+    type: t("txHistory.typeHeader"),
+    status: t("txHistory.statusHeader"),
+    amount: t("txHistory.amountHeader"),
+    asset: t("txHistory.assetHeader"),
+    date: t("txHistory.dateHeader"),
+    hash: t("txHistory.hashHeader"),
+  };
+
+  const visibleColumnCount = TRANSACTION_COLUMN_IDS.filter((id) => visibleColumnIds[id]).length;
 
   const error = queryError 
     ? (isValidationError(queryError) ? queryError : normalizeApiError(queryError)) 
@@ -383,7 +403,7 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({
 
   const sharedTableProps = {
     caption: "Transaction history",
-    columns,
+    columns: visibleColumns,
     rows: displayRows,
     rowKey: (row: Transaction) => row.id,
     emptyMessage,
@@ -529,6 +549,46 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({
                     </button>
                   </div>
                 </div>
+
+                <Popover
+                  title={t("txHistory.columns.title")}
+                  content={
+                    <div className="flex flex-col gap-sm" role="group" aria-label={t("txHistory.columns.title")}>
+                      {TRANSACTION_COLUMN_IDS.map((columnId) => {
+                        const isVisible = visibleColumnIds[columnId];
+                        const isLastVisible = isVisible && visibleColumnCount <= 1;
+                        return (
+                          <label
+                            key={columnId}
+                            className="flex items-center gap-sm"
+                            style={{
+                              cursor: isLastVisible ? "not-allowed" : "pointer",
+                              opacity: isLastVisible ? 0.6 : 1,
+                            }}
+                          >
+                            <input
+                              type="checkbox"
+                              checked={isVisible}
+                              disabled={isLastVisible}
+                              onChange={() => toggleTransactionColumnVisibility(columnId)}
+                            />
+                            <span className="text-body-sm">{columnLabelById[columnId]}</span>
+                          </label>
+                        );
+                      })}
+                    </div>
+                  }
+                >
+                  <button
+                    type="button"
+                    className="btn btn-secondary"
+                    style={{ alignSelf: "flex-end", height: "42px", display: "flex", gap: "8px" }}
+                    aria-label={t("txHistory.columns.toggle")}
+                  >
+                    <Columns3 size={16} />
+                    {t("txHistory.columns.button")}
+                  </button>
+                </Popover>
 
                 <button
                   type="button"


### PR DESCRIPTION
closes #620 
closes #621 
closes #626 
closes #652

PR description
Summary
This PR adds four frontend improvements: persisted transaction table column visibility, standardized async wallet action button states, dashboard route prefetching, and a testnet-only pre-mainnet security audit offer banner.

Task 1 — Persisted column visibility for transaction tables
Extended the wallet-scoped preference store (userPreferenceStore.ts) with transactionVisibleColumns for all six transaction columns (type, status, amount, asset, date, hash).
Preferences persist in localStorage alongside existing table settings (density, view mode, page size).
Added setTransactionVisibleColumns and toggleTransactionColumnVisibility with a guard so at least one column stays visible.
Transaction History toolbar now has a Columns popover to show/hide columns; choices are restored per wallet on reload.
Added unit tests for column persistence and the “cannot hide all columns” rule.

Task 2 — Reusable loading button states for async wallet actions
Extended Button with status (idle | pending | success | error) plus optional loadingLabel, successLabel, and errorLabel.
Added useAsyncActionButton hook and AsyncActionButton wrapper for mapping mutation/wallet state to button UI.
Migrated key wallet flows to the shared pattern:
VaultDashboard — USDC approval and confirm deposit/withdraw
WalletConnect — connect / discovering states
TransactionConfirmationModal — signing state

Task 3 — Route prefetch for primary dashboard navigation
Centralized lazy route imports in lib/routePrefetch.ts so prefetch and React.lazy share the same dynamic import functions.
Navbar — prefetches route chunks on link hover/focus (desktop, mobile, and fallback menus).
App — idle-prefetches other primary dashboard routes after mount via requestIdleCallback.
Keyboard shortcuts — prefetches before navigating to /, /portfolio, /analytics, and /transactions.

Task 4 — Security review offer (free initial audit before mainnet)
Added SecurityAuditOfferBanner on the home page, visible only when networkConfig.isTestnet is true.
Banner copy and CTA are i18n-ready (EN + ES); CTA opens a mailto: to request the free pre-mainnet audit.
Placed between the hero and vault dashboard for visibility without blocking core flows.

  