### PR TITLE
[#856] Backend: Persist write-ahead audit log entries to Prisma for multi-instance durability

### DIFF
--- a/backend/prisma/migrations/20260727000000_add_write_ahead_audit_entries/migration.sql
+++ b/backend/prisma/migrations/20260727000000_add_write_ahead_audit_entries/migration.sql
@@ -1,0 +1,25 @@
+-- Migration: Add WriteAheadAuditEntry table
+-- Issue #856: Persist write-ahead audit log entries to Prisma for
+-- multi-instance durability (replaces the process-local in-memory store
+-- used by the Issue #707 prepare/commit/rollback flow).
+
+CREATE TABLE "WriteAheadAuditEntry" (
+  "id"                 TEXT      NOT NULL PRIMARY KEY,
+  "configType"         TEXT      NOT NULL,
+  "action"             TEXT      NOT NULL,
+  "actor"              TEXT      NOT NULL,
+  "ipAddress"          TEXT,
+  "userAgent"          TEXT,
+  "preChangeSnapshot"  TEXT      NOT NULL,
+  "postChangeSnapshot" TEXT,
+  "metadata"           TEXT      NOT NULL,
+  "status"             TEXT      NOT NULL DEFAULT 'pending',
+  "requestId"          TEXT,
+  "createdAt"          DATETIME  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "committedAt"        DATETIME
+);
+
+CREATE INDEX "WriteAheadAuditEntry_status_idx"    ON "WriteAheadAuditEntry"("status");
+CREATE INDEX "WriteAheadAuditEntry_createdAt_idx" ON "WriteAheadAuditEntry"("createdAt");
+CREATE INDEX "WriteAheadAuditEntry_configType_idx" ON "WriteAheadAuditEntry"("configType");
+CREATE INDEX "WriteAheadAuditEntry_actor_idx"     ON "WriteAheadAuditEntry"("actor");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -459,3 +459,29 @@ model ApiKey {
   @@index([tenantId])
   @@index([role])
 }
+
+// Durable write-ahead audit log for admin configuration changes (Issue #707).
+// Replaces the process-local in-memory store (issue #856) so entries survive
+// process restarts and are visible to every backend instance in multi-pod
+// deployments, letting operators reconstruct partial config changes that
+// were prepared but never committed/rolled back before a crash.
+model WriteAheadAuditEntry {
+  id                 String    @id
+  configType         String
+  action             String
+  actor              String
+  ipAddress          String?
+  userAgent          String?
+  preChangeSnapshot  String
+  postChangeSnapshot String?
+  metadata           String
+  status             String    @default("pending")
+  requestId          String?
+  createdAt          DateTime  @default(now())
+  committedAt        DateTime?
+
+  @@index([status])
+  @@index([createdAt])
+  @@index([configType])
+  @@index([actor])
+}

--- a/backend/src/__tests__/issues705-707-719-723.test.ts
+++ b/backend/src/__tests__/issues705-707-719-723.test.ts
@@ -114,12 +114,12 @@ describe('Issue #705: Request ID propagation across async job pipeline', () => {
 // ─── Issue #707: Write-ahead audit log ──────────────────────────────────────
 
 describe('Issue #707: Write-ahead audit log for admin configuration changes', () => {
-  beforeEach(() => {
-    writeAheadAuditLog.clear();
+  beforeEach(async () => {
+    await writeAheadAuditLog.clear();
   });
 
-  it('prepares a pending WAL entry with pre-change snapshot', () => {
-    const entry = writeAheadAuditLog.prepare({
+  it('prepares a pending WAL entry with pre-change snapshot', async () => {
+    const entry = await writeAheadAuditLog.prepare({
       configType: 'maintenance',
       action: 'toggle',
       actor: 'admin-1',
@@ -133,15 +133,15 @@ describe('Issue #707: Write-ahead audit log for admin configuration changes', ()
     expect(entry.id).toMatch(/^wal-/);
   });
 
-  it('commits a WAL entry with post-change snapshot', () => {
-    const entry = writeAheadAuditLog.prepare({
+  it('commits a WAL entry with post-change snapshot', async () => {
+    const entry = await writeAheadAuditLog.prepare({
       configType: 'maintenance',
       action: 'toggle',
       actor: 'admin-1',
       preChangeSnapshot: { enabled: false },
     });
 
-    const committed = writeAheadAuditLog.commit(entry.id, { enabled: true });
+    const committed = await writeAheadAuditLog.commit(entry.id, { enabled: true });
 
     expect(committed).not.toBeNull();
     expect(committed!.status).toBe('committed');
@@ -149,92 +149,137 @@ describe('Issue #707: Write-ahead audit log for admin configuration changes', ()
     expect(committed!.committedAt).not.toBeNull();
   });
 
-  it('rolls back a WAL entry with reason', () => {
-    const entry = writeAheadAuditLog.prepare({
+  it('rolls back a WAL entry with reason', async () => {
+    const entry = await writeAheadAuditLog.prepare({
       configType: 'feature_flags',
       action: 'override',
       actor: 'admin-2',
       preChangeSnapshot: { flag: 'old' },
     });
 
-    const rolledBack = writeAheadAuditLog.rollback(entry.id, 'validation failed');
+    const rolledBack = await writeAheadAuditLog.rollback(entry.id, 'validation failed');
 
     expect(rolledBack).not.toBeNull();
     expect(rolledBack!.status).toBe('rolled_back');
     expect(rolledBack!.metadata).toHaveProperty('rollbackReason', 'validation failed');
   });
 
-  it('cannot commit an already committed entry', () => {
-    const entry = writeAheadAuditLog.prepare({
+  it('cannot commit an already committed entry', async () => {
+    const entry = await writeAheadAuditLog.prepare({
       configType: 'test',
       action: 'update',
       actor: 'admin-1',
       preChangeSnapshot: {},
     });
 
-    writeAheadAuditLog.commit(entry.id, { value: 1 });
-    const secondCommit = writeAheadAuditLog.commit(entry.id, { value: 2 });
+    await writeAheadAuditLog.commit(entry.id, { value: 1 });
+    const secondCommit = await writeAheadAuditLog.commit(entry.id, { value: 2 });
 
     expect(secondCommit).toBeNull();
   });
 
-  it('lists entries with filters', () => {
-    writeAheadAuditLog.prepare({
+  it('lists entries with filters', async () => {
+    await writeAheadAuditLog.prepare({
       configType: 'maintenance',
       action: 'toggle',
       actor: 'admin-1',
       preChangeSnapshot: {},
     });
-    const entry2 = writeAheadAuditLog.prepare({
+    const entry2 = await writeAheadAuditLog.prepare({
       configType: 'feature_flags',
       action: 'override',
       actor: 'admin-2',
       preChangeSnapshot: {},
     });
-    writeAheadAuditLog.commit(entry2.id, {});
+    await writeAheadAuditLog.commit(entry2.id, {});
 
-    const maintenanceEntries = writeAheadAuditLog.list({ configType: 'maintenance' });
+    const maintenanceEntries = await writeAheadAuditLog.list({ configType: 'maintenance' });
     expect(maintenanceEntries).toHaveLength(1);
 
-    const committedEntries = writeAheadAuditLog.list({ status: 'committed' });
+    const committedEntries = await writeAheadAuditLog.list({ status: 'committed' });
     expect(committedEntries).toHaveLength(1);
 
-    const pendingEntries = writeAheadAuditLog.getPendingEntries();
+    const pendingEntries = await writeAheadAuditLog.getPendingEntries();
     expect(pendingEntries).toHaveLength(1);
   });
 
-  it('tracks metrics correctly', () => {
-    const e1 = writeAheadAuditLog.prepare({
+  it('tracks metrics correctly', async () => {
+    const e1 = await writeAheadAuditLog.prepare({
       configType: 'a',
       action: 'x',
       actor: 'admin',
       preChangeSnapshot: {},
     });
-    const e2 = writeAheadAuditLog.prepare({
+    const e2 = await writeAheadAuditLog.prepare({
       configType: 'b',
       action: 'y',
       actor: 'admin',
       preChangeSnapshot: {},
     });
-    writeAheadAuditLog.prepare({
+    await writeAheadAuditLog.prepare({
       configType: 'c',
       action: 'z',
       actor: 'admin',
       preChangeSnapshot: {},
     });
 
-    writeAheadAuditLog.commit(e1.id, {});
-    writeAheadAuditLog.rollback(e2.id, 'err');
+    await writeAheadAuditLog.commit(e1.id, {});
+    await writeAheadAuditLog.rollback(e2.id, 'err');
 
-    const metrics = writeAheadAuditLog.getMetrics();
+    const metrics = await writeAheadAuditLog.getMetrics();
     expect(metrics.total).toBe(3);
     expect(metrics.committed).toBe(1);
     expect(metrics.rolledBack).toBe(1);
     expect(metrics.pending).toBe(1);
+    expect(metrics.stalePending).toBe(0);
   });
 
-  it('includes actor metadata (ipAddress, userAgent)', () => {
-    const entry = writeAheadAuditLog.prepare({
+  it('surfaces stale pending entries in metrics (Issue #856)', async () => {
+    const original = process.env.WAL_STALE_PENDING_TTL_MS;
+    process.env.WAL_STALE_PENDING_TTL_MS = '0';
+
+    try {
+      await writeAheadAuditLog.prepare({
+        configType: 'maintenance',
+        action: 'toggle',
+        actor: 'admin-1',
+        preChangeSnapshot: {},
+      });
+
+      // With a TTL of 0ms, any pending entry is immediately "stale".
+      await new Promise((resolve) => setTimeout(resolve, 5));
+
+      const metrics = await writeAheadAuditLog.getMetrics();
+      expect(metrics.pending).toBe(1);
+      expect(metrics.stalePending).toBe(1);
+    } finally {
+      if (original === undefined) {
+        delete process.env.WAL_STALE_PENDING_TTL_MS;
+      } else {
+        process.env.WAL_STALE_PENDING_TTL_MS = original;
+      }
+    }
+  });
+
+  it('a stale pending entry can still be rolled back (Issue #856)', async () => {
+    const entry = await writeAheadAuditLog.prepare({
+      configType: 'maintenance',
+      action: 'toggle',
+      actor: 'admin-1',
+      preChangeSnapshot: {},
+    });
+
+    const rolledBack = await writeAheadAuditLog.rollback(entry.id, 'stale, abandoning');
+    expect(rolledBack).not.toBeNull();
+    expect(rolledBack!.status).toBe('rolled_back');
+
+    const metrics = await writeAheadAuditLog.getMetrics();
+    expect(metrics.pending).toBe(0);
+    expect(metrics.rolledBack).toBe(1);
+  });
+
+  it('includes actor metadata (ipAddress, userAgent)', async () => {
+    const entry = await writeAheadAuditLog.prepare({
       configType: 'test',
       action: 'update',
       actor: 'admin-x',

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -4384,61 +4384,95 @@ app.get('/health/probes', async (_req: Request, res: Response) => {
  * GET /admin/wal/entries
  * Lists write-ahead audit log entries with optional filters.
  */
-app.get('/admin/wal/entries', validateApiKey, (req: Request, res: Response) => {
+app.get('/admin/wal/entries', validateApiKey, async (req: Request, res: Response) => {
   const configType = typeof req.query.configType === 'string' ? req.query.configType : undefined;
   const actor = typeof req.query.actor === 'string' ? req.query.actor : undefined;
   const status = typeof req.query.status === 'string' ? req.query.status as 'pending' | 'committed' | 'rolled_back' : undefined;
   const limit = parseLimited(req.query.limit, 50, 1, 200);
 
-  const entries = writeAheadAuditLog.list({ configType, actor, status, limit });
+  try {
+    const entries = await writeAheadAuditLog.list({ configType, actor, status, limit });
+    const metrics = await writeAheadAuditLog.getMetrics();
 
-  res.status(200).json({
-    entries,
-    count: entries.length,
-    metrics: writeAheadAuditLog.getMetrics(),
-    timestamp: new Date().toISOString(),
-  });
+    res.status(200).json({
+      entries,
+      count: entries.length,
+      metrics,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    res.status(500).json({
+      error: 'Internal Server Error',
+      status: 500,
+      message: error instanceof Error ? error.message : 'Failed to list write-ahead audit log entries',
+    });
+  }
 });
 
 /**
  * GET /admin/wal/entries/:id
  * Returns a specific write-ahead audit log entry.
  */
-app.get('/admin/wal/entries/:id', validateApiKey, (req: Request, res: Response) => {
-  const entry = writeAheadAuditLog.getEntry(req.params.id);
-  if (!entry) {
-    res.status(404).json({
-      error: 'Not Found',
-      status: 404,
-      message: 'Write-ahead audit log entry not found',
+app.get('/admin/wal/entries/:id', validateApiKey, async (req: Request, res: Response) => {
+  try {
+    const entry = await writeAheadAuditLog.getEntry(req.params.id);
+    if (!entry) {
+      res.status(404).json({
+        error: 'Not Found',
+        status: 404,
+        message: 'Write-ahead audit log entry not found',
+      });
+      return;
+    }
+    res.status(200).json({ entry });
+  } catch (error) {
+    res.status(500).json({
+      error: 'Internal Server Error',
+      status: 500,
+      message: error instanceof Error ? error.message : 'Failed to fetch write-ahead audit log entry',
     });
-    return;
   }
-  res.status(200).json({ entry });
 });
 
 /**
  * GET /admin/wal/metrics
  * Returns metrics for the write-ahead audit log.
  */
-app.get('/admin/wal/metrics', validateApiKey, (_req: Request, res: Response) => {
-  res.status(200).json({
-    metrics: writeAheadAuditLog.getMetrics(),
-    timestamp: new Date().toISOString(),
-  });
+app.get('/admin/wal/metrics', validateApiKey, async (_req: Request, res: Response) => {
+  try {
+    const metrics = await writeAheadAuditLog.getMetrics();
+    res.status(200).json({
+      metrics,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    res.status(500).json({
+      error: 'Internal Server Error',
+      status: 500,
+      message: error instanceof Error ? error.message : 'Failed to fetch write-ahead audit log metrics',
+    });
+  }
 });
 
 /**
  * GET /admin/wal/pending
  * Returns currently pending (uncommitted) write-ahead entries.
  */
-app.get('/admin/wal/pending', validateApiKey, (_req: Request, res: Response) => {
-  const pending = writeAheadAuditLog.getPendingEntries();
-  res.status(200).json({
-    entries: pending,
-    count: pending.length,
-    timestamp: new Date().toISOString(),
-  });
+app.get('/admin/wal/pending', validateApiKey, async (_req: Request, res: Response) => {
+  try {
+    const pending = await writeAheadAuditLog.getPendingEntries();
+    res.status(200).json({
+      entries: pending,
+      count: pending.length,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    res.status(500).json({
+      error: 'Internal Server Error',
+      status: 500,
+      message: error instanceof Error ? error.message : 'Failed to fetch pending write-ahead audit log entries',
+    });
+  }
 });
 
 // ─── Scoped Admin Token Endpoints (Issue #723 / #858) ───────────────────────

--- a/backend/src/writeAheadAuditLog.ts
+++ b/backend/src/writeAheadAuditLog.ts
@@ -1,6 +1,7 @@
 import crypto from 'crypto';
 import { logger } from './middleware/structuredLogging';
 import { getActiveRequestId } from './requestContext';
+import { prisma } from './prisma';
 
 export interface WriteAheadEntry {
   id: string;
@@ -28,11 +29,90 @@ export interface WriteAheadInput {
   metadata?: Record<string, unknown>;
 }
 
+export interface WriteAheadMetrics {
+  total: number;
+  pending: number;
+  committed: number;
+  rolledBack: number;
+  /**
+   * Pending entries older than WAL_STALE_PENDING_TTL_MS (default 15 minutes).
+   * Surfaced so operators can spot config changes stuck between prepare and
+   * commit/rollback, e.g. after a crash mid-transaction.
+   */
+  stalePending: number;
+}
+
+const DEFAULT_STALE_PENDING_TTL_MS = 15 * 60 * 1000;
+
+function getStalePendingTtlMs(): number {
+  const parsed = parseInt(process.env.WAL_STALE_PENDING_TTL_MS || '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_STALE_PENDING_TTL_MS;
+}
+
+/**
+ * Whether to use the in-memory fallback store instead of Prisma.
+ *
+ * Mirrors the same convention already used by adminConfigChangeAudit.ts:
+ * tests (and any environment without a configured database) run against a
+ * fast, dependency-free in-memory store rather than requiring a live
+ * Postgres connection, while any real deployment persists durably via
+ * Prisma.
+ */
+function shouldUseInMemoryWalFallback(): boolean {
+  const nodeEnv = process.env.NODE_ENV || '';
+  const hasDatabaseUrl = Boolean(process.env.DATABASE_URL);
+  return nodeEnv === 'test' || Boolean(process.env.JEST_WORKER_ID) || !hasDatabaseUrl;
+}
+
+function toDateIso(value: Date | string | null): string | null {
+  if (value === null) return null;
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+interface WriteAheadRow {
+  id: string;
+  configType: string;
+  action: string;
+  actor: string;
+  ipAddress: string | null;
+  userAgent: string | null;
+  preChangeSnapshot: string;
+  postChangeSnapshot: string | null;
+  metadata: string;
+  status: string;
+  requestId: string | null;
+  createdAt: Date | string;
+  committedAt: Date | string | null;
+}
+
+function toEntry(row: WriteAheadRow): WriteAheadEntry {
+  return {
+    id: row.id,
+    configType: row.configType,
+    action: row.action,
+    actor: row.actor,
+    ipAddress: row.ipAddress,
+    userAgent: row.userAgent,
+    preChangeSnapshot: JSON.parse(row.preChangeSnapshot),
+    postChangeSnapshot: row.postChangeSnapshot ? JSON.parse(row.postChangeSnapshot) : null,
+    metadata: JSON.parse(row.metadata),
+    status: row.status as WriteAheadEntry['status'],
+    requestId: row.requestId,
+    createdAt: toDateIso(row.createdAt) as string,
+    committedAt: toDateIso(row.committedAt),
+  };
+}
+
 class WriteAheadAuditLogStore {
+  // In-memory store: the sole backing store in test mode, and also used as
+  // a same-process fallback if a Prisma call unexpectedly errors at runtime
+  // (e.g. a transient DB outage), so a WAL entry prepared just before an
+  // outage can still be found by a subsequent commit/rollback/list call in
+  // this same process rather than silently disappearing.
   private entries: WriteAheadEntry[] = [];
   private maxEntries = 10000;
 
-  prepare(input: WriteAheadInput): WriteAheadEntry {
+  async prepare(input: WriteAheadInput): Promise<WriteAheadEntry> {
     const entry: WriteAheadEntry = {
       id: `wal-${crypto.randomUUID()}`,
       configType: input.configType,
@@ -49,20 +129,62 @@ class WriteAheadAuditLogStore {
       committedAt: null,
     };
 
+    if (!shouldUseInMemoryWalFallback()) {
+      try {
+        const row = await prisma.writeAheadAuditEntry.create({
+          data: {
+            id: entry.id,
+            configType: entry.configType,
+            action: entry.action,
+            actor: entry.actor,
+            ipAddress: entry.ipAddress,
+            userAgent: entry.userAgent,
+            preChangeSnapshot: JSON.stringify(entry.preChangeSnapshot),
+            metadata: JSON.stringify(entry.metadata),
+            status: entry.status,
+            requestId: entry.requestId,
+          },
+        });
+        const persisted = toEntry(row as WriteAheadRow);
+        this.logEvent('info', 'Write-ahead audit entry prepared', persisted);
+        return persisted;
+      } catch (error) {
+        this.logFallback('prepare', error);
+      }
+    }
+
     this.entries.unshift(entry);
     this.trimEntries();
-
-    logger.log('info', 'Write-ahead audit entry prepared', {
-      walId: entry.id,
-      configType: entry.configType,
-      action: entry.action,
-      actor: entry.actor,
-    });
-
+    this.logEvent('info', 'Write-ahead audit entry prepared', entry);
     return entry;
   }
 
-  commit(walId: string, postChangeSnapshot: Record<string, unknown>): WriteAheadEntry | null {
+  async commit(walId: string, postChangeSnapshot: Record<string, unknown>): Promise<WriteAheadEntry | null> {
+    if (!shouldUseInMemoryWalFallback()) {
+      try {
+        const existing = await prisma.writeAheadAuditEntry.findUnique({ where: { id: walId } });
+        if (!existing || existing.status !== 'pending') return null;
+
+        const row = await prisma.writeAheadAuditEntry.update({
+          where: { id: walId },
+          data: {
+            postChangeSnapshot: JSON.stringify(postChangeSnapshot),
+            status: 'committed',
+            committedAt: new Date(),
+          },
+        });
+        const committed = toEntry(row as WriteAheadRow);
+        logger.log('info', 'Write-ahead audit entry committed', {
+          walId: committed.id,
+          configType: committed.configType,
+          action: committed.action,
+        });
+        return committed;
+      } catch (error) {
+        this.logFallback('commit', error);
+      }
+    }
+
     const entry = this.entries.find((e) => e.id === walId);
     if (!entry || entry.status !== 'pending') return null;
 
@@ -79,7 +201,32 @@ class WriteAheadAuditLogStore {
     return entry;
   }
 
-  rollback(walId: string, reason?: string): WriteAheadEntry | null {
+  async rollback(walId: string, reason?: string): Promise<WriteAheadEntry | null> {
+    if (!shouldUseInMemoryWalFallback()) {
+      try {
+        const existing = await prisma.writeAheadAuditEntry.findUnique({ where: { id: walId } });
+        if (!existing || existing.status !== 'pending') return null;
+
+        const metadata = { ...JSON.parse(existing.metadata), rollbackReason: reason ?? 'unknown' };
+        const row = await prisma.writeAheadAuditEntry.update({
+          where: { id: walId },
+          data: {
+            status: 'rolled_back',
+            metadata: JSON.stringify(metadata),
+          },
+        });
+        const rolledBack = toEntry(row as WriteAheadRow);
+        logger.log('warn', 'Write-ahead audit entry rolled back', {
+          walId: rolledBack.id,
+          configType: rolledBack.configType,
+          reason,
+        });
+        return rolledBack;
+      } catch (error) {
+        this.logFallback('rollback', error);
+      }
+    }
+
     const entry = this.entries.find((e) => e.id === walId);
     if (!entry || entry.status !== 'pending') return null;
 
@@ -95,16 +242,45 @@ class WriteAheadAuditLogStore {
     return entry;
   }
 
-  getEntry(walId: string): WriteAheadEntry | null {
+  async getEntry(walId: string): Promise<WriteAheadEntry | null> {
+    if (!shouldUseInMemoryWalFallback()) {
+      try {
+        const row = await prisma.writeAheadAuditEntry.findUnique({ where: { id: walId } });
+        return row ? toEntry(row as WriteAheadRow) : null;
+      } catch (error) {
+        this.logFallback('getEntry', error);
+      }
+    }
+
     return this.entries.find((e) => e.id === walId) ?? null;
   }
 
-  list(opts: {
-    configType?: string;
-    actor?: string;
-    status?: 'pending' | 'committed' | 'rolled_back';
-    limit?: number;
-  } = {}): WriteAheadEntry[] {
+  async list(
+    opts: {
+      configType?: string;
+      actor?: string;
+      status?: 'pending' | 'committed' | 'rolled_back';
+      limit?: number;
+    } = {},
+  ): Promise<WriteAheadEntry[]> {
+    if (!shouldUseInMemoryWalFallback()) {
+      try {
+        const where: Record<string, unknown> = {};
+        if (opts.configType) where.configType = opts.configType;
+        if (opts.actor) where.actor = opts.actor;
+        if (opts.status) where.status = opts.status;
+
+        const rows = await prisma.writeAheadAuditEntry.findMany({
+          where,
+          orderBy: { createdAt: 'desc' },
+          take: opts.limit ?? 100,
+        });
+        return rows.map((row: WriteAheadRow) => toEntry(row));
+      } catch (error) {
+        this.logFallback('list', error);
+      }
+    }
+
     let result = this.entries;
 
     if (opts.configType) {
@@ -120,27 +296,86 @@ class WriteAheadAuditLogStore {
     return result.slice(0, opts.limit ?? 100);
   }
 
-  getPendingEntries(): WriteAheadEntry[] {
+  async getPendingEntries(): Promise<WriteAheadEntry[]> {
+    if (!shouldUseInMemoryWalFallback()) {
+      try {
+        const rows = await prisma.writeAheadAuditEntry.findMany({
+          where: { status: 'pending' },
+          orderBy: { createdAt: 'desc' },
+        });
+        return rows.map((row: WriteAheadRow) => toEntry(row));
+      } catch (error) {
+        this.logFallback('getPendingEntries', error);
+      }
+    }
+
     return this.entries.filter((e) => e.status === 'pending');
   }
 
-  getMetrics() {
+  async getMetrics(): Promise<WriteAheadMetrics> {
+    const staleBefore = new Date(Date.now() - getStalePendingTtlMs());
+
+    if (!shouldUseInMemoryWalFallback()) {
+      try {
+        const [total, pending, committed, rolledBack, stalePending] = await Promise.all([
+          prisma.writeAheadAuditEntry.count(),
+          prisma.writeAheadAuditEntry.count({ where: { status: 'pending' } }),
+          prisma.writeAheadAuditEntry.count({ where: { status: 'committed' } }),
+          prisma.writeAheadAuditEntry.count({ where: { status: 'rolled_back' } }),
+          prisma.writeAheadAuditEntry.count({
+            where: { status: 'pending', createdAt: { lt: staleBefore } },
+          }),
+        ]);
+        return { total, pending, committed, rolledBack, stalePending };
+      } catch (error) {
+        this.logFallback('getMetrics', error);
+      }
+    }
+
     const total = this.entries.length;
     const pending = this.entries.filter((e) => e.status === 'pending').length;
     const committed = this.entries.filter((e) => e.status === 'committed').length;
     const rolledBack = this.entries.filter((e) => e.status === 'rolled_back').length;
+    const stalePending = this.entries.filter(
+      (e) => e.status === 'pending' && new Date(e.createdAt) < staleBefore,
+    ).length;
 
-    return { total, pending, committed, rolledBack };
+    return { total, pending, committed, rolledBack, stalePending };
   }
 
-  clear(): void {
+  /** Test-only: clears both the in-memory fallback and, outside test mode, the Prisma table. */
+  async clear(): Promise<void> {
     this.entries = [];
+
+    if (!shouldUseInMemoryWalFallback()) {
+      try {
+        await prisma.writeAheadAuditEntry.deleteMany({});
+      } catch (error) {
+        this.logFallback('clear', error);
+      }
+    }
   }
 
   private trimEntries(): void {
     if (this.entries.length > this.maxEntries) {
       this.entries = this.entries.slice(0, this.maxEntries);
     }
+  }
+
+  private logEvent(level: 'info' | 'warn', message: string, entry: WriteAheadEntry): void {
+    logger.log(level, message, {
+      walId: entry.id,
+      configType: entry.configType,
+      action: entry.action,
+      actor: entry.actor,
+    });
+  }
+
+  private logFallback(operation: string, error: unknown): void {
+    logger.log('warn', 'Falling back to in-memory write-ahead audit store after Prisma error', {
+      operation,
+      error: error instanceof Error ? error.message : String(error),
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
Closes #856. `writeAheadAuditLog.ts` (the Issue #707 prepare/commit/rollback flow for admin configuration changes) stored entries in a process-local array capped at 10,000 records. Entries were lost on restart and invisible to peer instances in multi-pod deployments, so operators couldn't reconstruct partial config changes after a crash between prepare and commit.

**Note on this update**: this branch was 847 commits behind current `main`, and several files it touched (`schema.prisma`, `writeAheadAuditLog.ts` itself, `check-postgres-drift.js`) had since been created or substantially changed by unrelated work upstream. Rather than force a mechanical rebase across that much drift (real risk of silently corrupting the Prisma schema or duplicating models), I reimplemented the feature fresh against current `main`, replacing this branch's history.

## What changed
- Added a `WriteAheadAuditEntry` Prisma model (`backend/prisma/schema.prisma`) and a matching migration (`backend/prisma/migrations/20260727000000_add_write_ahead_audit_entries`), following the same field shape and index conventions as the existing `AdminConfigChange` model
- Rewrote `writeAheadAuditLog.ts`: `prepare`/`commit`/`rollback`/`getEntry`/`list`/`getPendingEntries`/`getMetrics`/`clear` are now async and persist via Prisma, following the exact same test-mode/no-`DATABASE_URL` fallback convention already established by `adminConfigChangeAudit.ts` (`NODE_ENV=test`, `JEST_WORKER_ID`, or no `DATABASE_URL`). Unlike that simpler precedent, this store is read back within the same request lifecycle (prepare then commit/rollback by id, then list), so the in-memory fallback is a fully functional store, not just a stub — and any unexpected Prisma error at runtime also falls back to the in-memory path per-call rather than throwing
- Added a `stalePending` count to `getMetrics()` (pending entries older than a configurable `WAL_STALE_PENDING_TTL_MS`, default 15 minutes) so operators can spot admin config changes stuck between prepare and commit/rollback after a crash — this is an additive field, so existing consumers of the WAL metrics response shape are unaffected
- Updated the 4 `GET /admin/wal/*` route handlers in `index.ts` to be async and await the now-async store, with try/catch around each returning a 500 on genuinely unexpected errors. HTTP response shapes are unchanged
- Updated the existing Issue #707 describe block in `issues705-707-719-723.test.ts` to await the now-async calls, and added 2 new tests covering the `stalePending` metric and confirming a stale pending entry can still be rolled back

## Verification
- [x] `npm install` succeeds
- [x] `tsc --noEmit`: 0 errors in any changed file. Confirmed against a clean `upstream/main` checkout: baseline is 95 pre-existing errors, entirely in files this PR doesn't touch (`apiKeyAuth.ts`, `walletNonce.ts`, etc.) — identical count and files before and after this change
- [x] `eslint`: 0 new errors. 1 new instance of an already-established `no-non-null-assertion` warning pattern in the new stale-pending test, matching the existing style throughout this same test file (baseline 13 warnings → 14, same rule, same file)
- [x] `node scripts/check-migrations.js`: passes
- [x] `tsx scripts/check-schema-snapshots.ts`: passes (WAL endpoints aren't covered by these API contract snapshots — confirmed by inspecting `apiContractSnapshots.ts`)
- [ ] Could not run `prisma generate` or the actual Jest suite: this sandbox's network policy blocks `binaries.prisma.sh` (confirmed 403 on every engine-fetch attempt, including with `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1` and forcing `PRISMA_CLIENT_ENGINE_TYPE=wasm`), and no engine binary exists anywhere on this filesystem to substitute. Jest fails before any test runs, at `PrismaClient` construction, with `"@prisma/client did not initialize yet. Please run prisma generate"` — this happens even though Jest sets `NODE_ENV=test` and my code would only exercise the in-memory fallback path, never actually querying Prisma, so it's specifically the client construction step that's blocked here.

Please run `prisma generate && npm test` in CI/locally to confirm test execution.

Closes #856
