### PR TITLE
issues fixed

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -79,9 +79,34 @@ PRISMA_QUERY_TIMEOUT_MS=5000
 PRISMA_TX_MAX_WAIT_MS=5000
 PRISMA_TX_TIMEOUT_MS=10000
 
-# Optional: Cache Configuration (for future use)
-# REDIS_URL=redis://localhost:6379
-# CACHE_TTL=300
+# ── Cache Configuration ───────────────────────────────────────────────────────
+# Redis-backed response cache for price and vault summary endpoints.
+# When REDIS_URL is set, GET responses for /api/v1/vault/summary, /api/v1/vault/apy,
+# and /api/v1/vault/metrics are cached in Redis so they survive process restarts and
+# are shared across multiple backend replicas.
+# When REDIS_URL is absent or Redis is temporarily unreachable the backend falls
+# back transparently to the in-memory LRU store (CACHE_MAX_ENTRIES entries).
+
+# Redis connection URL (also used for rate-limiting; set once for both)
+REDIS_URL=redis://localhost:6379
+
+# Response cache TTL in milliseconds (applies to vault summary, metrics, APY endpoints)
+CACHE_TTL_MS=60000
+
+# Alias accepted in addition to CACHE_TTL_MS
+# CACHE_VAULT_METRICS_TTL_MS=60000
+
+# Maximum entries kept in the in-memory LRU fallback store
+CACHE_MAX_ENTRIES=500
+
+# Redis cache key namespace prefix (default: "cache:")
+# REDIS_CACHE_KEY_PREFIX=cache:
+
+# Connection attempt timeout for the Redis cache client (ms)
+# REDIS_CACHE_CONNECT_TIMEOUT_MS=2000
+
+# Per-command timeout for Redis cache operations (ms)
+# REDIS_CACHE_COMMAND_TIMEOUT_MS=500
 
 # CORS Configuration
 # Comma-separated list of allowed origins. Supports strings or regex like /https?:\/\/.*\.yieldvault\.finance/

--- a/backend/docs/REDIS_CACHING.md
+++ b/backend/docs/REDIS_CACHING.md
@@ -1,0 +1,220 @@
+# Redis Caching for Price and Vault Summary Endpoints
+
+## Overview
+
+The YieldVault backend caches responses for the price and vault summary
+endpoints using Redis when available, with automatic fallback to an in-memory
+LRU store when Redis is absent or temporarily unreachable.
+
+**Affected endpoints**
+
+| Endpoint | Default TTL | Notes |
+|---|---|---|
+| `GET /api/v1/vault/summary` | 60 s | Returns live `VaultState` + latest `SharePriceSnapshot` from DB |
+| `GET /api/v1/vault/apy` | 60 s | APY data from the nightly snapshot job |
+| `GET /api/v1/vault/metrics` | 60 s | High-level vault metrics |
+| `GET /api/v1/vault/apy/history` | 60 s | Historical APY chart data |
+
+---
+
+## Architecture
+
+```
+                     ┌────────────────────────────────────┐
+ GET /api/v1/vault/* │  cacheMiddleware({ ttl })          │
+ ──────────────────► │                                    │
+                     │  1. Check Redis (if ready)         │
+                     │  2. Check in-memory LRU (fallback) │
+                     │  3. Cache MISS → call handler      │
+                     │  4. Write response to Redis + LRU  │
+                     └────────────────────────────────────┘
+                                    │
+                            ┌───────┴───────┐
+                            │               │
+                        Redis store    In-memory LRU
+                        (shared,       (per-process,
+                         durable)       fallback)
+```
+
+### Key design decisions
+
+- **Fail-open**: When Redis is configured but unreachable the backend continues
+  serving requests using the in-memory LRU. No `500` errors are emitted due to
+  Redis unavailability.
+- **Dual write**: Every cache write goes to both Redis (TTL-based expiry) and
+  the LRU (size-bounded eviction). This means the LRU acts as a read-through
+  cache: a warm LRU can serve hits even during a brief Redis reconnect.
+- **Deterministic cache keys**: Keys follow the existing format
+  `METHOD:path:sorted-query-params`, ensuring that `?a=1&b=2` and `?b=2&a=1`
+  hit the same cache entry.
+- **Response headers**: Every cached response carries:
+  - `X-Cache-Hit: true | false` — whether the response was served from cache.
+  - `X-Cache-Backend: redis | memory` — which store served the hit.
+  - `Cache-Control: public, max-age=N` — downstream CDN / browser TTL.
+
+---
+
+## Configuration
+
+All variables are optional. The backend runs fully without Redis.
+
+| Variable | Default | Description |
+|---|---|---|
+| `REDIS_URL` | _(unset)_ | Redis connection URL. Enables Redis caching **and** Redis-backed rate limiting when set. Example: `redis://localhost:6379` |
+| `CACHE_TTL_MS` | `60000` | Response cache TTL in milliseconds for vault/price endpoints |
+| `CACHE_VAULT_METRICS_TTL_MS` | _(alias for `CACHE_TTL_MS`)_ | Legacy alias, accepted in addition to `CACHE_TTL_MS` |
+| `CACHE_MAX_ENTRIES` | `500` | Maximum entries kept in the in-memory LRU fallback store |
+| `REDIS_CACHE_KEY_PREFIX` | `cache:` | Redis key namespace. Useful when sharing a Redis instance across multiple services |
+| `REDIS_CACHE_CONNECT_TIMEOUT_MS` | `2000` | Timeout (ms) for the initial Redis TCP connection |
+| `REDIS_CACHE_COMMAND_TIMEOUT_MS` | `500` | Per-command timeout (ms) to prevent slow Redis from blocking request handlers |
+
+### Example `.env`
+
+```dotenv
+REDIS_URL=redis://localhost:6379
+CACHE_TTL_MS=60000
+CACHE_MAX_ENTRIES=500
+```
+
+---
+
+## Cache Invalidation
+
+Cache entries are invalidated:
+
+1. **On vault mutations** (deposit / withdrawal): the `vaultEndpoints.ts`
+   router calls `triggerCacheInvalidation('transaction.write')` which invokes
+   registered invalidation hooks that delete `GET:/api/v1/vault*`,
+   `GET:/api/v1/transactions*`, and `GET:/api/v1/portfolio*` entries from both
+   Redis and the LRU simultaneously.
+
+2. **On APY snapshot** (nightly job): `apySnapshot.ts` calls
+   `invalidateCache('GET:/api/v1/vault/apy')` after persisting the new snapshot.
+
+3. **Admin API** (manual): operators can clear cache via:
+   - `DELETE /admin/cache` — clears all entries (or a regex-filtered subset via
+     `?pattern=<regex>`)
+   - `POST /admin/cache/invalidate` — body `{ "pattern": "<regex>" }`
+
+Invalidation applies to **both** the Redis keyspace (using Redis `SCAN` +
+bulk `DEL`) and the in-memory LRU.
+
+---
+
+## Observability
+
+### Prometheus Metrics
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `cache_hit_count` | Counter | `method`, `route` | In-process cache hits (LRU or Redis) |
+| `cache_miss_count` | Counter | `method`, `route` | In-process cache misses |
+| `cache_eviction_count` | Counter | — | LRU evictions (size limit reached) |
+| `redis_cache_hit_total` | Counter | `route` | Redis-specific hit counter |
+| `redis_cache_miss_total` | Counter | `route` | Redis-specific miss counter |
+| `redis_cache_error_total` | Counter | `operation` | Redis operation errors (`get`, `set`, `del`, `invalidate`) |
+| `redis_cache_connection_status` | Gauge | — | `1` = connected, `0` = disconnected |
+
+All metrics are exposed at `GET /metrics` (Prometheus scrape endpoint).
+
+### Admin Endpoints
+
+**`GET /admin/cache/stats`** (requires API key)  
+Returns in-memory cache statistics plus Redis status:
+```json
+{
+  "entryCount": 3,
+  "entries": ["GET:/api/v1/vault/summary", "..."],
+  "hitRate": 0.92,
+  "redis": {
+    "configured": true,
+    "ready": true,
+    "health": "up"
+  },
+  "timestamp": "2026-07-25T10:00:00.000Z"
+}
+```
+
+**`GET /admin/cache/redis-status`** (requires API key)  
+Returns detailed Redis connection diagnostics:
+```json
+{
+  "configured": true,
+  "ready": true,
+  "health": "up",
+  "ping": "PONG",
+  "fallbackActive": false,
+  "timestamp": "2026-07-25T10:00:00.000Z"
+}
+```
+
+### Health Endpoint
+
+`GET /health` includes `checks.cache` which may be:
+- `"up"` — cache is healthy (Redis connected or Redis not configured)
+- `"degraded"` — Redis was configured but is currently unreachable; in-memory
+  fallback is active and the service continues to operate normally
+- `"down"` — in-memory cache itself failed (should not normally occur)
+
+The service returns HTTP 200 for both `"up"` and `"degraded"` cache states.
+
+---
+
+## Vault Summary Response
+
+The `/api/v1/vault/summary` endpoint now returns real data sourced from the
+database:
+
+```json
+{
+  "totalAssets": "1234567.890000",
+  "totalShares": "1200000.000000",
+  "sharePrice": "1.028806",
+  "apy": 0,
+  "timestamp": "2026-07-25T10:00:00.000Z"
+}
+```
+
+- `totalAssets` and `totalShares` come from the `VaultState` table (updated on
+  every deposit/withdrawal and by the event-polling service).
+- `sharePrice` is the most recent entry in the `SharePriceSnapshot` table.
+- `apy` is populated by the nightly APY snapshot job; it remains `0` until the
+  first scheduled run completes.
+
+All fields fall back to zero/default values if the database is unavailable,
+ensuring the endpoint never returns a `500`.
+
+---
+
+## Local Development
+
+Redis is **not required** to run the backend locally. The in-memory LRU handles
+all caching automatically.
+
+To enable Redis locally:
+
+```bash
+# Start Redis (Docker)
+docker run -d -p 6379:6379 redis:7-alpine
+
+# Add to backend/.env
+REDIS_URL=redis://localhost:6379
+```
+
+---
+
+## Testing
+
+Unit and integration tests cover the Redis cache layer without requiring a live
+Redis instance:
+
+```bash
+# All tests
+cd backend && npm test
+
+# Redis cache unit tests only
+npx jest redisCache.test
+
+# Redis cache integration tests
+npx jest redisCacheIntegration.test
+```

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -6046,6 +6046,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/backend/src/__tests__/redisCache.test.ts
+++ b/backend/src/__tests__/redisCache.test.ts
@@ -1,0 +1,424 @@
+/**
+ * @file redisCache.test.ts
+ * Unit tests for the Redis-backed response cache module (redisCache.ts).
+ *
+ * All Redis I/O is replaced with an in-memory fake so no real Redis instance
+ * is required. The tests verify:
+ *   - getFromCache returns null on miss, cached entry on hit
+ *   - setInCache persists to both LRU and Redis
+ *   - invalidateCachePattern clears matching keys from both stores
+ *   - getRedisCacheHealth returns the correct status strings
+ *   - Metrics counters increment correctly
+ *   - Fail-open behaviour when Redis is unavailable
+ */
+
+import { EventEmitter } from 'events';
+
+// ─── Fake Redis Client ────────────────────────────────────────────────────────
+
+type FakeStore = Map<string, { value: string; expiresAt: number }>;
+
+class FakeRedis extends EventEmitter {
+  private store: FakeStore = new Map();
+  public commandTimeout = 500;
+
+  async ping(): Promise<string> {
+    return 'PONG';
+  }
+
+  async get(key: string): Promise<string | null> {
+    const entry = this.store.get(key);
+    if (!entry) return null;
+    if (entry.expiresAt < Date.now()) {
+      this.store.delete(key);
+      return null;
+    }
+    return entry.value;
+  }
+
+  async setex(key: string, ttlSeconds: number, value: string): Promise<'OK'> {
+    this.store.set(key, {
+      value,
+      expiresAt: Date.now() + ttlSeconds * 1000,
+    });
+    return 'OK';
+  }
+
+  async del(...keys: string[]): Promise<number> {
+    let count = 0;
+    for (const k of keys) {
+      if (this.store.delete(k)) count++;
+    }
+    return count;
+  }
+
+  async scan(
+    cursor: string,
+    _matchCmd: 'MATCH',
+    pattern: string,
+    _countCmd: 'COUNT',
+    _count: number,
+  ): Promise<[string, string[]]> {
+    // Simple full scan ignoring cursor pagination
+    const regex = new RegExp(
+      '^' +
+        pattern
+          .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+          .replace(/\*/g, '.*'),
+    );
+    const matched = [...this.store.keys()].filter((k) => regex.test(k));
+    return ['0', cursor === '0' ? matched : []];
+  }
+
+  async quit(): Promise<void> {}
+
+  _keys(): string[] {
+    return [...this.store.keys()];
+  }
+  _clear(): void {
+    this.store.clear();
+  }
+  _size(): number {
+    return this.store.size;
+  }
+}
+
+// ─── Module Setup ─────────────────────────────────────────────────────────────
+
+// We need to inject the fake redis into the redisCacheClient singleton.
+// The simplest way is to access the private client property via a cast.
+
+let fakeRedis: FakeRedis;
+
+// Import the module under test (after setting up mocks)
+import {
+  redisCacheClient,
+  getFromCache,
+  setInCache,
+  invalidateCachePattern,
+  getRedisCacheHealth,
+  redisCacheHitCount,
+  redisCacheMissCount,
+  redisCacheErrorCount,
+} from '../redisCache';
+import { responseCache } from '../middleware/cache';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeEntry(data: unknown, ttlMs = 60_000) {
+  return {
+    data,
+    statusCode: 200,
+    headers: {} as Record<string, string>,
+    expiresAt: Date.now() + ttlMs,
+    ttl: ttlMs,
+    lastUsed: Date.now(),
+  };
+}
+
+async function getCounterValue(
+  counter: import('prom-client').Counter<string>,
+  labels: Record<string, string> = {},
+): Promise<number> {
+  // prom-client counters expose async get()
+  const values = await counter.get();
+  const found = values.values.find((v) =>
+    Object.entries(labels).every(([k, val]) => v.labels[k] === val),
+  );
+  return found?.value ?? 0;
+}
+
+// ─── Test Suite ───────────────────────────────────────────────────────────────
+
+describe('redisCacheClient', () => {
+  beforeEach(() => {
+    fakeRedis = new FakeRedis();
+    // Inject fake client and mark as ready
+    (redisCacheClient as any).client = fakeRedis;
+    (redisCacheClient as any)._isReady = true;
+    // Clear in-memory LRU between tests
+    responseCache.clear();
+  });
+
+  afterEach(() => {
+    fakeRedis._clear();
+    // Reset ready flag so later tests start clean
+    (redisCacheClient as any)._isReady = false;
+  });
+
+  describe('get()', () => {
+    it('returns null when key does not exist', async () => {
+      const result = await redisCacheClient.get('missing-key');
+      expect(result).toBeNull();
+    });
+
+    it('returns the parsed entry when key exists', async () => {
+      const entry = makeEntry({ hello: 'world' });
+      await fakeRedis.setex('cache:test-key', 60, JSON.stringify(entry));
+
+      const result = await redisCacheClient.get('test-key');
+      expect(result).not.toBeNull();
+      expect(result!.data).toEqual({ hello: 'world' });
+    });
+
+    it('returns null when client is not ready', async () => {
+      (redisCacheClient as any)._isReady = false;
+      const result = await redisCacheClient.get('any-key');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('set()', () => {
+    it('stores an entry with the correct prefixed key', async () => {
+      const entry = makeEntry({ vault: 'data' });
+      await redisCacheClient.set('vault-key', entry, 30_000);
+
+      const raw = await fakeRedis.get('cache:vault-key');
+      expect(raw).not.toBeNull();
+      expect(JSON.parse(raw!).data).toEqual({ vault: 'data' });
+    });
+
+    it('converts ttlMs to seconds when calling setex', async () => {
+      const entry = makeEntry({});
+      await redisCacheClient.set('ttl-key', entry, 90_000); // 90 seconds
+
+      // Check that the store entry expires ~90s from now
+      const raw = fakeRedis['store'].get('cache:ttl-key');
+      expect(raw).toBeDefined();
+      const ttlRemaining = (raw!.expiresAt - Date.now()) / 1000;
+      expect(ttlRemaining).toBeGreaterThan(88);
+      expect(ttlRemaining).toBeLessThanOrEqual(90);
+    });
+
+    it('no-ops silently when client is not ready', async () => {
+      (redisCacheClient as any)._isReady = false;
+      // Should not throw
+      await expect(
+        redisCacheClient.set('k', makeEntry({}), 1000),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('del()', () => {
+    it('removes an existing key', async () => {
+      await fakeRedis.setex('cache:del-key', 60, JSON.stringify(makeEntry({})));
+      await redisCacheClient.del('del-key');
+      expect(fakeRedis._size()).toBe(0);
+    });
+  });
+
+  describe('invalidatePattern()', () => {
+    it('removes all keys matching a glob pattern', async () => {
+      const entry = JSON.stringify(makeEntry({}));
+      await fakeRedis.setex('cache:GET:/api/v1/vault/summary', 60, entry);
+      await fakeRedis.setex('cache:GET:/api/v1/vault/apy', 60, entry);
+      await fakeRedis.setex('cache:GET:/api/v1/transactions', 60, entry);
+
+      const removed = await redisCacheClient.invalidatePattern(
+        'GET:/api/v1/vault*',
+      );
+
+      expect(removed).toBe(2);
+      expect(fakeRedis._size()).toBe(1);
+    });
+
+    it('returns 0 when no keys match', async () => {
+      const removed = await redisCacheClient.invalidatePattern('nomatch*');
+      expect(removed).toBe(0);
+    });
+
+    it('returns 0 when client is not ready', async () => {
+      (redisCacheClient as any)._isReady = false;
+      const removed = await redisCacheClient.invalidatePattern('*');
+      expect(removed).toBe(0);
+    });
+  });
+
+  describe('ping()', () => {
+    it('returns PONG when ready', async () => {
+      const result = await redisCacheClient.ping();
+      expect(result).toBe('PONG');
+    });
+
+    it('returns null when not ready', async () => {
+      (redisCacheClient as any)._isReady = false;
+      const result = await redisCacheClient.ping();
+      expect(result).toBeNull();
+    });
+  });
+});
+
+describe('getFromCache', () => {
+  beforeEach(() => {
+    fakeRedis = new FakeRedis();
+    (redisCacheClient as any).client = fakeRedis;
+    (redisCacheClient as any)._isReady = true;
+    responseCache.clear();
+  });
+
+  afterEach(() => {
+    fakeRedis._clear();
+    (redisCacheClient as any)._isReady = false;
+  });
+
+  it('returns null on cache miss', async () => {
+    const result = await getFromCache('GET:/api/v1/vault/summary');
+    expect(result).toBeNull();
+  });
+
+  it('returns entry from Redis on cache hit', async () => {
+    const entry = makeEntry({ totalAssets: '1000' });
+    await fakeRedis.setex(
+      'cache:GET:/api/v1/vault/summary',
+      60,
+      JSON.stringify(entry),
+    );
+
+    const result = await getFromCache('GET:/api/v1/vault/summary');
+    expect(result).not.toBeNull();
+    expect((result!.data as any).totalAssets).toBe('1000');
+  });
+
+  it('returns null for stale Redis entries', async () => {
+    const staleEntry = makeEntry({}, -1000); // already expired
+    await fakeRedis.setex(
+      'cache:GET:/api/v1/vault/summary',
+      1, // 1s TTL in Redis; entry itself has expiresAt in the past
+      JSON.stringify(staleEntry),
+    );
+    // We need to override expiresAt to be in the past for our check
+    const raw = await fakeRedis.get('cache:GET:/api/v1/vault/summary');
+    const parsed = JSON.parse(raw!);
+    parsed.expiresAt = Date.now() - 1000;
+    fakeRedis['store'].set('cache:GET:/api/v1/vault/summary', {
+      value: JSON.stringify(parsed),
+      expiresAt: Date.now() + 60_000,
+    });
+
+    const result = await getFromCache('GET:/api/v1/vault/summary');
+    expect(result).toBeNull();
+  });
+
+  it('falls back to in-memory LRU when Redis is not ready', async () => {
+    (redisCacheClient as any)._isReady = false;
+
+    const entry = makeEntry({ totalAssets: '500' });
+    responseCache.set('GET:/api/v1/vault/summary', entry);
+
+    const result = await getFromCache('GET:/api/v1/vault/summary');
+    expect(result).not.toBeNull();
+    expect((result!.data as any).totalAssets).toBe('500');
+  });
+});
+
+describe('setInCache', () => {
+  beforeEach(() => {
+    fakeRedis = new FakeRedis();
+    (redisCacheClient as any).client = fakeRedis;
+    (redisCacheClient as any)._isReady = true;
+    responseCache.clear();
+  });
+
+  afterEach(() => {
+    fakeRedis._clear();
+    (redisCacheClient as any)._isReady = false;
+  });
+
+  it('writes to both Redis and in-memory LRU', async () => {
+    const entry = makeEntry({ sharePrice: '1.05' });
+    await setInCache('GET:/api/v1/vault/summary', entry, 60_000);
+
+    // Verify Redis
+    const redisRaw = await fakeRedis.get('cache:GET:/api/v1/vault/summary');
+    expect(redisRaw).not.toBeNull();
+    expect(JSON.parse(redisRaw!).data.sharePrice).toBe('1.05');
+
+    // Verify LRU
+    const lruEntry = responseCache.get('GET:/api/v1/vault/summary');
+    expect(lruEntry).not.toBeUndefined();
+    expect((lruEntry!.data as any).sharePrice).toBe('1.05');
+  });
+
+  it('writes only to LRU when Redis is not ready (fail-open)', async () => {
+    (redisCacheClient as any)._isReady = false;
+
+    const entry = makeEntry({ sharePrice: '1.10' });
+    await setInCache('GET:/api/v1/vault/summary', entry, 60_000);
+
+    expect(fakeRedis._size()).toBe(0);
+    const lruEntry = responseCache.get('GET:/api/v1/vault/summary');
+    expect(lruEntry).not.toBeUndefined();
+  });
+});
+
+describe('invalidateCachePattern', () => {
+  beforeEach(() => {
+    fakeRedis = new FakeRedis();
+    (redisCacheClient as any).client = fakeRedis;
+    (redisCacheClient as any)._isReady = true;
+    responseCache.clear();
+  });
+
+  afterEach(() => {
+    fakeRedis._clear();
+    (redisCacheClient as any)._isReady = false;
+  });
+
+  it('clears matching keys from both Redis and in-memory LRU', async () => {
+    const entry = makeEntry({});
+
+    // Seed Redis
+    const entryJson = JSON.stringify(entry);
+    fakeRedis['store'].set('cache:GET:/api/v1/vault/summary', {
+      value: entryJson,
+      expiresAt: Date.now() + 60_000,
+    });
+    fakeRedis['store'].set('cache:GET:/api/v1/transactions', {
+      value: entryJson,
+      expiresAt: Date.now() + 60_000,
+    });
+
+    // Seed LRU
+    responseCache.set('GET:/api/v1/vault/summary', entry);
+    responseCache.set('GET:/api/v1/transactions', entry);
+
+    await invalidateCachePattern('GET:/api/v1/vault.*');
+
+    // Vault entry should be gone from LRU
+    expect(responseCache.get('GET:/api/v1/vault/summary')).toBeUndefined();
+    // Transactions entry should still be present
+    expect(responseCache.get('GET:/api/v1/transactions')).not.toBeUndefined();
+  });
+});
+
+describe('getRedisCacheHealth', () => {
+  beforeEach(() => {
+    fakeRedis = new FakeRedis();
+    (redisCacheClient as any).client = fakeRedis;
+  });
+
+  afterEach(() => {
+    (redisCacheClient as any)._isReady = false;
+  });
+
+  it('returns "up" when Redis is ready and PING succeeds', async () => {
+    (redisCacheClient as any)._isReady = true;
+    const health = await getRedisCacheHealth();
+    expect(health).toBe('up');
+  });
+
+  it('returns "degraded" when Redis is configured but not ready', async () => {
+    (redisCacheClient as any)._isReady = false;
+    const health = await getRedisCacheHealth();
+    expect(health).toBe('degraded');
+  });
+
+  it('returns "up" when Redis is not configured (in-memory only)', async () => {
+    (redisCacheClient as any).client = null;
+    (redisCacheClient as any)._isReady = false;
+    const health = await getRedisCacheHealth();
+    expect(health).toBe('up');
+    // Restore
+    (redisCacheClient as any).client = fakeRedis;
+  });
+});

--- a/backend/src/__tests__/redisCacheIntegration.test.ts
+++ b/backend/src/__tests__/redisCacheIntegration.test.ts
@@ -1,0 +1,370 @@
+/**
+ * @file redisCacheIntegration.test.ts
+ * Integration-level tests for the Redis cache layer.
+ *
+ * These tests exercise the public API of redisCache.ts + the cache middleware
+ * (cache.ts) together, using a fake Redis client injected into the singleton,
+ * without booting the full Express app (which requires the workspace package
+ * @yieldvault/api-schemas to be built).
+ *
+ * Coverage:
+ *   - getFromCache / setInCache round-trip through both Redis and in-memory LRU
+ *   - invalidateCachePattern clears both stores
+ *   - getRedisCacheHealth reflects real connection state
+ *   - X-Cache-Hit and X-Cache-Backend headers are set by cacheMiddleware
+ *   - Cache-Control header reflects the TTL
+ *   - cacheMiddleware falls back to LRU when Redis is not ready
+ *   - cacheMiddleware uses async Redis path when Redis is ready
+ */
+
+import { EventEmitter } from 'events';
+import type { Request, Response } from 'express';
+
+// ─── Fake Redis ───────────────────────────────────────────────────────────────
+
+class FakeRedis extends EventEmitter {
+  private store = new Map<string, { value: string; expiresAt: number }>();
+
+  async ping() { return 'PONG'; }
+
+  async get(key: string): Promise<string | null> {
+    const e = this.store.get(key);
+    if (!e || e.expiresAt < Date.now()) { this.store.delete(key); return null; }
+    return e.value;
+  }
+
+  async setex(key: string, ttlSec: number, value: string) {
+    this.store.set(key, { value, expiresAt: Date.now() + ttlSec * 1000 });
+    return 'OK';
+  }
+
+  async del(...keys: string[]) {
+    let n = 0;
+    for (const k of keys) if (this.store.delete(k)) n++;
+    return n;
+  }
+
+  async scan(cursor: string, _m: 'MATCH', pattern: string, _c: 'COUNT', _n: number): Promise<[string, string[]]> {
+    const re = new RegExp('^' + pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*'));
+    const matched = [...this.store.keys()].filter(k => re.test(k));
+    return ['0', cursor === '0' ? matched : []];
+  }
+
+  async quit() {}
+
+  size() { return this.store.size; }
+  clear() { this.store.clear(); }
+  keys() { return [...this.store.keys()]; }
+}
+
+// ─── Imports ──────────────────────────────────────────────────────────────────
+
+import {
+  redisCacheClient,
+  getFromCache,
+  setInCache,
+  invalidateCachePattern,
+  getRedisCacheHealth,
+} from '../redisCache';
+import { responseCache, cacheMiddleware, buildCacheKey } from '../middleware/cache';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+let fakeRedis: FakeRedis;
+
+function makeEntry(data: unknown, ttlMs = 60_000) {
+  return {
+    data,
+    statusCode: 200,
+    headers: {} as Record<string, string>,
+    expiresAt: Date.now() + ttlMs,
+    ttl: ttlMs,
+    lastUsed: Date.now(),
+  };
+}
+
+function makeFakeRequest(path: string, query: Record<string, string> = {}): Partial<Request> {
+  return {
+    method: 'GET',
+    path,
+    baseUrl: '',
+    query,
+    headers: {},
+    route: { path },
+  } as unknown as Partial<Request>;
+}
+
+function makeFakeResponse(): { res: Partial<Response>; capturedJson: unknown; capturedStatus: number; headers: Record<string, string | number> } {
+  const headers: Record<string, string | number> = {};
+  let capturedJson: unknown = undefined;
+  let capturedStatus = 200;
+
+  const res = {
+    statusCode: 200,
+    setHeader(name: string, value: string | number) {
+      headers[name.toLowerCase()] = value;
+      (this as any).statusCode = name === 'status' ? Number(value) : (this as any).statusCode;
+    },
+    status(code: number) {
+      capturedStatus = code;
+      (this as any).statusCode = code;
+      return this;
+    },
+    json(data: unknown) {
+      capturedJson = data;
+      return this;
+    },
+  } as unknown as Partial<Response>;
+
+  return { res, capturedJson, capturedStatus, headers };
+}
+
+// ─── Setup ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  fakeRedis = new FakeRedis();
+  (redisCacheClient as any).client = fakeRedis;
+  (redisCacheClient as any)._isReady = true;
+  responseCache.clear();
+});
+
+afterEach(() => {
+  fakeRedis.clear();
+  (redisCacheClient as any)._isReady = false;
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('getFromCache + setInCache round-trip', () => {
+  it('returns null on empty cache', async () => {
+    expect(await getFromCache('GET:/api/v1/vault/summary')).toBeNull();
+  });
+
+  it('stores to Redis and retrieves back', async () => {
+    const entry = makeEntry({ totalAssets: '1000', sharePrice: '1.05' });
+    await setInCache('GET:/api/v1/vault/summary', entry, 60_000);
+
+    const retrieved = await getFromCache('GET:/api/v1/vault/summary');
+    expect(retrieved).not.toBeNull();
+    expect((retrieved!.data as any).totalAssets).toBe('1000');
+    expect((retrieved!.data as any).sharePrice).toBe('1.05');
+  });
+
+  it('stores to both Redis and in-memory LRU simultaneously', async () => {
+    const entry = makeEntry({ apy: 8.5 });
+    await setInCache('GET:/api/v1/vault/apy', entry, 30_000);
+
+    // Verify Redis key exists
+    const redisRaw = await fakeRedis.get('cache:GET:/api/v1/vault/apy');
+    expect(redisRaw).not.toBeNull();
+
+    // Verify LRU entry exists
+    const lruEntry = responseCache.get('GET:/api/v1/vault/apy');
+    expect(lruEntry).not.toBeUndefined();
+  });
+
+  it('falls back to LRU when Redis not ready', async () => {
+    (redisCacheClient as any)._isReady = false;
+
+    const entry = makeEntry({ totalAssets: '500' });
+    await setInCache('GET:/api/v1/vault/summary', entry, 60_000);
+
+    // Nothing written to Redis
+    expect(fakeRedis.size()).toBe(0);
+
+    // Still retrievable from LRU
+    const retrieved = await getFromCache('GET:/api/v1/vault/summary');
+    expect(retrieved).not.toBeNull();
+    expect((retrieved!.data as any).totalAssets).toBe('500');
+  });
+
+  it('respects TTL — stale entries are treated as misses', async () => {
+    const expired = makeEntry({}, -5000); // expiresAt in the past
+    // Write directly to Redis with a past expiresAt
+    fakeRedis['store'].set('cache:GET:/api/v1/vault/summary', {
+      value: JSON.stringify(expired),
+      expiresAt: Date.now() + 60_000, // Redis TTL still valid
+    });
+
+    const result = await getFromCache('GET:/api/v1/vault/summary');
+    expect(result).toBeNull();
+  });
+});
+
+describe('invalidateCachePattern', () => {
+  it('removes vault keys from both Redis and LRU', async () => {
+    const entry = makeEntry({ totalAssets: '999' });
+
+    // Seed both stores
+    await setInCache('GET:/api/v1/vault/summary', entry, 60_000);
+    await setInCache('GET:/api/v1/vault/apy', entry, 60_000);
+    await setInCache('GET:/api/v1/transactions', entry, 60_000);
+
+    await invalidateCachePattern('GET:/api/v1/vault*');
+
+    // Vault entries gone from LRU
+    expect(responseCache.get('GET:/api/v1/vault/summary')).toBeUndefined();
+    expect(responseCache.get('GET:/api/v1/vault/apy')).toBeUndefined();
+    // Transaction entry still present
+    expect(responseCache.get('GET:/api/v1/transactions')).not.toBeUndefined();
+
+    // Redis vault keys gone
+    expect(await fakeRedis.get('cache:GET:/api/v1/vault/summary')).toBeNull();
+    expect(await fakeRedis.get('cache:GET:/api/v1/vault/apy')).toBeNull();
+    // Redis transaction key still present
+    expect(await fakeRedis.get('cache:GET:/api/v1/transactions')).not.toBeNull();
+  });
+
+  it('is a no-op when nothing matches', async () => {
+    const removed = await invalidateCachePattern('GET:/api/v1/nonexistent.*');
+    expect(removed).toBe(0);
+  });
+});
+
+describe('getRedisCacheHealth', () => {
+  it('returns "up" when Redis is configured and responding', async () => {
+    expect(await getRedisCacheHealth()).toBe('up');
+  });
+
+  it('returns "degraded" when Redis configured but not ready', async () => {
+    (redisCacheClient as any)._isReady = false;
+    expect(await getRedisCacheHealth()).toBe('degraded');
+  });
+
+  it('returns "up" when Redis is not configured (in-memory only mode)', async () => {
+    const savedClient = (redisCacheClient as any).client;
+    (redisCacheClient as any).client = null;
+    (redisCacheClient as any)._isReady = false;
+
+    expect(await getRedisCacheHealth()).toBe('up');
+
+    (redisCacheClient as any).client = savedClient;
+  });
+});
+
+describe('cacheMiddleware — Redis path', () => {
+  it('sets X-Cache-Hit: false on first request (miss)', (done) => {
+    const req = makeFakeRequest('/api/v1/vault/summary');
+    const { res, headers } = makeFakeResponse();
+    let nextCalled = false;
+
+    // Intercept res.json to capture what the middleware does on miss
+    (res as any).json = function (data: unknown) {
+      (res as any).statusCode = 200;
+      // After our handler calls res.json, the middleware should have set headers
+      expect(headers['x-cache-hit']).toBe('false');
+      expect(headers['x-cache-backend']).toBeDefined();
+      done();
+      return res;
+    };
+
+    const middleware = cacheMiddleware({ ttl: 60_000 });
+
+    middleware(req as Request, res as Response, () => {
+      nextCalled = true;
+      // Simulate route handler
+      (res as any).json({ totalAssets: '1000' });
+    });
+  });
+
+  it('serves X-Cache-Hit: true on second request (hit)', async () => {
+    const key = 'GET:/api/v1/vault/summary';
+    const entry = makeEntry({ totalAssets: '2000' });
+
+    // Prime the cache
+    await setInCache(key, entry, 60_000);
+
+    return new Promise<void>((resolve, reject) => {
+      const req = makeFakeRequest('/api/v1/vault/summary');
+      const { res, headers } = makeFakeResponse();
+
+      // Override res.json and status to capture the cache hit response
+      (res as any).json = function (data: unknown) {
+        try {
+          expect(headers['x-cache-hit']).toBe('true');
+          expect(headers['x-cache-backend']).toBeDefined();
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+        return res;
+      };
+
+      (res as any).status = function (code: number) {
+        (res as any).statusCode = code;
+        return res;
+      };
+
+      const middleware = cacheMiddleware({ ttl: 60_000 });
+      middleware(req as Request, res as Response, () => {
+        reject(new Error('next() should not be called on a cache hit'));
+      });
+    });
+  });
+
+  it('sets Cache-Control with correct max-age', (done) => {
+    const req = makeFakeRequest('/api/v1/vault/metrics');
+    const { res, headers } = makeFakeResponse();
+
+    (res as any).json = function (_data: unknown) {
+      (res as any).statusCode = 200;
+      const cc = headers['cache-control'] as string | undefined;
+      expect(cc).toMatch(/max-age=\d+/);
+      const match = cc?.match(/max-age=(\d+)/);
+      expect(parseInt(match![1], 10)).toBeGreaterThan(0);
+      done();
+      return res;
+    };
+
+    const middleware = cacheMiddleware({ ttl: 45_000 });
+    middleware(req as Request, res as Response, () => {
+      (res as any).json({ message: 'Vault metrics' });
+    });
+  });
+
+  it('skips cache for requests with Authorization header', (done) => {
+    const req = {
+      ...makeFakeRequest('/api/v1/vault/summary'),
+      headers: { authorization: 'Bearer token123' },
+    } as unknown as Request;
+
+    const { res } = makeFakeResponse();
+    const middleware = cacheMiddleware({ ttl: 60_000 });
+
+    middleware(req, res as Response, () => {
+      // next() should be called immediately — no caching for authed requests
+      done();
+    });
+  });
+
+  it('does not cache non-GET requests', (done) => {
+    const req = { ...makeFakeRequest('/api/v1/vault/summary'), method: 'POST' } as unknown as Request;
+    const { res } = makeFakeResponse();
+    const middleware = cacheMiddleware({ ttl: 60_000 });
+
+    middleware(req, res as Response, () => {
+      // next() called, no cache interaction
+      done();
+    });
+  });
+});
+
+describe('buildCacheKey', () => {
+  it('produces deterministic keys regardless of query param order', () => {
+    const req1 = makeFakeRequest('/api/v1/vault/apy', { limit: '10', offset: '0' });
+    const req2 = makeFakeRequest('/api/v1/vault/apy', { offset: '0', limit: '10' });
+    expect(buildCacheKey(req1 as Request)).toBe(buildCacheKey(req2 as Request));
+  });
+
+  it('includes method and path in key', () => {
+    const req = makeFakeRequest('/api/v1/vault/summary');
+    const key = buildCacheKey(req as Request);
+    expect(key).toBe('GET:/api/v1/vault/summary');
+  });
+
+  it('appends sorted query params', () => {
+    const req = makeFakeRequest('/api/v1/vault/apy', { b: '2', a: '1' });
+    const key = buildCacheKey(req as Request);
+    expect(key).toBe('GET:/api/v1/vault/apy:a=1&b=2');
+  });
+});

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -43,6 +43,7 @@ import { structuredLoggingMiddleware, logger, LogLevel } from './middleware/stru
 import { corsMiddleware } from './middleware/cors';
 import { geofencingMiddleware } from './middleware/geofencing';
 import { cacheMiddleware, invalidateCache, getCacheStats } from './middleware/cache';
+import { getRedisCacheHealth, redisCacheClient } from './redisCache';
 import { validate, LoginSchema, NonceRequestSchema, RefreshSchema } from './middleware/validate';
 import { tieredJsonBodyParser } from './middleware/payloadLimit';
 import { requireSignedWalletAction } from './middleware/walletSignedAction';
@@ -213,6 +214,50 @@ function buildVaultSummaryResponse() {
     apy: 0,
     timestamp: new Date().toISOString(),
   };
+}
+
+/**
+ * Reads the vault summary from the VaultState table and the most recent
+ * SharePriceSnapshot for the share price. Falls back to zeroed values when
+ * the database is unavailable (e.g., during startup or in tests).
+ */
+async function buildVaultSummaryResponseFromDb(): Promise<{
+  totalAssets: string;
+  totalShares: string;
+  sharePrice: string;
+  apy: number;
+  timestamp: string;
+}> {
+  try {
+    const prismaClient = getPrismaClient();
+    const [vaultState, latestSnapshot] = await Promise.all([
+      prismaClient.vaultState.findUnique({ where: { id: 1 } }),
+      prismaClient.sharePriceSnapshot
+        .findFirst({ orderBy: { recordedAt: 'desc' } })
+        .catch(() => null),
+    ]);
+
+    const totalAssets = vaultState?.totalAssets ?? '0';
+    const totalShares = vaultState?.totalShares ?? '0';
+    const sharePrice = latestSnapshot?.sharePrice ?? '1.000000';
+
+    return {
+      totalAssets,
+      totalShares,
+      sharePrice,
+      apy: 0, // APY is computed by the nightly snapshot job; placeholder until first run
+      timestamp: new Date().toISOString(),
+    };
+  } catch {
+    // Fail-open: return safe zero values so the endpoint never 500s
+    return {
+      totalAssets: '0',
+      totalShares: '0',
+      sharePrice: '1.000000',
+      apy: 0,
+      timestamp: new Date().toISOString(),
+    };
+  }
 }
 
 function resolveActingAdminAddress(req: Request): string {
@@ -648,8 +693,11 @@ app.get('/health', async (_req: Request, res: Response) => {
     sorobanCircuitBreaker: circuitSnapshot,
   };
 
-  // Check if all dependencies are healthy
-  const allHealthy = Object.values(health.checks).every((check) => check === 'up');
+  // 'degraded' is acceptable for cache (in-memory fallback active); only 'down' is unhealthy
+  const allHealthy = Object.entries(health.checks).every(([key, check]) => {
+    if (key === 'cache') return check === 'up' || check === 'degraded';
+    return check === 'up';
+  });
 
   res.status(allHealthy ? 200 : 503).json(health);
 });
@@ -885,6 +933,8 @@ app.get('/api/v1/vault/transactions/export', handleTransactionExport);
  */
 /**
  * GET /api/v1/vault/summary – read-only summary; relaxed rate limit.
+ * Data is sourced from VaultState + SharePriceSnapshot (DB) and cached via
+ * the Redis-backed response cache.
  */
 app.get(
   '/api/v1/vault/summary',
@@ -900,12 +950,19 @@ app.get(
       code: 'VAULT_SUMMARY_TIMEOUT',
       message: 'Vault summary is temporarily unavailable. Please refresh in a moment.',
       stale: true,
-      data: buildVaultSummaryResponse(),
+      data: {
+        totalAssets: '0',
+        totalShares: '0',
+        sharePrice: '1.000000',
+        apy: 0,
+        timestamp: new Date().toISOString(),
+      },
       timestamp: new Date().toISOString(),
     }),
   }),
-  (_req: Request, res: Response) => {
-    res.json(buildVaultSummaryResponse());
+  async (_req: Request, res: Response) => {
+    const summary = await buildVaultSummaryResponseFromDb();
+    res.json(summary);
   },
 );
 
@@ -1408,7 +1465,7 @@ app.delete('/admin/feature-flags/overrides/:id', validateApiKey, async (req: Req
 });
 
 /**
- * GET /admin/cache/stats - Get cache statistics including hit rate (R8)
+ * GET /admin/cache/stats - Get cache statistics including hit rate (R8) and Redis status
  * Requires API key authentication
  */
 app.get('/admin/cache/stats', validateApiKey, async (_req: Request, res: Response) => {
@@ -1444,10 +1501,35 @@ app.get('/admin/cache/stats', validateApiKey, async (_req: Request, res: Respons
     hitRate = null;
   }
 
+  const redisHealth = await getRedisCacheHealth();
+
   res.json({
     entryCount: stats.size,
     entries: stats.entries,
     hitRate,
+    redis: {
+      configured: redisCacheClient.isConfigured,
+      ready: redisCacheClient.isReady,
+      health: redisHealth,
+    },
+    timestamp: new Date().toISOString(),
+  });
+});
+
+/**
+ * GET /admin/cache/redis-status - Detailed Redis cache connection and health status
+ * Requires API key authentication
+ */
+app.get('/admin/cache/redis-status', validateApiKey, async (_req: Request, res: Response) => {
+  const redisHealth = await getRedisCacheHealth();
+  const pingResponse = await redisCacheClient.ping();
+
+  res.json({
+    configured: redisCacheClient.isConfigured,
+    ready: redisCacheClient.isReady,
+    health: redisHealth,
+    ping: pingResponse,
+    fallbackActive: redisCacheClient.isConfigured && !redisCacheClient.isReady,
     timestamp: new Date().toISOString(),
   });
 });
@@ -3828,20 +3910,32 @@ if (process.env.NODE_ENV !== 'test' && process.env.VAULT_CONTRACT_ID) {
 // ─── Dependency Health Checks ────────────────────────────────────────────────
 
 /**
- * Check cache health
+ * Check cache health.
+ * Tests the in-memory NodeCache first; also probes Redis when configured.
+ * Returns 'up' when the primary store is healthy (Redis or memory).
  */
 function getCacheHealth(): string {
   try {
     cache.set('health-check', true);
     const value = cache.get('health-check');
-    return value ? 'up' : 'down';
+    if (!value) return 'down';
+
+    // If Redis is configured, surface its connection status as well
+    if (redisCacheClient.isConfigured && !redisCacheClient.isReady) {
+      // Redis configured but not yet connected → degraded, memory cache still up
+      return 'degraded';
+    }
+
+    return 'up';
   } catch {
     return 'down';
   }
 }
 
 function checkCacheDependency(): boolean {
-  return getCacheHealth() === 'up';
+  const health = getCacheHealth();
+  // 'degraded' means memory fallback is active — service is still operational
+  return health === 'up' || health === 'degraded';
 }
 
 /**

--- a/backend/src/middleware/cache.ts
+++ b/backend/src/middleware/cache.ts
@@ -1,6 +1,7 @@
 import type { Request, Response, NextFunction } from 'express';
 import { cacheHitCount, cacheMissCount, cacheEvictionCount } from '../metrics';
 import { latencyMonitoringService } from '../latencyMonitoring';
+import { getFromCache, setInCache, redisCacheClient } from '../redisCache';
 
 interface CacheEntry {
   data: unknown;
@@ -158,6 +159,83 @@ export function cacheMiddleware(options: CacheOptions) {
 
     const route = (req.route?.path as string | undefined) ?? req.path;
     const cacheKey = buildCacheKey(req);
+
+    // ── Redis-aware async path ───────────────────────────────────────────────
+    // When Redis is configured we use the async Redis+LRU path; otherwise we
+    // fall through to the synchronous in-memory-only path for zero overhead.
+    if (redisCacheClient.isConfigured) {
+      const hitStart = Date.now();
+
+      getFromCache(cacheKey)
+        .then((cached) => {
+          if (cached && cached.expiresAt > Date.now()) {
+            // Cache HIT (Redis or LRU fallback)
+            cacheHitCount.inc({ method: req.method, route });
+
+            const remainingMs = cached.expiresAt - Date.now();
+            const remainingSec = Math.ceil(remainingMs / 1000);
+
+            res.setHeader('X-Cache-Hit', 'true');
+            res.setHeader('X-Cache-Backend', redisCacheClient.isReady ? 'redis' : 'memory');
+            res.setHeader('Cache-Control', `public, max-age=${Math.max(remainingSec, 0)}`);
+
+            for (const [name, value] of Object.entries(cached.headers)) {
+              if (name !== 'Cache-Control' && name !== 'X-Cache-Hit' && name !== 'X-Cache-Backend') {
+                res.setHeader(name, value);
+              }
+            }
+
+            res.status(cached.statusCode).json(cached.data);
+            latencyMonitoringService.recordLatency(route, Date.now() - hitStart, true);
+            return;
+          }
+
+          // Cache MISS — intercept response to store it
+          const missStart = Date.now();
+          cacheMissCount.inc({ method: req.method, route });
+
+          const originalJson = res.json.bind(res);
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          res.json = function (data: any) {
+            const status = res.statusCode ?? 200;
+
+            if (status >= 200 && status < 300) {
+              const maxAgeSec = Math.ceil(options.ttl / 1000);
+              res.setHeader('X-Cache-Hit', 'false');
+              res.setHeader('X-Cache-Backend', redisCacheClient.isReady ? 'redis' : 'memory');
+              res.setHeader('Cache-Control', `public, max-age=${maxAgeSec}`);
+
+              const entry = {
+                data,
+                statusCode: status,
+                headers: {},
+                expiresAt: Date.now() + options.ttl,
+                ttl: options.ttl,
+                lastUsed: Date.now(),
+              };
+
+              // Fire-and-forget: write to Redis + LRU asynchronously
+              void setInCache(cacheKey, entry, options.ttl).catch(() => {
+                // Errors are already logged inside setInCache; do not crash the response
+              });
+            }
+
+            const result = originalJson(data);
+            latencyMonitoringService.recordLatency(route, Date.now() - missStart, false);
+            return result;
+          } as typeof res.json;
+
+          next();
+        })
+        .catch(() => {
+          // Redis lookup failed entirely — fall through to handler without caching
+          next();
+        });
+
+      return;
+    }
+
+    // ── Synchronous in-memory-only path (Redis not configured) ───────────────
     const cached = responseCache.get(cacheKey);
 
     if (cached && cached.expiresAt > Date.now()) {
@@ -169,11 +247,12 @@ export function cacheMiddleware(options: CacheOptions) {
       const remainingSec = Math.ceil(remainingMs / 1000);
 
       res.setHeader('X-Cache-Hit', 'true');
+      res.setHeader('X-Cache-Backend', 'memory');
       res.setHeader('Cache-Control', `public, max-age=${Math.max(remainingSec, 0)}`);
 
       // Restore any other cached response headers
       for (const [name, value] of Object.entries(cached.headers)) {
-        if (name !== 'Cache-Control' && name !== 'X-Cache-Hit') {
+        if (name !== 'Cache-Control' && name !== 'X-Cache-Hit' && name !== 'X-Cache-Backend') {
           res.setHeader(name, value);
         }
       }
@@ -199,6 +278,7 @@ export function cacheMiddleware(options: CacheOptions) {
       if (status >= 200 && status < 300) {
         const maxAgeSec = Math.ceil(options.ttl / 1000);
         res.setHeader('X-Cache-Hit', 'false');
+        res.setHeader('X-Cache-Backend', 'memory');
         res.setHeader('Cache-Control', `public, max-age=${maxAgeSec}`);
 
         responseCache.set(cacheKey, {
@@ -272,6 +352,8 @@ export function invalidateCache(pattern?: string): number {
   if (!pattern) {
     const count = responseCache.size;
     responseCache.clear();
+    // Also flush matching Redis keys asynchronously (best-effort)
+    void redisCacheClient.invalidatePattern('*').catch(() => {});
     return count;
   }
 
@@ -283,6 +365,10 @@ export function invalidateCache(pattern?: string): number {
       removed++;
     }
   }
+
+  // Asynchronously invalidate matching Redis keys (fail-safe; does not block the caller)
+  void redisCacheClient.invalidatePattern(pattern).catch(() => {});
+
   return removed;
 }
 

--- a/backend/src/redisCache.ts
+++ b/backend/src/redisCache.ts
@@ -1,0 +1,445 @@
+/**
+ * @file redisCache.ts
+ * Redis-backed response cache for price and vault summary endpoints.
+ *
+ * Provides a unified caching interface that:
+ *   1. Uses Redis (via ioredis) when REDIS_URL is configured and the connection
+ *      is healthy.
+ *   2. Falls back transparently to the existing in-memory LRU store when Redis
+ *      is not configured or temporarily unreachable (fail-open).
+ *
+ * Cache keys follow the same deterministic format used by the existing LRU
+ * middleware so entries written through either path are interchangeable.
+ *
+ * Prometheus counters are exported so operators can track Redis vs in-memory
+ * hit/miss ratios from the /metrics endpoint.
+ *
+ * Environment variables:
+ *   REDIS_URL                  – Redis connection URL (required to enable Redis)
+ *   REDIS_CACHE_KEY_PREFIX     – Key namespace prefix (default: "cache:")
+ *   REDIS_CACHE_CONNECT_TIMEOUT_MS – Connection timeout (default: 2000)
+ *   REDIS_CACHE_COMMAND_TIMEOUT_MS – Per-command timeout (default: 500)
+ *
+ * TTL values are always specified in milliseconds by callers; this module
+ * converts them to seconds when writing to Redis (Redis TTL is in seconds).
+ */
+
+import { Redis } from 'ioredis';
+import { Counter, Gauge, register as defaultRegister } from 'prom-client';
+import { responseCache } from './middleware/cache';
+
+// ─── Configuration ────────────────────────────────────────────────────────────
+
+const DEFAULT_KEY_PREFIX = 'cache:';
+const DEFAULT_CONNECT_TIMEOUT_MS = 2000;
+const DEFAULT_COMMAND_TIMEOUT_MS = 500;
+
+function resolveEnvInt(key: string, defaultValue: number): number {
+  const raw = process.env[key];
+  if (!raw) return defaultValue;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : defaultValue;
+}
+
+const KEY_PREFIX = process.env.REDIS_CACHE_KEY_PREFIX ?? DEFAULT_KEY_PREFIX;
+const CONNECT_TIMEOUT_MS = resolveEnvInt(
+  'REDIS_CACHE_CONNECT_TIMEOUT_MS',
+  DEFAULT_CONNECT_TIMEOUT_MS,
+);
+const COMMAND_TIMEOUT_MS = resolveEnvInt(
+  'REDIS_CACHE_COMMAND_TIMEOUT_MS',
+  DEFAULT_COMMAND_TIMEOUT_MS,
+);
+
+// ─── Prometheus Metrics ───────────────────────────────────────────────────────
+
+function createOrGet<T extends { name: string }>(
+  factory: () => T,
+  name: string,
+): T {
+  const existing = defaultRegister.getSingleMetric(name);
+  if (existing) return existing as unknown as T;
+  return factory();
+}
+
+export const redisCacheHitCount = createOrGet(
+  () =>
+    new Counter({
+      name: 'redis_cache_hit_total',
+      help: 'Total Redis cache hits for response caching',
+      labelNames: ['route'] as const,
+      registers: [defaultRegister],
+    }),
+  'redis_cache_hit_total',
+);
+
+export const redisCacheMissCount = createOrGet(
+  () =>
+    new Counter({
+      name: 'redis_cache_miss_total',
+      help: 'Total Redis cache misses for response caching',
+      labelNames: ['route'] as const,
+      registers: [defaultRegister],
+    }),
+  'redis_cache_miss_total',
+);
+
+export const redisCacheErrorCount = createOrGet(
+  () =>
+    new Counter({
+      name: 'redis_cache_error_total',
+      help: 'Total Redis errors encountered during response caching operations',
+      labelNames: ['operation'] as const,
+      registers: [defaultRegister],
+    }),
+  'redis_cache_error_total',
+);
+
+export const redisCacheConnectionStatus = createOrGet(
+  () =>
+    new Gauge({
+      name: 'redis_cache_connection_status',
+      help: 'Redis cache connection status: 1 = connected, 0 = disconnected',
+      registers: [defaultRegister],
+    }),
+  'redis_cache_connection_status',
+);
+
+// ─── Redis Client ─────────────────────────────────────────────────────────────
+
+/**
+ * Serialised cache entry stored in Redis.
+ * All fields are preserved so a Redis-sourced hit behaves identically to
+ * a hit served from the in-memory LRU store.
+ */
+export interface RedisCacheEntry {
+  data: unknown;
+  statusCode: number;
+  headers: Record<string, string>;
+  expiresAt: number;
+  ttl: number;
+  lastUsed: number;
+}
+
+class RedisCacheClient {
+  private client: Redis | null = null;
+  private _isReady: boolean = false;
+  private readonly redisUrl: string | undefined;
+
+  constructor() {
+    this.redisUrl = process.env.REDIS_URL;
+    if (!this.redisUrl) {
+      this._log('warn', 'redis_cache_not_configured', {
+        message:
+          'REDIS_URL not set; vault summary/price cache will use in-memory LRU fallback',
+      });
+      return;
+    }
+
+    this.client = new Redis(this.redisUrl, {
+      lazyConnect: true,
+      connectTimeout: CONNECT_TIMEOUT_MS,
+      commandTimeout: COMMAND_TIMEOUT_MS,
+      // Prevent Node process from being kept alive solely by this client
+      maxRetriesPerRequest: 1,
+    });
+
+    const parsed = new URL(this.redisUrl);
+    const host = parsed.hostname;
+    const port = parseInt(parsed.port || '6379', 10);
+
+    this.client.on('connect', () => {
+      this._isReady = true;
+      redisCacheConnectionStatus.set(1);
+      this._log('info', 'redis_cache_connected', { host, port });
+    });
+
+    this.client.on('ready', () => {
+      this._isReady = true;
+      redisCacheConnectionStatus.set(1);
+    });
+
+    this.client.on('reconnecting', () => {
+      this._log('info', 'redis_cache_reconnecting', { host, port });
+    });
+
+    this.client.on('error', (err: Error) => {
+      this._isReady = false;
+      redisCacheConnectionStatus.set(0);
+      this._log('error', 'redis_cache_error', {
+        host,
+        port,
+        reason: err.message,
+      });
+    });
+
+    this.client.on('close', () => {
+      this._isReady = false;
+      redisCacheConnectionStatus.set(0);
+    });
+  }
+
+  /** Whether Redis is configured and the connection is currently healthy. */
+  get isReady(): boolean {
+    return this._isReady;
+  }
+
+  /** Whether REDIS_URL is set (client was configured, regardless of health). */
+  get isConfigured(): boolean {
+    return this.client !== null;
+  }
+
+  /** Underlying ioredis client – primarily for testing. */
+  getClient(): Redis | null {
+    return this.client;
+  }
+
+  // ─── Cache Operations ─────────────────────────────────────────────────────
+
+  /**
+   * Retrieve a cache entry by key.
+   * Returns `null` when the key is absent, Redis is unavailable, or JSON
+   * parsing fails.
+   */
+  async get(key: string): Promise<RedisCacheEntry | null> {
+    if (!this._isReady || !this.client) {
+      return null;
+    }
+
+    try {
+      const raw = await this.client.get(this._prefixed(key));
+      if (!raw) return null;
+      const entry = JSON.parse(raw) as RedisCacheEntry;
+      return entry;
+    } catch (err) {
+      redisCacheErrorCount.inc({ operation: 'get' });
+      this._log('error', 'redis_cache_get_error', {
+        key,
+        reason: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    }
+  }
+
+  /**
+   * Store a cache entry with an explicit TTL (in milliseconds).
+   * Silently no-ops when Redis is unavailable.
+   */
+  async set(key: string, entry: RedisCacheEntry, ttlMs: number): Promise<void> {
+    if (!this._isReady || !this.client) {
+      return;
+    }
+
+    const ttlSeconds = Math.max(1, Math.ceil(ttlMs / 1000));
+    try {
+      await this.client.setex(this._prefixed(key), ttlSeconds, JSON.stringify(entry));
+    } catch (err) {
+      redisCacheErrorCount.inc({ operation: 'set' });
+      this._log('error', 'redis_cache_set_error', {
+        key,
+        reason: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /**
+   * Delete a single cache key.
+   */
+  async del(key: string): Promise<void> {
+    if (!this._isReady || !this.client) return;
+
+    try {
+      await this.client.del(this._prefixed(key));
+    } catch (err) {
+      redisCacheErrorCount.inc({ operation: 'del' });
+      this._log('error', 'redis_cache_del_error', {
+        key,
+        reason: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /**
+   * Delete all keys matching a glob pattern.
+   * Uses SCAN to avoid blocking the server.
+   *
+   * @param pattern – Redis glob-style pattern applied AFTER the key prefix,
+   *                  e.g. `"GET:/api/v1/vault*"` clears all vault cache keys.
+   */
+  async invalidatePattern(pattern: string): Promise<number> {
+    if (!this._isReady || !this.client) return 0;
+
+    const fullPattern = `${KEY_PREFIX}${pattern}`;
+    let cursor = '0';
+    let totalDeleted = 0;
+
+    try {
+      do {
+        const [nextCursor, keys] = await this.client.scan(
+          cursor,
+          'MATCH',
+          fullPattern,
+          'COUNT',
+          100,
+        );
+        cursor = nextCursor;
+
+        if (keys.length > 0) {
+          await this.client.del(...keys);
+          totalDeleted += keys.length;
+        }
+      } while (cursor !== '0');
+    } catch (err) {
+      redisCacheErrorCount.inc({ operation: 'invalidate' });
+      this._log('error', 'redis_cache_invalidate_error', {
+        pattern,
+        reason: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    return totalDeleted;
+  }
+
+  /**
+   * Ping the Redis server and return its response.
+   * Used by the health check subsystem.
+   */
+  async ping(): Promise<string | null> {
+    if (!this._isReady || !this.client) return null;
+
+    try {
+      return await this.client.ping();
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Gracefully close the Redis connection.
+   * Called during graceful shutdown.
+   */
+  async close(): Promise<void> {
+    if (this.client) {
+      await this.client.quit().catch(() => {
+        /* ignore close errors */
+      });
+      this._isReady = false;
+      redisCacheConnectionStatus.set(0);
+    }
+  }
+
+  // ─── Private Helpers ──────────────────────────────────────────────────────
+
+  private _prefixed(key: string): string {
+    return `${KEY_PREFIX}${key}`;
+  }
+
+  private _log(
+    level: 'info' | 'warn' | 'error',
+    event: string,
+    extra: Record<string, unknown>,
+  ): void {
+    // eslint-disable-next-line no-console
+    console.log(JSON.stringify({ level, event, ...extra }));
+  }
+}
+
+// ─── Singleton ────────────────────────────────────────────────────────────────
+
+export const redisCacheClient = new RedisCacheClient();
+
+// ─── High-level Cache Operations ─────────────────────────────────────────────
+
+/**
+ * Read a cache entry by key, consulting Redis first then falling back to the
+ * in-memory LRU store.
+ *
+ * Returns `null` when neither source has a valid (non-expired) entry.
+ */
+export async function getFromCache(key: string): Promise<RedisCacheEntry | null> {
+  // Try Redis first
+  if (redisCacheClient.isReady) {
+    const entry = await redisCacheClient.get(key);
+    if (entry && entry.expiresAt > Date.now()) {
+      redisCacheHitCount.inc({ route: key });
+      return entry;
+    }
+    if (entry) {
+      // Stale entry – Redis should have expired it but hadn't yet; treat as miss
+      redisCacheMissCount.inc({ route: key });
+      return null;
+    }
+    redisCacheMissCount.inc({ route: key });
+    return null;
+  }
+
+  // Fall back to in-memory LRU
+  const lruEntry = responseCache.get(key);
+  if (lruEntry && lruEntry.expiresAt > Date.now()) {
+    return lruEntry as RedisCacheEntry;
+  }
+
+  return null;
+}
+
+/**
+ * Write a cache entry, persisting to Redis (with TTL) and/or the in-memory
+ * LRU store depending on availability.
+ */
+export async function setInCache(
+  key: string,
+  entry: RedisCacheEntry,
+  ttlMs: number,
+): Promise<void> {
+  // Always update the in-memory LRU (cheap; serves as fallback and local read-through)
+  responseCache.set(key, {
+    ...entry,
+    lastUsed: Date.now(),
+  });
+
+  // Persist to Redis when available
+  if (redisCacheClient.isReady) {
+    await redisCacheClient.set(key, entry, ttlMs);
+  }
+}
+
+/**
+ * Invalidate all cache entries whose keys match a pattern.
+ * Clears both the Redis keyspace and the in-memory LRU simultaneously.
+ *
+ * The `pattern` uses:
+ *   - Redis glob syntax for the Redis scan (e.g. `"GET:/api/v1/vault*"`)
+ *   - JavaScript RegExp syntax for the in-memory LRU (same string, treated as
+ *     a regex; simple glob patterns like `"GET:/api/v1/vault*"` are also valid
+ *     regex with `.` treated as any char which is conservative but safe)
+ */
+export async function invalidateCachePattern(pattern: string): Promise<number> {
+  let totalRemoved = 0;
+
+  // Invalidate in Redis
+  if (redisCacheClient.isReady) {
+    totalRemoved += await redisCacheClient.invalidatePattern(pattern);
+  }
+
+  // Invalidate in-memory LRU using the existing helper
+  const { invalidateCache } = await import('./middleware/cache');
+  totalRemoved += invalidateCache(pattern);
+
+  return totalRemoved;
+}
+
+/**
+ * Health check for the Redis cache layer.
+ * Returns 'up' when Redis is configured and responding to PING.
+ * Returns 'degraded' when Redis is configured but unreachable (in-memory fallback active).
+ * Returns 'up' when Redis is not configured (in-memory LRU is sole store — always available).
+ */
+export async function getRedisCacheHealth(): Promise<'up' | 'degraded'> {
+  if (!redisCacheClient.isConfigured) {
+    // No Redis configured; in-memory LRU is always healthy
+    return 'up';
+  }
+
+  const pong = await redisCacheClient.ping();
+  return pong === 'PONG' ? 'up' : 'degraded';
+}


### PR DESCRIPTION
closes #889 
closes #891 
closes #892 
closes #897 

summary

What was implemented
New file: 
redisCache.ts
A production-hardened Redis cache client wrapping ioredis:

RedisCacheClient singleton with get, set, del, invalidatePattern (via Redis SCAN), ping, and close methods
Fail-open: silently falls back to the in-memory LRU when Redis is unavailable — no request ever errors due to Redis
Prometheus metrics: redis_cache_hit_total, redis_cache_miss_total, redis_cache_error_total, redis_cache_connection_status
High-level exports: getFromCache, setInCache, invalidateCachePattern, getRedisCacheHealth
Updated: 
cache.ts
cacheMiddleware now has two paths: an async Redis+LRU path when REDIS_URL is configured, and the original synchronous LRU-only path otherwise — no overhead when Redis isn't used
Adds X-Cache-Backend: redis | memory header so operators can see which store served the hit
invalidateCache now also fires redisCacheClient.invalidatePattern() asynchronously, so pattern invalidations clear both stores
Updated: 
index.ts
buildVaultSummaryResponseFromDb(): replaces the hardcoded-zeros stub — reads VaultState and SharePriceSnapshot from Prisma with a fail-open fallback
getCacheHealth(): returns 'degraded' when Redis is configured but unreachable (memory fallback active), and 'up' otherwise — service still returns HTTP 200
/admin/cache/stats: includes redis: { configured, ready, health } section
/admin/cache/redis-status: new endpoint for detailed Redis diagnostics
Both imports and getRedisCacheHealth / redisCacheClient wired in
New tests
redisCache.test.ts
 — 22 unit tests covering all RedisCacheClient operations, getFromCache/setInCache/invalidateCachePattern, health checks, and fail-open behaviour
redisCacheIntegration.test.ts
 — 18 integration tests covering round-trips, invalidation, middleware headers (X-Cache-Hit, X-Cache-Backend, Cache-Control), and buildCacheKey
New docs: 
REDIS_CACHING.md
Architecture diagram, configuration reference, invalidation flow, Prometheus metrics table, and admin endpoint examples.

Updated: 
.env.example
REDIS_URL uncommented with full documentation of all new cache env vars.