### PR TITLE
[905] Frontend: Build portfolio overview with real-time vault health indicators

### DIFF
--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -89,6 +89,7 @@ const portfolioHoldings = [
   {
     id: 'hold-1',
     asset: 'USDC Treasury Pool',
+    vaultId: 'vault-1',
     vaultName: 'Stellar RWA Yield Fund',
     symbol: 'yvUSDC',
     shares: 1250.5,
@@ -101,6 +102,7 @@ const portfolioHoldings = [
   {
     id: 'hold-2',
     asset: 'Government Bond Basket',
+    vaultId: 'vault-2',
     vaultName: 'Sovereign Income Sleeve',
     symbol: 'yvBOND',
     shares: 840.12,
@@ -113,6 +115,7 @@ const portfolioHoldings = [
   {
     id: 'hold-3',
     asset: 'Short Duration Credit',
+    vaultId: 'vault-3',
     vaultName: 'Liquidity Ladder',
     symbol: 'yvCASH',
     shares: 500.33,
@@ -125,6 +128,7 @@ const portfolioHoldings = [
   {
     id: 'hold-4',
     asset: 'Tokenized T-Bills',
+    vaultId: 'vault-4',
     vaultName: 'USD Treasury Express',
     symbol: 'yvUSTB',
     shares: 1380,
@@ -137,6 +141,7 @@ const portfolioHoldings = [
   {
     id: 'hold-5',
     asset: 'Yield Bearing Cash',
+    vaultId: 'vault-5',
     vaultName: 'Prime Reserve Strategy',
     symbol: 'yvPRIME',
     shares: 320.42,
@@ -149,6 +154,7 @@ const portfolioHoldings = [
   {
     id: 'hold-6',
     asset: 'EM Debt Blend',
+    vaultId: 'vault-6',
     vaultName: 'Global Carry Vault',
     symbol: 'yvEMD',
     shares: 214.1,
@@ -157,6 +163,63 @@ const portfolioHoldings = [
     unrealizedGainUsd: 14.07,
     issuer: 'Templeton',
     status: 'pending',
+  },
+];
+
+const vaultHealth = [
+  {
+    vaultId: 'vault-1',
+    name: 'Stellar RWA Yield Fund',
+    status: 'healthy',
+    latencyMs: 48,
+    uptimePct: 99.98,
+    lastCheckedAt: '2026-07-24T08:45:00.000Z',
+    message: 'All systems operational',
+  },
+  {
+    vaultId: 'vault-2',
+    name: 'Sovereign Income Sleeve',
+    status: 'healthy',
+    latencyMs: 62,
+    uptimePct: 99.95,
+    lastCheckedAt: '2026-07-24T08:45:00.000Z',
+    message: 'All systems operational',
+  },
+  {
+    vaultId: 'vault-3',
+    name: 'Liquidity Ladder',
+    status: 'degraded',
+    latencyMs: 420,
+    uptimePct: 98.2,
+    lastCheckedAt: '2026-07-24T08:45:00.000Z',
+    message: 'Elevated settlement latency',
+  },
+  {
+    vaultId: 'vault-4',
+    name: 'USD Treasury Express',
+    status: 'healthy',
+    latencyMs: 55,
+    uptimePct: 99.99,
+    lastCheckedAt: '2026-07-24T08:45:00.000Z',
+    message: 'All systems operational',
+  },
+  {
+    vaultId: 'vault-5',
+    name: 'Prime Reserve Strategy',
+    status: 'healthy',
+    latencyMs: 71,
+    uptimePct: 99.91,
+    lastCheckedAt: '2026-07-24T08:45:00.000Z',
+    message: 'All systems operational',
+  },
+  {
+    vaultId: 'vault-6',
+    name: 'Global Carry Vault',
+    status: 'unhealthy',
+    latencyMs: 2100,
+    uptimePct: 94.5,
+    lastCheckedAt: '2026-07-24T08:45:00.000Z',
+    message: 'Oracle feed unreachable',
   },
 ];
 
@@ -226,6 +289,13 @@ export async function interceptApiRoutes(page: Page) {
       status: 200,
       contentType: 'application/json',
       body: JSON.stringify(portfolioHoldings),
+    }),
+  );
+  await page.route('**/mock-api/vault-health.json', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(vaultHealth),
     }),
   );
 

--- a/frontend/e2e/portfolio.spec.ts
+++ b/frontend/e2e/portfolio.spec.ts
@@ -27,6 +27,7 @@ test.describe('Portfolio page  authenticated', () => {
     await page.goto('/portfolio');
     await expect(page.getByText(SHORT_ADDR)).toBeVisible({ timeout: 5000 });
     await expect(page.getByText('Total Net Value')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Vault Health' })).toBeVisible();
     await expect(page.getByRole('table', { name: 'Portfolio holdings' })).toBeVisible();
     // Highest value holding from mock data (sorted by valueUsd desc)
     await expect(page.getByText('Tokenized T-Bills')).toBeVisible();

--- a/frontend/public/mock-api/portfolio-holdings.json
+++ b/frontend/public/mock-api/portfolio-holdings.json
@@ -2,6 +2,7 @@
   {
     "id": "hold-1",
     "asset": "USDC Treasury Pool",
+    "vaultId": "vault-1",
     "vaultName": "Stellar RWA Yield Fund",
     "symbol": "yvUSDC",
     "shares": 1250.5,
@@ -14,6 +15,7 @@
   {
     "id": "hold-2",
     "asset": "Government Bond Basket",
+    "vaultId": "vault-2",
     "vaultName": "Sovereign Income Sleeve",
     "symbol": "yvBOND",
     "shares": 840.12,
@@ -26,6 +28,7 @@
   {
     "id": "hold-3",
     "asset": "Short Duration Credit",
+    "vaultId": "vault-3",
     "vaultName": "Liquidity Ladder",
     "symbol": "yvCASH",
     "shares": 500.33,
@@ -38,6 +41,7 @@
   {
     "id": "hold-4",
     "asset": "Tokenized T-Bills",
+    "vaultId": "vault-4",
     "vaultName": "USD Treasury Express",
     "symbol": "yvUSTB",
     "shares": 1380,
@@ -50,6 +54,7 @@
   {
     "id": "hold-5",
     "asset": "Yield Bearing Cash",
+    "vaultId": "vault-5",
     "vaultName": "Prime Reserve Strategy",
     "symbol": "yvPRIME",
     "shares": 320.42,
@@ -62,6 +67,7 @@
   {
     "id": "hold-6",
     "asset": "EM Debt Blend",
+    "vaultId": "vault-6",
     "vaultName": "Global Carry Vault",
     "symbol": "yvEMD",
     "shares": 214.1,

--- a/frontend/public/mock-api/vault-health.json
+++ b/frontend/public/mock-api/vault-health.json
@@ -1,0 +1,56 @@
+[
+  {
+    "vaultId": "vault-1",
+    "name": "Stellar RWA Yield Fund",
+    "status": "healthy",
+    "latencyMs": 48,
+    "uptimePct": 99.98,
+    "lastCheckedAt": "2026-07-24T08:45:00.000Z",
+    "message": "All systems operational"
+  },
+  {
+    "vaultId": "vault-2",
+    "name": "Sovereign Income Sleeve",
+    "status": "healthy",
+    "latencyMs": 62,
+    "uptimePct": 99.95,
+    "lastCheckedAt": "2026-07-24T08:45:00.000Z",
+    "message": "All systems operational"
+  },
+  {
+    "vaultId": "vault-3",
+    "name": "Liquidity Ladder",
+    "status": "degraded",
+    "latencyMs": 420,
+    "uptimePct": 98.2,
+    "lastCheckedAt": "2026-07-24T08:45:00.000Z",
+    "message": "Elevated settlement latency"
+  },
+  {
+    "vaultId": "vault-4",
+    "name": "USD Treasury Express",
+    "status": "healthy",
+    "latencyMs": 55,
+    "uptimePct": 99.99,
+    "lastCheckedAt": "2026-07-24T08:45:00.000Z",
+    "message": "All systems operational"
+  },
+  {
+    "vaultId": "vault-5",
+    "name": "Prime Reserve Strategy",
+    "status": "healthy",
+    "latencyMs": 71,
+    "uptimePct": 99.91,
+    "lastCheckedAt": "2026-07-24T08:45:00.000Z",
+    "message": "All systems operational"
+  },
+  {
+    "vaultId": "vault-6",
+    "name": "Global Carry Vault",
+    "status": "unhealthy",
+    "latencyMs": 2100,
+    "uptimePct": 94.5,
+    "lastCheckedAt": "2026-07-24T08:45:00.000Z",
+    "message": "Oracle feed unreachable"
+  }
+]

--- a/frontend/src/components/PortfolioOverview.test.tsx
+++ b/frontend/src/components/PortfolioOverview.test.tsx
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ComponentProps } from "react";
+import PortfolioOverview from "./PortfolioOverview";
+import type { VaultHealthRecord } from "../lib/vaultHealthApi";
+
+const mockUseVaultHealth = vi.fn();
+
+vi.mock("../hooks/useVaultHealth", () => ({
+  useVaultHealth: (...args: unknown[]) => mockUseVaultHealth(...args),
+}));
+
+const mockHealth: VaultHealthRecord[] = [
+  {
+    vaultId: "vault-1",
+    name: "Stellar RWA Yield Fund",
+    status: "healthy",
+    latencyMs: 48,
+    uptimePct: 99.98,
+    lastCheckedAt: "2026-07-24T08:45:00.000Z",
+    message: "All systems operational",
+  },
+  {
+    vaultId: "vault-3",
+    name: "Liquidity Ladder",
+    status: "degraded",
+    latencyMs: 420,
+    uptimePct: 98.2,
+    lastCheckedAt: "2026-07-24T08:45:00.000Z",
+    message: "Elevated settlement latency",
+  },
+];
+
+function renderOverview(
+  overrides: Partial<ComponentProps<typeof PortfolioOverview>> = {},
+) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <PortfolioOverview
+        totalValue={4627.76}
+        totalGain={122.35}
+        weightedApy={7.42}
+        activePositions={4}
+        holdingsCount={6}
+        locale="en-US"
+        formatSensitiveCurrency={(amount, withSign) => {
+          const formatted = `$${amount.toFixed(2)}`;
+          return withSign && amount >= 0 ? `+${formatted}` : formatted;
+        }}
+        referralStats={null}
+        onShareClick={vi.fn()}
+        {...overrides}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe("PortfolioOverview", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseVaultHealth.mockReturnValue({
+      data: mockHealth,
+      isLoading: false,
+      isError: false,
+    });
+  });
+
+  it("renders summary cards", () => {
+    renderOverview();
+
+    expect(screen.getByText("Total Net Value")).toBeInTheDocument();
+    expect(screen.getByText("Cumulative Yield")).toBeInTheDocument();
+    expect(screen.getByText("Weighted Avg APY")).toBeInTheDocument();
+    expect(screen.getByText("Active Positions")).toBeInTheDocument();
+    expect(screen.getByText("$4627.76")).toBeInTheDocument();
+  });
+
+  it("renders the Vault Health section with per-vault cards", () => {
+    renderOverview();
+
+    expect(screen.getByRole("heading", { name: "Vault Health" })).toBeInTheDocument();
+    expect(screen.getByRole("article", { name: "Stellar RWA Yield Fund" })).toBeInTheDocument();
+    expect(screen.getByRole("article", { name: "Liquidity Ladder" })).toBeInTheDocument();
+    expect(screen.getByText("Elevated settlement latency")).toBeInTheDocument();
+  });
+
+  it("shows a loading message while vault health is fetching", () => {
+    mockUseVaultHealth.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    });
+
+    renderOverview();
+
+    expect(screen.getByRole("status")).toHaveTextContent(/Loading vault health/i);
+  });
+
+  it("shows an error message when vault health fails", () => {
+    mockUseVaultHealth.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    });
+
+    renderOverview();
+
+    expect(screen.getByRole("alert")).toHaveTextContent(/Unable to load vault health/i);
+  });
+});

--- a/frontend/src/components/PortfolioOverview.tsx
+++ b/frontend/src/components/PortfolioOverview.tsx
@@ -1,0 +1,269 @@
+import React, { useMemo } from "react";
+import { Activity, TrendingUp, DollarSign, Percent, Briefcase, Share2 } from "./icons";
+import { useTranslation } from "../i18n";
+import HelpIcon from "./ui/HelpIcon";
+import VaultHealthIndicator from "./VaultHealthIndicator";
+import { useVaultHealth } from "../hooks/useVaultHealth";
+import { formatPercent } from "../lib/formatters";
+import type { VaultHealthRecord } from "../lib/vaultHealthApi";
+
+export interface PortfolioOverviewReferralStats {
+  total_reward_earned: string | number;
+  referral_count: number;
+}
+
+export interface PortfolioOverviewProps {
+  totalValue: number;
+  totalGain: number;
+  weightedApy: number;
+  activePositions: number;
+  holdingsCount: number;
+  locale: string;
+  formatSensitiveCurrency: (amount: number, withSign?: boolean) => string;
+  referralStats?: PortfolioOverviewReferralStats | null;
+  onShareClick: () => void;
+}
+
+const PortfolioSummaryCard: React.FC<{
+  label: React.ReactNode;
+  value: string;
+  icon: React.ReactNode;
+  trend?: string;
+  trendPositive?: boolean;
+  onClick?: () => void;
+  clickable?: boolean;
+}> = ({ label, value, icon, trend, trendPositive, onClick, clickable }) => (
+  <div
+    className="glass-panel"
+    style={{
+      padding: "24px",
+      background: "var(--bg-muted)",
+      position: "relative",
+      overflow: "hidden",
+      border: "1px solid var(--border-glass)",
+      transition: "transform 0.2s ease",
+      cursor: clickable ? "pointer" : "default",
+    }}
+    onMouseEnter={(e) =>
+      (e.currentTarget.style.transform = clickable ? "translateY(-4px)" : "translateY(-2px)")
+    }
+    onMouseLeave={(e) => (e.currentTarget.style.transform = "translateY(0)")}
+    onClick={onClick}
+  >
+    <div style={{ position: "absolute", top: "-10px", right: "-10px", opacity: 0.05 }}>
+      {React.cloneElement(icon as React.ReactElement<Record<string, unknown>>, { size: 80 })}
+    </div>
+    <div
+      className="flex items-center gap-sm"
+      style={{ color: "var(--text-secondary)", marginBottom: "12px" }}
+    >
+      {icon}
+      <span className="text-body-sm" style={{ fontWeight: 500, letterSpacing: "0.02em" }}>
+        {label}
+      </span>
+    </div>
+    <div
+      style={{
+        fontSize: "2rem",
+        fontWeight: 700,
+        fontFamily: "var(--font-display)",
+        color: "var(--text-primary)",
+      }}
+    >
+      {value}
+    </div>
+    {trend && (
+      <div
+        style={{
+          marginTop: "8px",
+          fontSize: "0.85rem",
+          color: trendPositive ? "var(--accent-cyan)" : "var(--text-error)",
+          fontWeight: 600,
+          display: "flex",
+          alignItems: "center",
+          gap: "4px",
+        }}
+      >
+        {trendPositive ? <TrendingUp size={14} /> : <Activity size={14} />}
+        {trend}
+      </div>
+    )}
+  </div>
+);
+
+function formatLatency(ms: number): string {
+  return ms < 1000 ? `${ms}ms` : `${(ms / 1000).toFixed(1)}s`;
+}
+
+const VaultHealthCard: React.FC<{ record: VaultHealthRecord }> = ({ record }) => {
+  const { t } = useTranslation();
+
+  return (
+    <article className="vault-health-card glass-panel" aria-label={record.name}>
+      <div className="vault-health-card__header">
+        <VaultHealthIndicator
+          status={record.status}
+          message={record.message}
+          vaultName={record.name}
+        />
+        <div className="vault-health-card__titles">
+          <h3 className="vault-health-card__name">{record.name}</h3>
+          <span className={`vault-health-card__status vault-health-card__status--${record.status}`}>
+            {t(`portfolio.health.${record.status}`)}
+          </span>
+        </div>
+      </div>
+      <p className="vault-health-card__message">{record.message}</p>
+      <dl className="vault-health-card__meta">
+        <div>
+          <dt>{t("portfolio.health.latency")}</dt>
+          <dd>{formatLatency(record.latencyMs)}</dd>
+        </div>
+        <div>
+          <dt>{t("portfolio.health.uptime")}</dt>
+          <dd>{record.uptimePct.toFixed(2)}%</dd>
+        </div>
+      </dl>
+    </article>
+  );
+};
+
+const PortfolioOverview: React.FC<PortfolioOverviewProps> = ({
+  totalValue,
+  totalGain,
+  weightedApy,
+  activePositions,
+  holdingsCount,
+  locale,
+  formatSensitiveCurrency,
+  referralStats,
+  onShareClick,
+}) => {
+  const { t } = useTranslation();
+  const { data: vaultHealth = [], isLoading, isError } = useVaultHealth(true);
+
+  const totalNetValueTrend = useMemo(() => {
+    if (totalValue === 0) return "N/A";
+    const trendPercent = (totalGain / (totalValue - totalGain)) * 100;
+    return Number.isFinite(trendPercent)
+      ? `${formatPercent(trendPercent, {
+          locale,
+          minimumFractionDigits: 1,
+          maximumFractionDigits: 1,
+        })} gain`
+      : "N/A";
+  }, [locale, totalValue, totalGain]);
+
+  const cumulativeYieldTrend = useMemo(() => {
+    if (totalGain === 0) return "--";
+    return `${formatSensitiveCurrency(totalGain)} realized`;
+  }, [totalGain, formatSensitiveCurrency]);
+
+  const weightedApyTrend = useMemo(() => {
+    if (holdingsCount === 0) return "N/A";
+    return `${holdingsCount} position${holdingsCount !== 1 ? "s" : ""}`;
+  }, [holdingsCount]);
+
+  return (
+    <div className="portfolio-overview">
+      <div className="portfolio-summary-grid" style={{ marginBottom: "8px" }}>
+        <PortfolioSummaryCard
+          label={t("portfolio.totalNetValue")}
+          value={formatSensitiveCurrency(totalValue)}
+          icon={<DollarSign size={20} color="var(--accent-cyan)" />}
+          trend={totalNetValueTrend}
+          trendPositive={totalGain >= 0}
+        />
+        <PortfolioSummaryCard
+          label={t("portfolio.cumulativeYield")}
+          value={formatSensitiveCurrency(totalGain, true)}
+          icon={<TrendingUp size={20} color="var(--accent-purple)" />}
+          trend={cumulativeYieldTrend}
+          trendPositive={totalGain >= 0}
+        />
+        <PortfolioSummaryCard
+          label={
+            <span style={{ display: "flex", alignItems: "center", gap: "6px" }}>
+              {t("portfolio.overview.weightedApy")}
+              <HelpIcon
+                variant="tooltip"
+                content={t("portfolio.overview.weightedApyTooltip")}
+              />
+            </span>
+          }
+          value={formatPercent(weightedApy, {
+            locale,
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+          })}
+          icon={<Percent size={20} color="var(--accent-cyan)" />}
+          trend={weightedApyTrend}
+          trendPositive={true}
+        />
+        <PortfolioSummaryCard
+          label={t("portfolio.activePositions")}
+          value={activePositions.toString()}
+          icon={<Briefcase size={20} color="var(--text-secondary)" />}
+        />
+        <PortfolioSummaryCard
+          label={
+            <span style={{ display: "flex", alignItems: "center", gap: "6px" }}>
+              {t("portfolio.overview.referralEarnings")}
+              <HelpIcon variant="tooltip" content={t("portfolio.referralTooltip")} />
+            </span>
+          }
+          value={referralStats ? `$${referralStats.total_reward_earned}` : "$0.00"}
+          icon={<TrendingUp size={20} color="var(--accent-green)" />}
+          trend={
+            referralStats
+              ? `${referralStats.referral_count} referral${referralStats.referral_count !== 1 ? "s" : ""}`
+              : "0 referrals"
+          }
+          trendPositive={true}
+        />
+        <PortfolioSummaryCard
+          label={t("portfolio.shareReferralLink")}
+          value=""
+          icon={<Share2 size={20} color="var(--accent-cyan)" />}
+          onClick={onShareClick}
+          clickable={true}
+        />
+      </div>
+
+      <section className="vault-health-section" aria-labelledby="vault-health-heading">
+        <div className="vault-health-section__header">
+          <h2 id="vault-health-heading">{t("portfolio.health.title")}</h2>
+          <p className="text-body-sm" style={{ color: "var(--text-secondary)" }}>
+            {t("portfolio.health.description")}
+          </p>
+        </div>
+
+        {isLoading && (
+          <p className="vault-health-section__status" role="status">
+            {t("portfolio.health.loading")}
+          </p>
+        )}
+
+        {isError && (
+          <p className="vault-health-section__status vault-health-section__status--error" role="alert">
+            {t("portfolio.health.error")}
+          </p>
+        )}
+
+        {!isLoading && !isError && vaultHealth.length === 0 && (
+          <p className="vault-health-section__status">{t("portfolio.health.empty")}</p>
+        )}
+
+        {!isLoading && !isError && vaultHealth.length > 0 && (
+          <div className="vault-health-grid">
+            {vaultHealth.map((record) => (
+              <VaultHealthCard key={record.vaultId} record={record} />
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+};
+
+export default PortfolioOverview;

--- a/frontend/src/components/VaultHealthIndicator.test.tsx
+++ b/frontend/src/components/VaultHealthIndicator.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import VaultHealthIndicator from "./VaultHealthIndicator";
+
+describe("VaultHealthIndicator", () => {
+  it("renders a healthy status indicator with accessible label", () => {
+    render(
+      <VaultHealthIndicator
+        status="healthy"
+        vaultName="Stellar RWA Yield Fund"
+        message="All systems operational"
+      />,
+    );
+
+    expect(
+      screen.getByRole("status", {
+        name: /Stellar RWA Yield Fund: Healthy\. All systems operational/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders degraded and unhealthy statuses", () => {
+    const { rerender } = render(
+      <VaultHealthIndicator status="degraded" message="Elevated latency" />,
+    );
+    expect(screen.getByRole("status", { name: /Degraded/i })).toBeInTheDocument();
+
+    rerender(<VaultHealthIndicator status="unhealthy" message="Oracle down" />);
+    expect(screen.getByRole("status", { name: /Unhealthy/i })).toBeInTheDocument();
+  });
+
+  it("shows a tooltip on hover", () => {
+    render(
+      <VaultHealthIndicator
+        status="degraded"
+        vaultName="Liquidity Ladder"
+        message="Elevated settlement latency"
+      />,
+    );
+
+    fireEvent.mouseEnter(screen.getByRole("status"));
+
+    expect(screen.getByRole("tooltip")).toHaveTextContent(/Liquidity Ladder/);
+    expect(screen.getByRole("tooltip")).toHaveTextContent(/Elevated settlement latency/);
+  });
+
+  it("applies compact class when compact is true", () => {
+    const { container } = render(
+      <VaultHealthIndicator status="healthy" compact />,
+    );
+
+    expect(container.firstChild).toHaveClass("vault-health-indicator--compact");
+  });
+});

--- a/frontend/src/components/VaultHealthIndicator.tsx
+++ b/frontend/src/components/VaultHealthIndicator.tsx
@@ -1,0 +1,97 @@
+import React, { useRef, useState, useCallback } from "react";
+import { useTranslation } from "../i18n";
+import type { VaultHealthStatus } from "../lib/vaultHealthApi";
+
+const STATUS_CONFIG = {
+  healthy: { dot: "rgb(34, 197, 94)", glow: "rgba(34, 197, 94, 0.35)", labelId: "portfolio.health.healthy" },
+  degraded: { dot: "rgb(234, 179, 8)", glow: "rgba(234, 179, 8, 0.35)", labelId: "portfolio.health.degraded" },
+  unhealthy: { dot: "rgb(239, 68, 68)", glow: "rgba(239, 68, 68, 0.35)", labelId: "portfolio.health.unhealthy" },
+} as const satisfies Record<
+  VaultHealthStatus,
+  { dot: string; glow: string; labelId: string }
+>;
+
+export interface VaultHealthIndicatorProps {
+  status: VaultHealthStatus;
+  message?: string;
+  vaultName?: string;
+  /** Compact mode for inline table cells (smaller dot, no outer glow). */
+  compact?: boolean;
+}
+
+const VaultHealthIndicator: React.FC<VaultHealthIndicatorProps> = ({
+  status,
+  message,
+  vaultName,
+  compact = false,
+}) => {
+  const { t } = useTranslation();
+  const [show, setShow] = useState(false);
+  const [pos, setPos] = useState<"top" | "bottom">("top");
+  const ref = useRef<HTMLDivElement>(null);
+  const { dot, glow, labelId } = STATUS_CONFIG[status];
+  const label = t(labelId);
+  const size = compact ? 8 : 10;
+
+  const onEnter = useCallback(() => {
+    if (ref.current) {
+      setPos(
+        ref.current.getBoundingClientRect().top < window.innerHeight / 3
+          ? "bottom"
+          : "top",
+      );
+    }
+    setShow(true);
+  }, []);
+
+  const ariaLabel = vaultName
+    ? `${vaultName}: ${label}${message ? `. ${message}` : ""}`
+    : `${t("portfolio.health.title")}: ${label}${message ? `. ${message}` : ""}`;
+
+  return (
+    <div
+      ref={ref}
+      className={`vault-health-indicator vault-health-indicator--${status}${compact ? " vault-health-indicator--compact" : ""}`}
+      onMouseEnter={onEnter}
+      onMouseLeave={() => setShow(false)}
+      onFocus={onEnter}
+      onBlur={() => setShow(false)}
+    >
+      <span
+        role="status"
+        tabIndex={0}
+        aria-label={ariaLabel}
+        className="vault-health-indicator__dot"
+        style={{
+          width: size,
+          height: size,
+          background: dot,
+          boxShadow: compact ? `0 0 0 2px ${glow}` : `0 0 0 3px ${glow}`,
+          animation:
+            status === "unhealthy"
+              ? "vaultHealthPulseHard 1.8s ease-in-out infinite"
+              : status === "degraded"
+                ? "vaultHealthPulseSoft 2.5s ease-in-out infinite"
+                : "none",
+        }}
+      />
+
+      {show && (
+        <div
+          role="tooltip"
+          className={`vault-health-indicator__tooltip vault-health-indicator__tooltip--${pos}`}
+          style={{ borderColor: `${dot}33` }}
+        >
+          <div className="vault-health-indicator__tooltip-title" style={{ color: dot }}>
+            {vaultName ? `${vaultName} — ${label}` : label}
+          </div>
+          {message && (
+            <div className="vault-health-indicator__tooltip-message">{message}</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default VaultHealthIndicator;

--- a/frontend/src/hooks/useVaultHealth.ts
+++ b/frontend/src/hooks/useVaultHealth.ts
@@ -1,0 +1,21 @@
+import { useQuery } from "@tanstack/react-query";
+import { getVaultHealth } from "../lib/vaultHealthApi";
+import { queryKeys } from "../lib/queryClient";
+
+/** Poll interval for real-time vault health indicators (15 seconds). */
+export const VAULT_HEALTH_POLL_INTERVAL_MS = 15_000;
+
+/**
+ * Hook for fetching vault health with caching and 15s polling.
+ *
+ * @param enabled - Optional flag to enable/disable polling (defaults to true)
+ */
+export function useVaultHealth(enabled = true) {
+  return useQuery({
+    queryKey: queryKeys.vault.health(),
+    queryFn: getVaultHealth,
+    staleTime: VAULT_HEALTH_POLL_INTERVAL_MS,
+    refetchInterval: VAULT_HEALTH_POLL_INTERVAL_MS,
+    enabled,
+  });
+}

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -509,6 +509,25 @@ export const en = {
     pendingStatus: "Pending",
     searchPlaceholder: "Search asset, vault, issuer...",
     tableCaption: "Portfolio holdings",
+    overview: {
+      weightedApy: "Weighted Avg APY",
+      weightedApyTooltip:
+        "The portfolio-value-weighted average of all active position APYs.",
+      referralEarnings: "Referral Earnings",
+    },
+    health: {
+      title: "Vault Health",
+      description:
+        "Live operational status for each vault, refreshed every 15 seconds.",
+      healthy: "Healthy",
+      degraded: "Degraded",
+      unhealthy: "Unhealthy",
+      latency: "Latency",
+      uptime: "Uptime",
+      loading: "Loading vault health…",
+      error: "Unable to load vault health",
+      empty: "No vault health data available",
+    },
   },
   networkQuality: {
     fast: "Fast network",

--- a/frontend/src/i18n/locales/es.ts
+++ b/frontend/src/i18n/locales/es.ts
@@ -495,6 +495,25 @@ export const es = {
     pendingStatus: "Pendiente",
     searchPlaceholder: "Buscar activo, bóveda, emisor...",
     tableCaption: "Posiciones del portafolio",
+    overview: {
+      weightedApy: "APY promedio ponderado",
+      weightedApyTooltip:
+        "El promedio ponderado por valor de portafolio de todos los APY de posiciones activas.",
+      referralEarnings: "Ganancias por referencias",
+    },
+    health: {
+      title: "Salud de la bóveda",
+      description:
+        "Estado operativo en vivo de cada bóveda, actualizado cada 15 segundos.",
+      healthy: "Saludable",
+      degraded: "Degradado",
+      unhealthy: "No saludable",
+      latency: "Latencia",
+      uptime: "Disponibilidad",
+      loading: "Cargando salud de la bóveda…",
+      error: "No se pudo cargar la salud de la bóveda",
+      empty: "No hay datos de salud de la bóveda disponibles",
+    },
   },
   networkQuality: {
     fast: "Red rápida",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2171,6 +2171,223 @@ button {
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
+/* ── Portfolio overview + vault health ───────────────────────── */
+.portfolio-overview {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.vault-health-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.vault-health-section__header h2 {
+  margin: 0 0 6px;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.vault-health-section__status {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.vault-health-section__status--error {
+  color: var(--text-error);
+}
+
+.vault-health-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.vault-health-card {
+  padding: 16px 18px;
+  background: var(--bg-muted);
+  border: 1px solid var(--border-glass);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.vault-health-card__header {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.vault-health-card__titles {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.vault-health-card__name {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.3;
+}
+
+.vault-health-card__status {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: capitalize;
+}
+
+.vault-health-card__status--healthy {
+  color: #22c55e;
+}
+
+.vault-health-card__status--degraded {
+  color: #eab308;
+}
+
+.vault-health-card__status--unhealthy {
+  color: #ef4444;
+}
+
+.vault-health-card__message {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+
+.vault-health-card__meta {
+  display: flex;
+  gap: 20px;
+  margin: 0;
+}
+
+.vault-health-card__meta div {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.vault-health-card__meta dt {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-secondary);
+  opacity: 0.75;
+}
+
+.vault-health-card__meta dd {
+  margin: 0;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.vault-health-indicator {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.vault-health-indicator__dot {
+  display: inline-block;
+  border-radius: 50%;
+  outline-offset: 3px;
+}
+
+.vault-health-indicator__dot:focus-visible {
+  outline: 2px solid var(--accent-cyan);
+}
+
+.vault-health-indicator__tooltip {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  min-width: 160px;
+  max-width: 240px;
+  background: var(--bg-surface, #1a1a2e);
+  border: 1px solid var(--border-glass);
+  border-radius: 8px;
+  padding: 8px 12px;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  z-index: 1000;
+  pointer-events: none;
+  white-space: normal;
+}
+
+.vault-health-indicator__tooltip--top {
+  bottom: calc(100% + 10px);
+}
+
+.vault-health-indicator__tooltip--bottom {
+  top: calc(100% + 10px);
+}
+
+.vault-health-indicator__tooltip-title {
+  font-weight: 600;
+  font-size: 0.8rem;
+  margin-bottom: 4px;
+}
+
+.vault-health-indicator__tooltip-message {
+  line-height: 1.35;
+}
+
+.asset-cell-with-health {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.asset-cell-with-health__indicator {
+  margin-top: 6px;
+}
+
+@keyframes vaultHealthPulseHard {
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.55;
+    transform: scale(0.9);
+  }
+}
+
+@keyframes vaultHealthPulseSoft {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.7;
+  }
+}
+
+@media (max-width: 768px) {
+  .vault-health-grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 12px;
+  }
+}
+
+@media (max-width: 480px) {
+  .vault-health-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 /* ── Analytics metrics grid ──────────────────────────────────── */
 .analytics-metrics-grid {
   display: grid;

--- a/frontend/src/lib/portfolioApi.ts
+++ b/frontend/src/lib/portfolioApi.ts
@@ -4,6 +4,7 @@ import { validate, PortfolioQuerySchema } from "./api";
 export interface PortfolioHolding {
   id: string;
   asset: string;
+  vaultId: string;
   vaultName: string;
   symbol: string;
   shares: number;

--- a/frontend/src/lib/queryClient.ts
+++ b/frontend/src/lib/queryClient.ts
@@ -39,6 +39,7 @@ export const queryKeys = {
     summary: () => [...queryKeys.vault.all, "summary"] as const,
     history: () => [...queryKeys.vault.all, "history"] as const,
     sharePrice: () => [...queryKeys.vault.all, "sharePrice"] as const,
+    health: () => [...queryKeys.vault.all, "health"] as const,
   },
   portfolio: {
     all: ["portfolio"] as const,

--- a/frontend/src/lib/vaultHealthApi.test.ts
+++ b/frontend/src/lib/vaultHealthApi.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getVaultHealth, VaultHealthResponseSchema } from "./vaultHealthApi";
+import { ValidationError } from "./api";
+
+const { mockGet } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+}));
+
+vi.mock("./apiClient", () => ({
+  apiClient: {
+    get: mockGet,
+  },
+}));
+
+const validRecords = [
+  {
+    vaultId: "vault-1",
+    name: "Stellar RWA Yield Fund",
+    status: "healthy",
+    latencyMs: 48,
+    uptimePct: 99.98,
+    lastCheckedAt: "2026-07-24T08:45:00.000Z",
+    message: "All systems operational",
+  },
+  {
+    vaultId: "vault-3",
+    name: "Liquidity Ladder",
+    status: "degraded",
+    latencyMs: 420,
+    uptimePct: 98.2,
+    lastCheckedAt: "2026-07-24T08:45:00.000Z",
+    message: "Elevated settlement latency",
+  },
+  {
+    vaultId: "vault-6",
+    name: "Global Carry Vault",
+    status: "unhealthy",
+    latencyMs: 2100,
+    uptimePct: 94.5,
+    lastCheckedAt: "2026-07-24T08:45:00.000Z",
+    message: "Oracle feed unreachable",
+  },
+];
+
+describe("VaultHealthResponseSchema", () => {
+  it("accepts a valid vault health payload", () => {
+    const result = VaultHealthResponseSchema.safeParse(validRecords);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an unknown status value", () => {
+    const result = VaultHealthResponseSchema.safeParse([
+      { ...validRecords[0], status: "offline" },
+    ]);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing required fields", () => {
+    const result = VaultHealthResponseSchema.safeParse([
+      { vaultId: "vault-1", status: "healthy" },
+    ]);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("getVaultHealth", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns validated vault health records", async () => {
+    mockGet.mockResolvedValue(validRecords);
+
+    const records = await getVaultHealth();
+
+    expect(mockGet).toHaveBeenCalledWith("/mock-api/vault-health.json");
+    expect(records).toEqual(validRecords);
+    expect(records).toHaveLength(3);
+  });
+
+  it("throws ValidationError when the payload is invalid", async () => {
+    mockGet.mockResolvedValue([{ vaultId: "vault-1" }]);
+
+    await expect(getVaultHealth()).rejects.toBeInstanceOf(ValidationError);
+  });
+});

--- a/frontend/src/lib/vaultHealthApi.ts
+++ b/frontend/src/lib/vaultHealthApi.ts
@@ -1,0 +1,33 @@
+import { z } from "zod";
+import { apiClient } from "./apiClient";
+import { validate } from "./api";
+
+export const VaultHealthStatusSchema = z.enum([
+  "healthy",
+  "degraded",
+  "unhealthy",
+]);
+
+export const VaultHealthRecordSchema = z.object({
+  vaultId: z.string().min(1),
+  name: z.string().min(1),
+  status: VaultHealthStatusSchema,
+  latencyMs: z.number().nonnegative(),
+  uptimePct: z.number().min(0).max(100),
+  lastCheckedAt: z.string().min(1),
+  message: z.string(),
+});
+
+export const VaultHealthResponseSchema = z.array(VaultHealthRecordSchema);
+
+export type VaultHealthStatus = z.infer<typeof VaultHealthStatusSchema>;
+export type VaultHealthRecord = z.infer<typeof VaultHealthRecordSchema>;
+
+/**
+ * Fetch live vault health indicators from the mock (or upstream) health API.
+ * Response is validated with Zod before returning.
+ */
+export async function getVaultHealth(): Promise<VaultHealthRecord[]> {
+  const data = await apiClient.get<unknown>("/mock-api/vault-health.json");
+  return validate(VaultHealthResponseSchema, data, "VaultHealth");
+}

--- a/frontend/src/pages/Portfolio.emptystate.test.tsx
+++ b/frontend/src/pages/Portfolio.emptystate.test.tsx
@@ -20,6 +20,14 @@ vi.mock("../hooks/useReferral", () => ({
   useReferralLink: vi.fn().mockReturnValue({ referralLink: null, referralCode: null }),
 }));
 
+vi.mock("../hooks/useVaultHealth", () => ({
+  useVaultHealth: vi.fn().mockReturnValue({
+    data: [],
+    isLoading: false,
+    isError: false,
+  }),
+}));
+
 vi.mock("../components/YieldBreakdownChart", () => ({
   default: () => <div data-testid="yield-chart" />,
 }));
@@ -50,6 +58,7 @@ function renderPortfolio(walletAddress: string | null) {
 const mockHolding: PortfolioHolding = {
   id: "pos-1",
   asset: "USDC",
+  vaultId: "vault-1",
   vaultName: "RWA Vault",
   symbol: "yvUSDC",
   issuer: "G...",

--- a/frontend/src/pages/Portfolio.test.tsx
+++ b/frontend/src/pages/Portfolio.test.tsx
@@ -18,6 +18,33 @@ vi.mock("../hooks/useReferral", () => ({
   useReferralLink: vi.fn().mockReturnValue({ referralLink: null, referralCode: null }),
 }));
 
+vi.mock("../hooks/useVaultHealth", () => ({
+  useVaultHealth: vi.fn().mockReturnValue({
+    data: [
+      {
+        vaultId: "vault-1",
+        name: "Stellar RWA Yield Fund",
+        status: "healthy",
+        latencyMs: 48,
+        uptimePct: 99.98,
+        lastCheckedAt: "2026-07-24T08:45:00.000Z",
+        message: "All systems operational",
+      },
+      {
+        vaultId: "vault-4",
+        name: "USD Treasury Express",
+        status: "healthy",
+        latencyMs: 55,
+        uptimePct: 99.99,
+        lastCheckedAt: "2026-07-24T08:45:00.000Z",
+        message: "All systems operational",
+      },
+    ],
+    isLoading: false,
+    isError: false,
+  }),
+}));
+
 vi.mock("../components/YieldBreakdownChart", () => ({
   default: () => <div data-testid="yield-chart" />,
 }));
@@ -30,6 +57,7 @@ const mockHoldings: PortfolioHolding[] = [
   {
     id: "hold-1",
     asset: "USDC Treasury Pool",
+    vaultId: "vault-1",
     vaultName: "Stellar RWA Yield Fund",
     symbol: "yvUSDC",
     shares: 1250.5,
@@ -42,6 +70,7 @@ const mockHoldings: PortfolioHolding[] = [
   {
     id: "hold-2",
     asset: "Government Bond Basket",
+    vaultId: "vault-2",
     vaultName: "Sovereign Income Sleeve",
     symbol: "yvBOND",
     shares: 840.12,
@@ -54,6 +83,7 @@ const mockHoldings: PortfolioHolding[] = [
   {
     id: "hold-3",
     asset: "Short Duration Credit",
+    vaultId: "vault-3",
     vaultName: "Liquidity Ladder",
     symbol: "yvCASH",
     shares: 500.33,
@@ -66,6 +96,7 @@ const mockHoldings: PortfolioHolding[] = [
   {
     id: "hold-4",
     asset: "Tokenized T-Bills",
+    vaultId: "vault-4",
     vaultName: "USD Treasury Express",
     symbol: "yvUSTB",
     shares: 1380,
@@ -78,6 +109,7 @@ const mockHoldings: PortfolioHolding[] = [
   {
     id: "hold-5",
     asset: "Yield Bearing Cash",
+    vaultId: "vault-5",
     vaultName: "Prime Reserve Strategy",
     symbol: "yvPRIME",
     shares: 320.42,
@@ -90,6 +122,7 @@ const mockHoldings: PortfolioHolding[] = [
   {
     id: "hold-6",
     asset: "EM Debt Blend",
+    vaultId: "vault-6",
     vaultName: "Global Carry Vault",
     symbol: "yvEMD",
     shares: 214.1,
@@ -164,10 +197,11 @@ describe("Portfolio", () => {
     renderPortfolio();
 
     await waitForHoldingsToLoad();
-    expect(screen.getByText(/Tokenized T-Bills/i)).toBeInTheDocument();
-    expect(screen.getByRole("table")).toBeInTheDocument();
+    const table = screen.getByRole("table");
+    expect(within(table).getByText(/Tokenized T-Bills/i)).toBeInTheDocument();
+    expect(table).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Sort by Asset/i })).toBeInTheDocument();
-    expect(screen.getAllByText(/Position ID:/i).length).toBeGreaterThan(0);
+    expect(within(table).getAllByText(/Position ID:/i).length).toBeGreaterThan(0);
     expect(screen.getAllByRole("button", { name: /Copy position ID/i }).length).toBeGreaterThan(0);
   });
 
@@ -179,8 +213,9 @@ describe("Portfolio", () => {
     fireEvent.change(searchInput, { target: { value: "OpenEden" } });
 
     await waitFor(() => {
-      expect(screen.getByText(/Tokenized T-Bills/i)).toBeInTheDocument();
-      expect(screen.queryByText(/USDC Treasury Pool/i)).not.toBeInTheDocument();
+      const table = screen.getByRole("table");
+      expect(within(table).getByText(/Tokenized T-Bills/i)).toBeInTheDocument();
+      expect(within(table).queryByText(/USDC Treasury Pool/i)).not.toBeInTheDocument();
       expect(screen.getByTestId("location-display")).toHaveTextContent(
         "search=OpenEden",
       );
@@ -191,8 +226,9 @@ describe("Portfolio", () => {
     renderPortfolio("/portfolio?page=1&pageSize=10&sortBy=asset&sortDirection=asc");
 
     await waitForHoldingsToLoad();
-    expect(screen.getByText(/Tokenized T-Bills/i)).toBeInTheDocument();
-    expect(screen.getByText(/Government Bond Basket/i)).toBeInTheDocument();
+    const table = screen.getByRole("table");
+    expect(within(table).getByText(/Tokenized T-Bills/i)).toBeInTheDocument();
+    expect(within(table).getByText(/Government Bond Basket/i)).toBeInTheDocument();
 
     const assetSort = screen.getByRole("button", { name: /Sort by Asset/i });
     fireEvent.keyDown(assetSort, { key: "Enter" });
@@ -200,5 +236,12 @@ describe("Portfolio", () => {
     await waitFor(() => {
       expect(screen.getByTestId("location-display").textContent).toMatch(/sortBy=asset/);
     });
+  });
+
+  it("shows vault health overview section", async () => {
+    renderPortfolio();
+
+    await waitForHoldingsToLoad();
+    expect(screen.getByRole("heading", { name: "Vault Health" })).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/Portfolio.tsx
+++ b/frontend/src/pages/Portfolio.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState, useEffect, useRef, useCallback } from "react";
-import { Activity, TrendingUp, DollarSign, Percent, Briefcase, Share2 } from "../components/icons";
+import { Briefcase } from "../components/icons";
 import { useTranslation } from "../i18n";
 import ApiStatusBanner from "../components/ApiStatusBanner";
 import {
@@ -19,7 +19,6 @@ import {
   type PortfolioHolding,
 } from "../lib/portfolioApi";
 import { useClientDataTable } from "../hooks/useClientDataTable";
-import HelpIcon from "../components/ui/HelpIcon";
 import { useUrlState } from "../hooks/useUrlState";
 import { useServerDataTable } from "../hooks/useServerDataTable";
 import { useToast } from "../context/ToastContext";
@@ -29,65 +28,18 @@ import { useReferralStats, useReferralLink } from "../hooks/useReferral";
 import ShareModal from "../components/ShareModal";
 import EmptyState from "../components/ui/EmptyState";
 import FirstTimePortfolioPanel from "../components/FirstTimePortfolioPanel";
+import PortfolioOverview from "../components/PortfolioOverview";
+import VaultHealthIndicator from "../components/VaultHealthIndicator";
+import { useVaultHealth } from "../hooks/useVaultHealth";
 import { useNavigate } from "react-router-dom";
 import { triggerDepositIntent } from "../lib/vaultIntentActions";
 import { formatCurrency, formatNumber, formatPercent } from "../lib/formatters";
 import { displayBalance } from "../lib/maskSensitiveValues";
+import type { VaultHealthStatus } from "../lib/vaultHealthApi";
 
 interface PortfolioProps {
   walletAddress: string | null;
 }
-
-const PortfolioSummaryCard: React.FC<{
-  label: React.ReactNode;
-  value: string;
-  icon: React.ReactNode;
-  trend?: string;
-  trendPositive?: boolean;
-  onClick?: () => void;
-  clickable?: boolean;
-}> = ({ label, value, icon, trend, trendPositive, onClick, clickable }) => (
-  <div
-    className="glass-panel"
-    style={{
-      padding: "24px",
-      background: "var(--bg-muted)",
-      position: "relative",
-      overflow: "hidden",
-      border: "1px solid var(--border-glass)",
-      transition: "transform 0.2s ease",
-      cursor: clickable ? "pointer" : "default",
-    }}
-    onMouseEnter={(e) => e.currentTarget.style.transform = clickable ? "translateY(-4px)" : "translateY(-2px)"}
-    onMouseLeave={(e) => e.currentTarget.style.transform = "translateY(0)"}
-    onClick={onClick}
-  >
-    <div style={{ position: "absolute", top: "-10px", right: "-10px", opacity: 0.05 }}>
-      {React.cloneElement(icon as React.ReactElement<Record<string, unknown>>, { size: 80 })}
-    </div>
-    <div className="flex items-center gap-sm" style={{ color: "var(--text-secondary)", marginBottom: "12px" }}>
-      {icon}
-      <span className="text-body-sm" style={{ fontWeight: 500, letterSpacing: "0.02em" }}>{label}</span>
-    </div>
-    <div style={{ fontSize: "2rem", fontWeight: 700, fontFamily: "var(--font-display)", color: "var(--text-primary)" }}>
-      {value}
-    </div>
-    {trend && (
-      <div style={{ 
-        marginTop: "8px", 
-        fontSize: "0.85rem", 
-        color: trendPositive ? "var(--accent-cyan)" : "var(--text-error)",
-        fontWeight: 600,
-        display: "flex",
-        alignItems: "center",
-        gap: "4px"
-      }}>
-        {trendPositive ? <TrendingUp size={14} /> : <Activity size={14} />}
-        {trend}
-      </div>
-    )}
-  </div>
-);
 
 const Portfolio: React.FC<PortfolioProps> = ({ walletAddress }) => {
   const toast = useToast();
@@ -104,6 +56,19 @@ const Portfolio: React.FC<PortfolioProps> = ({ walletAddress }) => {
   const [showShareModal, setShowShareModal] = useState(false);
   const locale = preferences.locale;
   const currency = preferences.currency;
+
+  const { data: vaultHealth = [] } = useVaultHealth(Boolean(walletAddress));
+  const healthByVaultId = useMemo(() => {
+    const map = new Map<string, { status: VaultHealthStatus; message: string; name: string }>();
+    for (const record of vaultHealth) {
+      map.set(record.vaultId, {
+        status: record.status,
+        message: record.message,
+        name: record.name,
+      });
+    }
+    return map;
+  }, [vaultHealth]);
 
   const formatSensitiveCurrency = useCallback((amount: number, withSign = false) => {
     if (!preferences.showBalances) {
@@ -237,26 +202,41 @@ const Portfolio: React.FC<PortfolioProps> = ({ walletAddress }) => {
       header: t("portfolio.assetHeader"),
       sortable: true,
       width: "28%",
-      cell: (row) => (
-        <div>
-          <div style={{ fontWeight: 600 }}>{row.asset}</div>
-          <div style={{ color: "var(--text-secondary)", fontSize: "0.82rem" }}>
-            {row.vaultName}
+      cell: (row) => {
+        const health = healthByVaultId.get(row.vaultId);
+        return (
+          <div className="asset-cell-with-health">
+            {health && (
+              <div className="asset-cell-with-health__indicator">
+                <VaultHealthIndicator
+                  status={health.status}
+                  message={health.message}
+                  vaultName={health.name}
+                  compact
+                />
+              </div>
+            )}
+            <div>
+              <div style={{ fontWeight: 600 }}>{row.asset}</div>
+              <div style={{ color: "var(--text-secondary)", fontSize: "0.82rem" }}>
+                {row.vaultName}
+              </div>
+              <div
+                className="copy-field"
+                style={{ marginTop: "8px", color: "var(--text-secondary)", fontSize: "0.78rem" }}
+              >
+                <span>Position ID:</span>
+                <span className="copy-field-value copy-field-value-mono">{row.id}</span>
+                <CopyButton
+                  value={row.id}
+                  label="position ID"
+                  successDescription={`Position ID ${row.id} has been copied to your clipboard.`}
+                />
+              </div>
+            </div>
           </div>
-          <div
-            className="copy-field"
-            style={{ marginTop: "8px", color: "var(--text-secondary)", fontSize: "0.78rem" }}
-          >
-            <span>Position ID:</span>
-            <span className="copy-field-value copy-field-value-mono">{row.id}</span>
-            <CopyButton
-              value={row.id}
-              label="position ID"
-              successDescription={`Position ID ${row.id} has been copied to your clipboard.`}
-            />
-          </div>
-        </div>
-      ),
+        );
+      },
     },
     {
       id: "shares",
@@ -315,32 +295,7 @@ const Portfolio: React.FC<PortfolioProps> = ({ walletAddress }) => {
         </span>
       ),
     },
-  ], [formatSensitiveCurrency, t]);
-
-  // Compute trend values
-  const totalNetValueTrend = useMemo(() => {
-    if (totalValue === 0) return "N/A";
-    // Calculate 7-day trend (simplified: using current value as proxy)
-    // In a real app, this would compare with historical data
-    const trendPercent = (totalGain / (totalValue - totalGain)) * 100;
-    return Number.isFinite(trendPercent)
-      ? `${formatPercent(trendPercent, {
-          locale,
-          minimumFractionDigits: 1,
-          maximumFractionDigits: 1,
-        })} gain`
-      : "N/A";
-  }, [locale, totalValue, totalGain]);
-
-  const cumulativeYieldTrend = useMemo(() => {
-    if (totalGain === 0) return "--";
-    return `${formatSensitiveCurrency(totalGain)} realized`;
-  }, [totalGain, formatSensitiveCurrency]);
-
-  const weightedApyTrend = useMemo(() => {
-    if (holdings.length === 0) return "N/A";
-    return `${holdings.length} position${holdings.length !== 1 ? 's' : ''}`;
-  }, [holdings.length]);
+  ], [formatSensitiveCurrency, healthByVaultId, locale, t]);
 
   const hasActiveHoldingsFilters = Boolean(
     urlState.filters.search ||
@@ -410,71 +365,17 @@ const Portfolio: React.FC<PortfolioProps> = ({ walletAddress }) => {
         <div className="flex flex-col gap-lg">
           {error && <ApiStatusBanner error={error} />}
 
-          <div
-            className="portfolio-summary-grid"
-            style={{ marginBottom: "8px" }}
-          >
-            <PortfolioSummaryCard
-              label={t("portfolio.totalNetValue")}
-              value={formatSensitiveCurrency(totalValue)}
-              icon={<DollarSign size={20} color="var(--accent-cyan)" />}
-              trend={totalNetValueTrend}
-              trendPositive={totalGain >= 0}
-            />
-            <PortfolioSummaryCard
-              label={t("portfolio.cumulativeYield")}
-              value={formatSensitiveCurrency(totalGain, true)}
-              icon={<TrendingUp size={20} color="var(--accent-purple)" />}
-              trend={cumulativeYieldTrend}
-              trendPositive={totalGain >= 0}
-            />
-            <PortfolioSummaryCard
-              label={
-                <span style={{ display: "flex", alignItems: "center", gap: "6px" }}>
-                  Weighted Avg APY
-                  <HelpIcon
-                    variant="tooltip"
-                    content="The portfolio-value-weighted average of all active position APYs."
-                  />
-                </span>
-              }
-              value={formatPercent(weightedApy, {
-                locale,
-                minimumFractionDigits: 2,
-                maximumFractionDigits: 2,
-              })}
-              icon={<Percent size={20} color="var(--accent-cyan)" />}
-              trend={weightedApyTrend}
-              trendPositive={true}
-            />
-            <PortfolioSummaryCard
-              label={t("portfolio.activePositions")}
-              value={holdings.filter(h => h.status === 'active').length.toString()}
-              icon={<Briefcase size={20} color="var(--text-secondary)" />}
-            />
-            <PortfolioSummaryCard
-              label={
-                <span style={{ display: "flex", alignItems: "center", gap: "6px" }}>
-                  Referral Earnings
-                  <HelpIcon
-                    variant="tooltip"
-                    content={t("portfolio.referralTooltip")}
-                  />
-                </span>
-              }
-              value={referralStats ? `$${referralStats.total_reward_earned}` : "$0.00"}
-              icon={<TrendingUp size={20} color="var(--accent-green)" />}
-              trend={referralStats ? `${referralStats.referral_count} referral${referralStats.referral_count !== 1 ? 's' : ''}` : "0 referrals"}
-              trendPositive={true}
-            />
-            <PortfolioSummaryCard
-              label={t("portfolio.shareReferralLink")}
-              value=""
-              icon={<Share2 size={20} color="var(--accent-cyan)" />}
-              onClick={() => setShowShareModal(true)}
-              clickable={true}
-            />
-          </div>
+          <PortfolioOverview
+            totalValue={totalValue}
+            totalGain={totalGain}
+            weightedApy={weightedApy}
+            activePositions={holdings.filter((h) => h.status === "active").length}
+            holdingsCount={holdings.length}
+            locale={locale}
+            formatSensitiveCurrency={formatSensitiveCurrency}
+            referralStats={referralStats}
+            onShareClick={() => setShowShareModal(true)}
+          />
 
           <YieldBreakdownChart totalGain={totalGain} />
 


### PR DESCRIPTION
## Summary
- Add PortfolioOverview section with aggregate summary cards and live vault health grid
- Poll vault health every 15s via useVaultHealth and show per-position indicators in the holdings table
- Extend portfolio mock data with vaultId and add validated vault-health API schema

Closes #905

## Test plan
- [x] frontend build passes
- [x] PortfolioOverview, VaultHealthIndicator, vaultHealthApi, and Portfolio unit tests pass
- [x] Portfolio e2e updated for Vault Health heading

Made with [Cursor](https://cursor.com)