### PR TITLE
feat: vault audit logs, tx history sorting, RPC failover & incident docs (#888, #890, #760, #915)

### DIFF
--- a/backend/src/__tests__/transactionQuery.test.ts
+++ b/backend/src/__tests__/transactionQuery.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Unit tests for the transaction history query helpers (Issue #890).
+ *
+ * These tests intentionally import only the pure helper module so they run
+ * independently of the Express app wiring.
+ */
+import {
+  resolveTransactionSort,
+  buildTransactionOrderBy,
+  buildTransactionCursorFilter,
+  parseTypeFilter,
+  parseStatusFilter,
+  isSortableField,
+  DEFAULT_SORT_FIELD,
+} from '../transactionQuery';
+
+describe('resolveTransactionSort', () => {
+  it('defaults to timestamp desc when nothing is supplied', () => {
+    expect(resolveTransactionSort(undefined, undefined)).toEqual({
+      field: 'timestamp',
+      order: 'desc',
+      valid: true,
+    });
+  });
+
+  it('accepts allowlisted fields and honours asc order', () => {
+    expect(resolveTransactionSort('type', 'asc')).toEqual({
+      field: 'type',
+      order: 'asc',
+      valid: true,
+    });
+    expect(resolveTransactionSort('status', 'desc')).toEqual({
+      field: 'status',
+      order: 'desc',
+      valid: true,
+    });
+  });
+
+  it('flags unknown fields as invalid and falls back to the default', () => {
+    const result = resolveTransactionSort('amount', 'asc');
+    expect(result.valid).toBe(false);
+    expect(result.field).toBe(DEFAULT_SORT_FIELD);
+    expect(result.requested).toBe('amount');
+  });
+
+  it('treats any non-"asc" order as desc', () => {
+    expect(resolveTransactionSort('timestamp', 'sideways').order).toBe('desc');
+    expect(resolveTransactionSort('timestamp', 'ASC').order).toBe('desc');
+  });
+});
+
+describe('isSortableField', () => {
+  it('recognises only allowlisted fields', () => {
+    expect(isSortableField('timestamp')).toBe(true);
+    expect(isSortableField('type')).toBe(true);
+    expect(isSortableField('status')).toBe(true);
+    expect(isSortableField('user')).toBe(false);
+    expect(isSortableField('__proto__')).toBe(false);
+  });
+});
+
+describe('buildTransactionOrderBy', () => {
+  it('adds a deterministic id tie-breaker in the same direction', () => {
+    expect(buildTransactionOrderBy({ field: 'status', order: 'asc' })).toEqual([
+      { status: 'asc' },
+      { id: 'asc' },
+    ]);
+    expect(buildTransactionOrderBy({ field: 'timestamp', order: 'desc' })).toEqual([
+      { timestamp: 'desc' },
+      { id: 'desc' },
+    ]);
+  });
+});
+
+describe('buildTransactionCursorFilter', () => {
+  const cursorRow = {
+    id: 'tx-42',
+    timestamp: new Date('2026-01-02T00:00:00.000Z'),
+    status: 'completed',
+  };
+
+  it('selects rows before the cursor for desc ordering (gt)', () => {
+    const filter = buildTransactionCursorFilter(
+      { field: 'timestamp', order: 'desc' },
+      cursorRow,
+    );
+    expect(filter).toEqual({
+      OR: [
+        { timestamp: { gt: cursorRow.timestamp } },
+        { AND: [{ timestamp: cursorRow.timestamp }, { id: { gt: 'tx-42' } }] },
+      ],
+    });
+  });
+
+  it('selects rows before the cursor for asc ordering (lt)', () => {
+    const filter = buildTransactionCursorFilter(
+      { field: 'status', order: 'asc' },
+      cursorRow,
+    );
+    expect(filter).toEqual({
+      OR: [
+        { status: { lt: 'completed' } },
+        { AND: [{ status: 'completed' }, { id: { lt: 'tx-42' } }] },
+      ],
+    });
+  });
+});
+
+describe('parseTypeFilter', () => {
+  it('returns an empty list when no filter is given', () => {
+    expect(parseTypeFilter(undefined)).toEqual({ types: [] });
+  });
+
+  it('parses comma-separated valid types', () => {
+    expect(parseTypeFilter('deposit,withdrawal')).toEqual({
+      types: ['deposit', 'withdrawal'],
+    });
+  });
+
+  it('rejects unknown types with an error message', () => {
+    const result = parseTypeFilter('deposit,transfer');
+    expect(result.types).toEqual([]);
+    expect(result.error).toMatch(/Invalid type filter/);
+  });
+});
+
+describe('parseStatusFilter', () => {
+  it('passes through recognised statuses', () => {
+    expect(parseStatusFilter('completed')).toEqual({ status: 'completed' });
+  });
+
+  it('rejects unknown statuses', () => {
+    const result = parseStatusFilter('archived');
+    expect(result.status).toBeUndefined();
+    expect(result.error).toMatch(/Invalid status filter/);
+  });
+
+  it('returns empty object when no status is provided', () => {
+    expect(parseStatusFilter(undefined)).toEqual({});
+  });
+});

--- a/backend/src/__tests__/vaultAuditLog.test.ts
+++ b/backend/src/__tests__/vaultAuditLog.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Unit tests for the vault lifecycle audit log (Issue #888).
+ *
+ * Imports only the audit module, so it runs independently of the Express app.
+ */
+import {
+  recordVaultLifecycleEvent,
+  getVaultAuditLogs,
+  getVaultAuditMetrics,
+  resetVaultAuditLogs,
+} from '../vaultAuditLog';
+
+describe('vaultAuditLog', () => {
+  beforeEach(() => {
+    resetVaultAuditLogs();
+    // Keep test output clean; the module logs each entry.
+    jest.spyOn(console, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('records a structured entry with derived action and outcome', () => {
+    const entry = recordVaultLifecycleEvent({
+      operation: 'deposit',
+      phase: 'initiated',
+      actor: 'GWALLET',
+      amount: 100,
+      asset: 'USDC',
+      correlationId: 'corr-1',
+    });
+
+    expect(entry.action).toBe('vault.deposit.initiated');
+    expect(entry.outcome).toBe('pending');
+    expect(entry.amount).toBe('100');
+    expect(entry.asset).toBe('USDC');
+    expect(entry.id).toMatch(/^vaudit_/);
+    expect(entry.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('classifies confirmed as success and failed as failure', () => {
+    const confirmed = recordVaultLifecycleEvent({
+      operation: 'withdrawal',
+      phase: 'confirmed',
+      actor: 'GWALLET',
+      txHash: 'abc123',
+    });
+    const failed = recordVaultLifecycleEvent({
+      operation: 'withdrawal',
+      phase: 'failed',
+      actor: 'GWALLET',
+      errorCode: 'SOROBAN_CIRCUIT_OPEN',
+      errorMessage: 'circuit open',
+    });
+
+    expect(confirmed.outcome).toBe('success');
+    expect(confirmed.action).toBe('vault.withdrawal.confirmed');
+    expect(failed.outcome).toBe('failure');
+    expect(failed.errorCode).toBe('SOROBAN_CIRCUIT_OPEN');
+  });
+
+  it('redacts sensitive metadata fields', () => {
+    const entry = recordVaultLifecycleEvent({
+      operation: 'deposit',
+      phase: 'initiated',
+      actor: 'GWALLET',
+      metadata: { authorization: 'Bearer super-secret', idempotent: true },
+    });
+
+    expect(entry.metadata?.idempotent).toBe(true);
+    expect(entry.metadata?.authorization).not.toBe('Bearer super-secret');
+  });
+
+  it('returns most-recent-first and supports filtering', () => {
+    recordVaultLifecycleEvent({ operation: 'deposit', phase: 'initiated', actor: 'A' });
+    recordVaultLifecycleEvent({ operation: 'withdrawal', phase: 'initiated', actor: 'B' });
+    recordVaultLifecycleEvent({ operation: 'deposit', phase: 'confirmed', actor: 'A' });
+
+    const all = getVaultAuditLogs();
+    expect(all).toHaveLength(3);
+    expect(all[0].phase).toBe('confirmed'); // newest first
+
+    const deposits = getVaultAuditLogs({ operation: 'deposit' });
+    expect(deposits).toHaveLength(2);
+    expect(deposits.every((e) => e.operation === 'deposit')).toBe(true);
+
+    const failures = getVaultAuditLogs({ outcome: 'failure' });
+    expect(failures).toHaveLength(0);
+
+    const actorB = getVaultAuditLogs({ actor: 'B' });
+    expect(actorB).toHaveLength(1);
+  });
+
+  it('clamps the query limit', () => {
+    for (let i = 0; i < 5; i += 1) {
+      recordVaultLifecycleEvent({ operation: 'deposit', phase: 'initiated', actor: 'A' });
+    }
+    expect(getVaultAuditLogs({ limit: 2 })).toHaveLength(2);
+    expect(getVaultAuditLogs({ limit: 0 })).toHaveLength(1);
+  });
+
+  it('aggregates metrics by phase', () => {
+    recordVaultLifecycleEvent({ operation: 'deposit', phase: 'initiated', actor: 'A' });
+    recordVaultLifecycleEvent({ operation: 'deposit', phase: 'submitted', actor: 'A' });
+    recordVaultLifecycleEvent({ operation: 'deposit', phase: 'confirmed', actor: 'A' });
+
+    const metrics = getVaultAuditMetrics();
+    expect(metrics.totalEntries).toBe(3);
+    expect(metrics.byPhase.initiated).toBe(1);
+    expect(metrics.byPhase.submitted).toBe(1);
+    expect(metrics.byPhase.confirmed).toBe(1);
+    expect(metrics.byPhase.failed).toBe(0);
+    expect(metrics.latestTimestamp).not.toBeNull();
+  });
+});

--- a/backend/src/transactionEndpoints.ts
+++ b/backend/src/transactionEndpoints.ts
@@ -12,6 +12,13 @@ import {
   createPaginationEnvelope,
 } from './pagination';
 import { DateRangeParseError, parseUtcDateRange, type ParsedUtcDateRange } from './dateRange';
+import {
+  resolveTransactionSort,
+  buildTransactionOrderBy,
+  buildTransactionCursorFilter,
+  parseTypeFilter,
+  parseStatusFilter,
+} from './transactionQuery';
 import { buildTransactionsResponse } from './listEndpoints';
 import { cacheMiddleware } from './middleware/cache';
 import { tenantGuard } from './middleware/tenantGuard';
@@ -29,10 +36,10 @@ const CACHE_TTL_MS = parseInt(process.env.CACHE_LIST_ENDPOINTS_TTL_MS || '30000'
  * - limit: Items per page (1-100, default 20)
  * - cursor: Opaque cursor for pagination (from previous response's nextCursor)
  * - type: Filter by transaction type ('deposit' or 'withdrawal', or both if omitted)
- * - status: Filter by transaction status
+ * - status: Filter by transaction status ('pending', 'completed' or 'failed')
  * - from: Start date (ISO 8601 or YYYY-MM-DD format)
  * - to: End date (ISO 8601 or YYYY-MM-DD format)
- * - sortBy: Field to sort by (default: 'timestamp')
+ * - sortBy: Field to sort by — one of 'timestamp', 'type', 'status' (default: 'timestamp')
  * - sortOrder: Sort direction 'asc' or 'desc' (default: 'desc')
  * 
  * Response: Paginated list of transactions with total count and no duplicate results across pages
@@ -84,22 +91,21 @@ router.get('/',
       }
 
       // Validate type filter if provided
-      const validTypes = ['deposit', 'withdrawal'];
-      let typeFilter: string[] = [];
-      if (type) {
-        const typeStr = typeof type === 'string' ? type : '';
-        const types = typeStr.split(',').map((t) => t.trim());
-        for (const t of types) {
-          if (!validTypes.includes(t)) {
-            res.status(400).json({
-              error: 'Bad Request',
-              status: 400,
-              message: `Invalid type filter. Allowed values: ${validTypes.join(', ')}`,
-            });
-            return;
-          }
-        }
-        typeFilter = types;
+      const { types: typeFilter, error: typeError } = parseTypeFilter(
+        typeof type === 'string' ? type : undefined,
+      );
+      if (typeError) {
+        res.status(400).json({ error: 'Bad Request', status: 400, message: typeError });
+        return;
+      }
+
+      // Validate status filter if provided
+      const { status: statusFilter, error: statusError } = parseStatusFilter(
+        typeof status === 'string' ? status : undefined,
+      );
+      if (statusError) {
+        res.status(400).json({ error: 'Bad Request', status: 400, message: statusError });
+        return;
       }
 
       // Parse pagination parameters
@@ -108,6 +114,17 @@ router.get('/',
         defaultSortBy: 'timestamp',
         defaultSortOrder: 'desc',
       });
+
+      // Resolve and validate the requested sort field against the allowlist.
+      const sort = resolveTransactionSort(paginationQuery.sortBy, paginationQuery.sortOrder);
+      if (!sort.valid) {
+        res.status(400).json({
+          error: 'Bad Request',
+          status: 400,
+          message: `Invalid sortBy value '${sort.requested}'. Allowed values: timestamp, type, status`,
+        });
+        return;
+      }
 
       // Parse and validate date range
       let dateRange: ParsedUtcDateRange = {};
@@ -127,9 +144,11 @@ router.get('/',
 
       span.setAttributes({
         'transaction.typeFilter': typeFilter.length > 0 ? typeFilter.join(',') : 'all',
-        'transaction.statusFilter': status ? String(status) : 'all',
+        'transaction.statusFilter': statusFilter ?? 'all',
         'transaction.walletFilter': walletAddress ? normalizeWalletAddress(String(walletAddress)) : 'all',
         'transaction.hasDateRange': !!(dateRange.start || dateRange.end),
+        'transaction.sortBy': sort.field,
+        'transaction.sortOrder': sort.order,
         'pagination.limit': paginationQuery.limit,
         'pagination.hasCursor': !!paginationQuery.cursor,
       });
@@ -143,8 +162,8 @@ router.get('/',
         whereClause.type = { in: typeFilter };
       }
 
-      if (status) {
-        whereClause.status = String(status);
+      if (statusFilter) {
+        whereClause.status = statusFilter;
       }
 
       if (walletAddress) {
@@ -164,10 +183,9 @@ router.get('/',
       // Fetch total count for response metadata
       const total = await prisma.transaction.count({ where: whereClause });
 
-      // Determine sort direction
-      const sortOrder = paginationQuery.sortOrder === 'asc' ? 'asc' : 'desc';
-
-      // Fetch transactions with cursor-based pagination
+      // Fetch transactions with cursor-based pagination. The skip count is
+      // derived from the resolved sort field so pagination stays correct for
+      // any sortable column, not just timestamp.
       let skip = 0;
       if (paginationQuery.cursor) {
         try {
@@ -186,13 +204,11 @@ router.get('/',
             return;
           }
 
-          // Count items before the cursor to determine skip value
+          // Count items before the cursor (under the active sort) to skip.
           skip = await prisma.transaction.count({
             where: {
               ...whereClause,
-              ...(sortOrder === 'desc'
-                ? { timestamp: { gt: cursorTx.timestamp } }
-                : { timestamp: { lt: cursorTx.timestamp } }),
+              ...buildTransactionCursorFilter(sort, cursorTx as Record<string, unknown> & { id: string }),
             },
           });
         } catch (err) {
@@ -213,9 +229,7 @@ router.get('/',
       const limit = paginationQuery.limit || DEFAULT_PAGINATION_CONFIG.defaultLimit;
       const transactions = await prisma.transaction.findMany({
         where: whereClause,
-        orderBy: {
-          timestamp: sortOrder,
-        },
+        orderBy: buildTransactionOrderBy(sort),
         skip,
         take: limit + 1,
       });

--- a/backend/src/transactionQuery.ts
+++ b/backend/src/transactionQuery.ts
@@ -1,0 +1,170 @@
+/**
+ * @file transactionQuery.ts
+ * Pure helpers for validating and building sort/filter clauses for the
+ * transaction history API (Issue #890).
+ *
+ * These helpers are intentionally free of Express/Prisma runtime coupling so
+ * they can be unit-tested in isolation and reused by both the wallet-scoped
+ * (Prisma-backed) path and the export path.
+ */
+
+/** Transaction status values recognised by the history API. */
+export const TRANSACTION_STATUSES = ['pending', 'completed', 'failed'] as const;
+export type TransactionStatus = (typeof TRANSACTION_STATUSES)[number];
+
+/** Transaction type values recognised by the history API. */
+export const TRANSACTION_TYPES = ['deposit', 'withdrawal'] as const;
+export type TransactionType = (typeof TRANSACTION_TYPES)[number];
+
+/**
+ * Allowlist of fields that transactions may be sorted by, mapped to the
+ * underlying Prisma column. Restricting to an allowlist prevents arbitrary
+ * `orderBy` injection and keeps the API surface stable.
+ *
+ * `amount` is intentionally excluded because it is persisted as a decimal
+ * string and would sort lexically rather than numerically.
+ */
+export const SORTABLE_TRANSACTION_FIELDS = {
+  timestamp: 'timestamp',
+  type: 'type',
+  status: 'status',
+} as const;
+
+export type SortableTransactionField = keyof typeof SORTABLE_TRANSACTION_FIELDS;
+
+export const DEFAULT_SORT_FIELD: SortableTransactionField = 'timestamp';
+export const DEFAULT_SORT_ORDER: SortOrder = 'desc';
+
+export type SortOrder = 'asc' | 'desc';
+
+export interface ResolvedSort {
+  /** The validated logical field the caller asked to sort by. */
+  field: SortableTransactionField;
+  /** The validated sort direction. */
+  order: SortOrder;
+  /** True when the requested `sortBy` was a recognised sortable field. */
+  valid: boolean;
+  /** The originally requested (possibly invalid) sort field, if any. */
+  requested?: string;
+}
+
+/**
+ * Validate a requested sort field against the allowlist.
+ *
+ * @param sortBy - Raw `sortBy` query value (may be undefined/invalid).
+ * @param sortOrder - Raw `sortOrder` query value (defaults to desc).
+ * @returns Resolved sort descriptor. `valid` is false when an unknown field
+ *   was requested, in which case the caller may choose to reject the request
+ *   or fall back to the default field.
+ */
+export function resolveTransactionSort(
+  sortBy?: string,
+  sortOrder?: string,
+): ResolvedSort {
+  const order: SortOrder = sortOrder === 'asc' ? 'asc' : DEFAULT_SORT_ORDER;
+
+  if (sortBy === undefined || sortBy === '') {
+    return { field: DEFAULT_SORT_FIELD, order, valid: true };
+  }
+
+  if (isSortableField(sortBy)) {
+    return { field: sortBy, order, valid: true };
+  }
+
+  return {
+    field: DEFAULT_SORT_FIELD,
+    order,
+    valid: false,
+    requested: sortBy,
+  };
+}
+
+export function isSortableField(value: string): value is SortableTransactionField {
+  return Object.prototype.hasOwnProperty.call(SORTABLE_TRANSACTION_FIELDS, value);
+}
+
+/**
+ * Build a deterministic Prisma `orderBy` array for the resolved sort. A
+ * secondary `id` sort in the same direction guarantees a stable, total
+ * ordering so cursor pagination never skips or repeats rows when the primary
+ * sort key has ties (e.g. many transactions sharing a `status`).
+ */
+export function buildTransactionOrderBy(
+  sort: Pick<ResolvedSort, 'field' | 'order'>,
+): Array<Record<string, SortOrder>> {
+  const column = SORTABLE_TRANSACTION_FIELDS[sort.field];
+  return [{ [column]: sort.order }, { id: sort.order }];
+}
+
+/**
+ * Build the Prisma `where` fragment that selects every row strictly *before*
+ * the cursor row under the `(field, id)` ordering. Counting rows matching this
+ * fragment yields the number of items to skip, keeping cursor pagination
+ * correct for any sortable field — not just `timestamp`.
+ *
+ * @param sort - Resolved sort descriptor.
+ * @param cursorRow - The row the cursor points at (its sort field + id).
+ */
+export function buildTransactionCursorFilter(
+  sort: Pick<ResolvedSort, 'field' | 'order'>,
+  cursorRow: { id: string } & Record<string, unknown>,
+): Record<string, unknown> {
+  const column = SORTABLE_TRANSACTION_FIELDS[sort.field];
+  const beyond = sort.order === 'desc' ? 'gt' : 'lt';
+  const cursorValue = cursorRow[column];
+
+  // Rows come "before" the cursor when their primary key is beyond the cursor
+  // value, or the primary key ties and the id is beyond the cursor id.
+  return {
+    OR: [
+      { [column]: { [beyond]: cursorValue } },
+      {
+        AND: [{ [column]: cursorValue }, { id: { [beyond]: cursorRow.id } }],
+      },
+    ],
+  };
+}
+
+/**
+ * Validate a comma-separated `type` filter. Returns the parsed list plus an
+ * optional error message for the first invalid value encountered.
+ */
+export function parseTypeFilter(
+  raw: string | undefined,
+): { types: string[]; error?: string } {
+  if (!raw) {
+    return { types: [] };
+  }
+  const types = raw
+    .split(',')
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+
+  for (const type of types) {
+    if (!TRANSACTION_TYPES.includes(type as TransactionType)) {
+      return {
+        types: [],
+        error: `Invalid type filter. Allowed values: ${TRANSACTION_TYPES.join(', ')}`,
+      };
+    }
+  }
+
+  return { types };
+}
+
+/**
+ * Validate an optional `status` filter against the recognised statuses.
+ */
+export function parseStatusFilter(
+  raw: string | undefined,
+): { status?: string; error?: string } {
+  if (!raw) {
+    return {};
+  }
+  if (!TRANSACTION_STATUSES.includes(raw as TransactionStatus)) {
+    return {
+      error: `Invalid status filter. Allowed values: ${TRANSACTION_STATUSES.join(', ')}`,
+    };
+  }
+  return { status: raw };
+}

--- a/backend/src/vaultAuditLog.ts
+++ b/backend/src/vaultAuditLog.ts
@@ -1,0 +1,194 @@
+/**
+ * @file vaultAuditLog.ts
+ * Structured audit logging for vault lifecycle operations (Issue #888).
+ *
+ * Every deposit / withdrawal moves through a small state machine:
+ *
+ *   initiated → submitted → confirmed
+ *                        ↘ failed
+ *
+ * This module records a structured audit entry at each transition. Entries are:
+ *   - emitted as a single-line JSON log via the shared structured logger, so
+ *     they flow into the existing log pipeline / SIEM; and
+ *   - retained in a bounded in-memory ring buffer so operators can query recent
+ *     vault activity (e.g. from an admin endpoint) without a log backend.
+ *
+ * The module is deliberately free of Express/Prisma coupling so it can be unit
+ * tested in isolation and called from anywhere in the vault operation flow.
+ */
+
+import crypto from 'crypto';
+import { logger } from './middleware/structuredLogging';
+import { redactSensitiveAttributes } from './redaction';
+
+/** Vault operations that emit lifecycle audit entries. */
+export type VaultOperation = 'deposit' | 'withdrawal';
+
+/** Lifecycle phase of a vault operation. */
+export type VaultLifecyclePhase = 'initiated' | 'submitted' | 'confirmed' | 'failed';
+
+/** Terminal outcome classification for a phase. */
+export type VaultAuditOutcome = 'pending' | 'success' | 'failure';
+
+export interface VaultAuditEntry {
+  /** Unique id for this audit entry. */
+  id: string;
+  /** ISO-8601 timestamp the entry was recorded. */
+  timestamp: string;
+  /** Fully-qualified action, e.g. `vault.deposit.submitted`. */
+  action: string;
+  /** The vault operation. */
+  operation: VaultOperation;
+  /** Lifecycle phase. */
+  phase: VaultLifecyclePhase;
+  /** Outcome classification for the phase. */
+  outcome: VaultAuditOutcome;
+  /** Wallet address performing the operation (the actor). */
+  actor: string;
+  /** Operation amount as a string (never coerced to float). */
+  amount?: string;
+  /** Asset code for the operation. */
+  asset?: string;
+  /** On-chain transaction hash once known. */
+  txHash?: string;
+  /** Correlation id propagated from the inbound request. */
+  correlationId?: string;
+  /** Trace id from the active OTel span, when available. */
+  traceId?: string;
+  /** Machine-readable error code for failed phases. */
+  errorCode?: string;
+  /** Human-readable error message for failed phases. */
+  errorMessage?: string;
+  /** Additional, redaction-filtered context. */
+  metadata?: Record<string, unknown>;
+}
+
+export interface RecordVaultLifecycleInput {
+  operation: VaultOperation;
+  phase: VaultLifecyclePhase;
+  actor: string;
+  amount?: string | number;
+  asset?: string;
+  txHash?: string;
+  correlationId?: string;
+  traceId?: string;
+  errorCode?: string;
+  errorMessage?: string;
+  metadata?: Record<string, unknown>;
+}
+
+interface VaultAuditFilters {
+  operation?: VaultOperation;
+  phase?: VaultLifecyclePhase;
+  outcome?: VaultAuditOutcome;
+  actor?: string;
+  txHash?: string;
+  limit?: number;
+}
+
+const entries: VaultAuditEntry[] = [];
+const RETENTION_LIMIT = Math.max(
+  1,
+  parseInt(process.env.VAULT_AUDIT_LOG_RETENTION || '1000', 10) || 1000,
+);
+
+/** Map a lifecycle phase to its outcome classification. */
+function phaseOutcome(phase: VaultLifecyclePhase): VaultAuditOutcome {
+  if (phase === 'confirmed') return 'success';
+  if (phase === 'failed') return 'failure';
+  return 'pending';
+}
+
+/**
+ * Record a structured audit entry for one vault lifecycle transition.
+ *
+ * The entry is both persisted to the in-memory ring buffer and emitted as a
+ * structured log line. `failed` phases log at `warn`, everything else at
+ * `info`. Returns the persisted entry so callers can assert / correlate.
+ */
+export function recordVaultLifecycleEvent(
+  input: RecordVaultLifecycleInput,
+): VaultAuditEntry {
+  const outcome = phaseOutcome(input.phase);
+  const entry: VaultAuditEntry = {
+    id: `vaudit_${crypto.randomBytes(8).toString('hex')}`,
+    timestamp: new Date().toISOString(),
+    action: `vault.${input.operation}.${input.phase}`,
+    operation: input.operation,
+    phase: input.phase,
+    outcome,
+    actor: input.actor,
+    amount: input.amount === undefined ? undefined : String(input.amount),
+    asset: input.asset,
+    txHash: input.txHash,
+    correlationId: input.correlationId,
+    traceId: input.traceId,
+    errorCode: input.errorCode,
+    errorMessage: input.errorMessage,
+    metadata: input.metadata ? redactSensitiveAttributes(input.metadata) : undefined,
+  };
+
+  entries.unshift(entry);
+  if (entries.length > RETENTION_LIMIT) {
+    entries.length = RETENTION_LIMIT;
+  }
+
+  logger.log(input.phase === 'failed' ? 'warn' : 'info', entry.action, {
+    audit: 'vault-lifecycle',
+    auditId: entry.id,
+    operation: entry.operation,
+    phase: entry.phase,
+    outcome: entry.outcome,
+    actor: entry.actor,
+    amount: entry.amount,
+    asset: entry.asset,
+    txHash: entry.txHash,
+    correlationId: entry.correlationId,
+    traceId: entry.traceId,
+    errorCode: entry.errorCode,
+  });
+
+  return entry;
+}
+
+/**
+ * Query the retained vault audit entries (most-recent first) with optional
+ * filtering. `limit` is clamped to `[1, RETENTION_LIMIT]`.
+ */
+export function getVaultAuditLogs(filters: VaultAuditFilters = {}): VaultAuditEntry[] {
+  const filtered = entries.filter((entry) => {
+    if (filters.operation && entry.operation !== filters.operation) return false;
+    if (filters.phase && entry.phase !== filters.phase) return false;
+    if (filters.outcome && entry.outcome !== filters.outcome) return false;
+    if (filters.actor && !entry.actor.includes(filters.actor)) return false;
+    if (filters.txHash && entry.txHash !== filters.txHash) return false;
+    return true;
+  });
+
+  const limit = Math.max(1, Math.min(filters.limit ?? 100, RETENTION_LIMIT));
+  return filtered.slice(0, limit);
+}
+
+/** Aggregate counters useful for dashboards / health surfaces. */
+export function getVaultAuditMetrics() {
+  const byPhase: Record<VaultLifecyclePhase, number> = {
+    initiated: 0,
+    submitted: 0,
+    confirmed: 0,
+    failed: 0,
+  };
+  for (const entry of entries) {
+    byPhase[entry.phase] += 1;
+  }
+  return {
+    totalEntries: entries.length,
+    retentionLimit: RETENTION_LIMIT,
+    latestTimestamp: entries[0]?.timestamp ?? null,
+    byPhase,
+  };
+}
+
+/** Reset the in-memory buffer (test helper). */
+export function resetVaultAuditLogs(): void {
+  entries.length = 0;
+}

--- a/backend/src/vaultEndpoints.ts
+++ b/backend/src/vaultEndpoints.ts
@@ -24,6 +24,7 @@ import crypto from 'crypto';
 // crypto is still used below for generateFingerprint and body.id generation.
 import { tryAcquireWalletLock } from './walletLock';
 import { normalizeWalletAddress } from './walletUtils';
+import { recordVaultLifecycleEvent } from './vaultAuditLog';
 import Decimal from 'decimal.js';
 
 const router = Router();
@@ -142,6 +143,7 @@ async function handleVaultOperation(
 
   const { amount, asset, walletAddress, email, referralCode } = req.body;
   const normalizedWallet = normalizeWalletAddress(walletAddress);
+  const correlationId = req.header('x-correlation-id') || undefined;
   const walletLock = tryAcquireWalletLock(normalizedWallet);
 
   if (!walletLock.acquired) {
@@ -153,6 +155,18 @@ async function handleVaultOperation(
       walletAddress: normalizedWallet,
     });
   }
+
+  // Audit: the vault operation has been accepted and is about to be attempted.
+  recordVaultLifecycleEvent({
+    operation: type,
+    phase: 'initiated',
+    actor: normalizedWallet,
+    amount: String(amount),
+    asset: String(asset),
+    correlationId,
+    traceId: getCurrentTraceId(),
+    metadata: { idempotent: !!idempotencyKey },
+  });
 
   const operation = async () => {
     return withSpan(`vault.${type}`, async (span) => {
@@ -173,6 +187,18 @@ async function handleVaultOperation(
         throw err;
       }
 
+      // Audit: the transaction was accepted by the Soroban RPC.
+      recordVaultLifecycleEvent({
+        operation: type,
+        phase: 'submitted',
+        actor: normalizedWallet,
+        amount: String(amount),
+        asset: String(asset),
+        txHash,
+        correlationId,
+        traceId: getCurrentTraceId(),
+      });
+
       // Persist transaction to DB
       const prisma = getPrismaClient();
       await prisma.transaction.create({
@@ -186,6 +212,18 @@ async function handleVaultOperation(
       });
 
       await updateVaultStateAndSnapshot(type, String(amount), new Date());
+
+      // Audit: transaction durably recorded and vault state updated.
+      recordVaultLifecycleEvent({
+        operation: type,
+        phase: 'confirmed',
+        actor: normalizedWallet,
+        amount: String(amount),
+        asset: String(asset),
+        txHash,
+        correlationId,
+        traceId: getCurrentTraceId(),
+      });
 
       // Handle referral recording on deposit
       if (type === 'deposit') {
@@ -297,6 +335,29 @@ async function handleVaultOperation(
     });
     return res.status(result.statusCode).json(result.body);
   } catch (err) {
+    // Audit: the operation failed. Idempotency conflicts are replays of an
+    // in-flight/complete request rather than a lifecycle failure, so they are
+    // classified with a distinct error code but still recorded.
+    const errorCode =
+      err instanceof CircuitOpenError
+        ? 'SOROBAN_CIRCUIT_OPEN'
+        : err instanceof SorobanSimulationError
+          ? err.code || 'SOROBAN_SIMULATION_ERROR'
+          : err instanceof IdempotencyConflictError
+            ? 'IDEMPOTENCY_CONFLICT'
+            : 'VAULT_OPERATION_ERROR';
+    recordVaultLifecycleEvent({
+      operation: type,
+      phase: 'failed',
+      actor: normalizedWallet,
+      amount: String(amount),
+      asset: String(asset),
+      correlationId,
+      traceId: getCurrentTraceId(),
+      errorCode,
+      errorMessage: err instanceof Error ? err.message : String(err),
+    });
+
     if (err instanceof IdempotencyConflictError) {
       return res.status(409).json({
         error: 'Conflict',

--- a/docs/RPC_PROVIDER_FAILOVER_STRATEGY.md
+++ b/docs/RPC_PROVIDER_FAILOVER_STRATEGY.md
@@ -1,0 +1,194 @@
+# RPC Provider Failover Strategy & Configuration Guide
+
+**Status:** Active
+**Audience:** Backend / SRE / on-call engineers
+**Scope:** Stellar Horizon + Soroban RPC providers used by the YieldVault backend
+**Related:** [`runbooks/RPC_FAILOVER.md`](./runbooks/RPC_FAILOVER.md) (hands-on switch procedure),
+[`MONITORING_OBSERVABILITY.md`](./MONITORING_OBSERVABILITY.md),
+[`SERVICE_DEPENDENCY_MATRIX.md`](./SERVICE_DEPENDENCY_MATRIX.md)
+
+> This guide documents the **strategy and configuration** for RPC provider
+> failover: how providers are ordered, how timeouts / retries / circuit
+> breaking are tuned, and how an operator switches providers. It complements the
+> step-by-step incident runbook in `runbooks/RPC_FAILOVER.md`, which remains the
+> authoritative "do this now" checklist during an outage.
+
+---
+
+## 1. Why failover matters
+
+Every deposit and withdrawal is submitted to the Stellar network through a
+Soroban RPC endpoint (`submitVaultOperation` in `backend/src/sorobanClient.ts`).
+If that endpoint is slow, rate-limited, or down, vault operations stall. To keep
+the write path resilient the backend layers three independent protections —
+**retries**, a **retry budget**, and a **circuit breaker** — in front of a
+configurable provider endpoint that operators can re-point during an incident.
+
+---
+
+## 2. Provider ordering (priority tiers)
+
+Providers are used in a strict priority order. The active provider is whichever
+`STELLAR_RPC_URL` / `STELLAR_HORIZON_URL` currently points at; failover is the
+act of promoting the next tier.
+
+| Tier | Role | Example | When to use |
+|------|------|---------|-------------|
+| 0 | **Primary** | Managed/paid provider (highest quota, lowest latency) | Default, steady state |
+| 1 | **Secondary** | Independent managed provider on a different network/backbone | Primary degraded, rate-limited, or down |
+| 2 | **Tertiary** | Self-hosted node or public community endpoint | Both managed providers unavailable |
+| 3 | **Read-only degrade** | Horizon read endpoint only | Writes paused; serve balances/history while recovery is in progress |
+
+**Ordering principles**
+
+1. **Diversity over duplication.** Tier 0 and Tier 1 must not share the same
+   upstream operator or hosting region, or a single outage takes out both.
+2. **Promote, never skip.** Always fail over to the next tier in order so
+   latency/quota characteristics degrade predictably.
+3. **Prefer correctness to availability for writes.** If no provider can be
+   trusted (e.g. suspected fork / stale ledger), pause writes (Tier 3) rather
+   than submit against an unhealthy node. See the circuit breaker below.
+4. **Fail back deliberately.** Return to Tier 0 only after it has been healthy
+   for a sustained window (see §6), not on the first successful probe.
+
+Record the concrete provider URLs for each tier in the secrets manager, **not**
+in this document. Keep at least Tier 0 and Tier 1 provisioned at all times.
+
+---
+
+## 3. Timeout, retry & circuit-breaking strategy
+
+The backend defends the RPC call path with three tunable layers. All are
+environment-driven so they can be adjusted per environment without a code
+change.
+
+### 3.1 Per-request timeout & bounded retries (`sorobanClient.ts`)
+
+| Setting | Env var | Default | Notes |
+|---------|---------|---------|-------|
+| Max retries per operation | `SOROBAN_MAX_RETRIES` | `3` | Applied around simulate/submit. |
+| Base retry delay | `SOROBAN_RETRY_DELAY_MS` | `1000` ms | **Exponential backoff**: `delay = base × 2^attempt`. |
+| Transaction submit timeout | (in-code) | `300` s | Stellar `TransactionBuilder.setTimeout`. |
+
+Validation errors (bad input, simulation failures) are **not** retried — only
+transient/transport failures are. This prevents burning the retry budget on
+requests that will never succeed.
+
+### 3.2 Retry budget (`retryBudget.ts`)
+
+A global retry budget stops retries from amplifying an outage into a
+thundering-herd. Retries are only permitted while the recent success rate stays
+healthy.
+
+| Setting | Env var | Purpose |
+|---------|---------|---------|
+| Max retries in window | `RETRY_BUDGET_MAX_RETRIES` | Hard cap on retries per rolling window. |
+| Failure threshold | `RETRY_BUDGET_FAILURE_THRESHOLD` | Failures before the budget tightens. |
+| Minimum success rate | `RETRY_BUDGET_MIN_SUCCESS_RATE` | Below this, retries are suppressed. |
+| Rolling window | `RETRY_BUDGET_WINDOW_MS` | Measurement window length. |
+
+### 3.3 Circuit breaker (`circuitBreaker.ts`)
+
+When failures cross the threshold the breaker **opens** and the API returns
+`503 Service Unavailable` with a `Retry-After` header instead of piling more
+load onto a failing provider. This is the signal to fail over.
+
+| Setting | Env var | Purpose |
+|---------|---------|---------|
+| Failure threshold | `CIRCUIT_BREAKER_FAILURE_THRESHOLD` | Failures that trip the breaker open. |
+| Measurement window | `CIRCUIT_BREAKER_WINDOW_MS` | Window the threshold is measured over. |
+| Cooldown | `CIRCUIT_BREAKER_COOLDOWN_MS` | How long to stay open before a half-open probe. |
+
+**Interaction:** per-request retries handle blips; the retry budget prevents
+retry storms; the circuit breaker sheds load and surfaces a clean `503` once a
+provider is genuinely unhealthy. A sustained open breaker is the trigger for the
+provider switch in §4.
+
+### 3.4 Recommended starting values
+
+| Environment | `SOROBAN_MAX_RETRIES` | `SOROBAN_RETRY_DELAY_MS` | `CIRCUIT_BREAKER_FAILURE_THRESHOLD` | `CIRCUIT_BREAKER_COOLDOWN_MS` |
+|-------------|-----------------------|--------------------------|-------------------------------------|-------------------------------|
+| Production | 3 | 1000 | 5 | 30000 |
+| Staging | 3 | 500 | 5 | 15000 |
+| Local/dev | 1 | 250 | 10 | 5000 |
+
+Tune from these baselines using the RPC latency/error dashboards; do not raise
+`SOROBAN_MAX_RETRIES` to mask a provider that should be failed over instead.
+
+---
+
+## 4. Operational switch procedure (summary)
+
+The authoritative, copy-paste checklist lives in
+[`runbooks/RPC_FAILOVER.md`](./runbooks/RPC_FAILOVER.md). At a glance:
+
+1. **Confirm the primary is the problem** — check the RPC error-rate/latency
+   dashboard and the circuit-breaker state; probe the backup with `curl` before
+   switching (`getHealth` / `getLatestLedger`).
+2. **Back up current config** — snapshot `.env` and log the previous
+   `STELLAR_RPC_URL` for auditability.
+3. **Promote the next tier** — set `STELLAR_RPC_URL` (and `STELLAR_HORIZON_URL`
+   if applicable) to the next provider in the ordering table.
+4. **Reload, don't rebuild** — restart / signal the process so the new endpoint
+   is picked up; the circuit breaker resets on a healthy provider.
+5. **Verify** — submit a canary read and a low-value write; confirm the breaker
+   stays closed and error rate returns to baseline.
+6. **Announce** — post status in the incident channel and update the status page
+   per §7.
+
+> **Provider ordering config:** keep the ordered list of provider URLs in the
+> secrets manager as e.g. `RPC_PROVIDER_TIER_0`, `RPC_PROVIDER_TIER_1`,
+> `RPC_PROVIDER_TIER_2`. The switch is then "copy Tier N into `STELLAR_RPC_URL`",
+> which removes guesswork during an incident.
+
+---
+
+## 5. Detection & alerting
+
+Fail over on **signals**, not vibes. Wire these to on-call:
+
+- RPC **error rate** above baseline for N minutes.
+- RPC **p95 latency** above the SLA in `SERVICE_DEPENDENCY_MATRIX.md`.
+- **Circuit breaker open** (503s with `Retry-After` on `/vault/*`).
+- **Retry budget exhausted** warnings in structured logs.
+- **Vault lifecycle audit** failures spiking — the `vault.*.failed` entries from
+  the vault audit log (Issue #888) are a direct, product-level signal that
+  submissions are not completing.
+
+---
+
+## 6. Fail-back criteria
+
+Return to a higher-priority provider only when **all** hold:
+
+- Provider healthy on direct probes for a sustained window (≥ 15 min suggested).
+- Circuit breaker closed and error rate at baseline on the current provider.
+- No active incident depending on the current provider's state.
+
+Fail back during low-traffic windows where possible, and watch the breaker for
+one full `CIRCUIT_BREAKER_WINDOW_MS` after switching.
+
+---
+
+## 7. Communication
+
+- **Internal:** announce switch start/finish in the incident channel with the
+  from/to tier and the reason.
+- **External:** if writes were paused or user-visible errors occurred, update
+  the status page and follow the incident comms flow in
+  [`incident_response_runbook.md`](./incident_response_runbook.md).
+- **Post-incident:** capture provider, duration, and trigger in the postmortem
+  ([`postmortem-playbook.md`](./postmortem-playbook.md)) and feed tuning changes
+  back into §3.4.
+
+---
+
+## 8. Configuration checklist
+
+- [ ] Tier 0 and Tier 1 providers provisioned with independent operators.
+- [ ] Provider URLs stored in secrets manager as ordered tiers (not in git).
+- [ ] `SOROBAN_MAX_RETRIES` / `SOROBAN_RETRY_DELAY_MS` set per environment.
+- [ ] Retry-budget and circuit-breaker envs set per §3.4.
+- [ ] Dashboards + alerts wired per §5.
+- [ ] `runbooks/RPC_FAILOVER.md` reviewed and tested against the current
+      provider list.

--- a/docs/VAULT_LIFECYCLE_AUDIT_LOG.md
+++ b/docs/VAULT_LIFECYCLE_AUDIT_LOG.md
@@ -1,0 +1,108 @@
+# Vault Lifecycle Audit Log
+
+**Status:** Active
+**Module:** `backend/src/vaultAuditLog.ts`
+**Wired into:** `backend/src/vaultEndpoints.ts` (`POST /api/v1/vault/deposits`, `POST /api/v1/vault/withdrawals`)
+**Related:** [`MONITORING_OBSERVABILITY.md`](./MONITORING_OBSERVABILITY.md) ·
+[`runbooks/FAILED_WITHDRAWAL_INCIDENT_PLAYBOOK.md`](./runbooks/FAILED_WITHDRAWAL_INCIDENT_PLAYBOOK.md)
+
+Structured, queryable audit trail for vault deposit/withdrawal lifecycle
+operations (Issue #888). Every operation is recorded at each state transition so
+operators can answer *"what happened to this withdrawal, and when?"* without
+reconstructing it from ad-hoc logs.
+
+---
+
+## Lifecycle state machine
+
+```
+initiated ── submitted ── confirmed
+                     └──── failed
+```
+
+| Phase | Emitted when | Outcome |
+|-------|--------------|---------|
+| `initiated` | Request accepted, wallet lock acquired, about to attempt | `pending` |
+| `submitted` | Soroban RPC accepted the transaction (tx hash known) | `pending` |
+| `confirmed` | Transaction durably persisted **and** vault state updated | `success` |
+| `failed` | Operation errored at any point | `failure` |
+
+A healthy operation emits `initiated → submitted → confirmed`. Any orphaned
+`submitted` without a matching `confirmed` indicates a persistence/reconciliation
+gap (see the withdrawal incident playbook).
+
+---
+
+## Entry schema
+
+Each entry (`VaultAuditEntry`) contains:
+
+| Field | Description |
+|-------|-------------|
+| `id` | Unique audit id (`vaudit_…`). |
+| `timestamp` | ISO-8601 time recorded. |
+| `action` | `vault.<operation>.<phase>`, e.g. `vault.withdrawal.failed`. |
+| `operation` | `deposit` \| `withdrawal`. |
+| `phase` | `initiated` \| `submitted` \| `confirmed` \| `failed`. |
+| `outcome` | `pending` \| `success` \| `failure`. |
+| `actor` | Normalized wallet address performing the operation. |
+| `amount` / `asset` | Operation amount (string) and asset code. |
+| `txHash` | On-chain transaction hash once known. |
+| `correlationId` / `traceId` | Request correlation + OTel trace ids. |
+| `errorCode` / `errorMessage` | Populated on `failed` phases. |
+| `metadata` | Extra context, passed through sensitive-attribute redaction. |
+
+`errorCode` values on failure: `SOROBAN_CIRCUIT_OPEN`,
+`SOROBAN_SIMULATION_ERROR`, `IDEMPOTENCY_CONFLICT`, `VAULT_OPERATION_ERROR`.
+
+---
+
+## Where entries go
+
+1. **Structured log line** — emitted via the shared structured logger
+   (`info`, or `warn` for `failed`) with `audit: "vault-lifecycle"`, so entries
+   flow into the existing log pipeline / SIEM.
+2. **In-memory ring buffer** — bounded by `VAULT_AUDIT_LOG_RETENTION`
+   (default `1000`), most-recent-first, for querying without a log backend.
+
+Metadata is filtered through `redactSensitiveAttributes` before storage or
+logging, so secrets in `metadata` are never persisted in the clear.
+
+---
+
+## Configuration
+
+| Env var | Default | Purpose |
+|---------|---------|---------|
+| `VAULT_AUDIT_LOG_RETENTION` | `1000` | Max entries retained in memory. |
+
+---
+
+## Querying (programmatic)
+
+```ts
+import { getVaultAuditLogs, getVaultAuditMetrics } from './vaultAuditLog';
+
+// Recent failed withdrawals
+getVaultAuditLogs({ operation: 'withdrawal', outcome: 'failure', limit: 50 });
+
+// Trace a specific on-chain tx
+getVaultAuditLogs({ txHash: 'abc123' });
+
+// Dashboard counters (totals + per-phase breakdown)
+getVaultAuditMetrics();
+```
+
+`getVaultAuditLogs` supports filtering by `operation`, `phase`, `outcome`,
+`actor` (substring), and `txHash`; `limit` is clamped to
+`[1, VAULT_AUDIT_LOG_RETENTION]`.
+
+---
+
+## Operational use
+
+The `vault.*.failed` entries are a direct, product-level signal used by the
+[Failed Withdrawal Incident Playbook](./runbooks/FAILED_WITHDRAWAL_INCIDENT_PLAYBOOK.md)
+and the [RPC Provider Failover Strategy](./RPC_PROVIDER_FAILOVER_STRATEGY.md)
+detection sections. Filter by `outcome = failure` and read the dominant
+`errorCode` to route to the correct mitigation.

--- a/docs/api/PAGINATION.md
+++ b/docs/api/PAGINATION.md
@@ -193,8 +193,18 @@ Cursor paging is **stable for a fixed dataset**, but new rows can appear while y
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `type` | string | 'all' | Filter by transaction type: 'deposit', 'withdrawal', or 'all' |
-| `walletAddress` | string | - | Filter by wallet address |
+| `type` | string | 'all' | Filter by transaction type: `deposit`, `withdrawal`, or a comma-separated combination. Unknown values return `400`. |
+| `status` | string | - | Filter by status: `pending`, `completed`, or `failed`. Unknown values return `400`. |
+| `from` / `to` | string | - | Inclusive date range (ISO 8601 or `YYYY-MM-DD`). |
+| `walletAddress` | string | - | Filter by wallet address (results are tenant-scoped to this wallet). |
+| `sortBy` | string | `timestamp` | Sort field. **Allowed:** `timestamp`, `type`, `status`. Unknown values return `400`. |
+| `sortOrder` | string | `desc` | `asc` or `desc`. |
+
+> **Note:** `amount` is **not** a sortable field for transactions because it is
+> persisted as a decimal string and would sort lexically rather than
+> numerically. Sortable fields are restricted to an allowlist to prevent
+> arbitrary `orderBy` injection. A secondary `id` tie-breaker (same direction)
+> guarantees stable cursor paging even when the primary sort key has ties.
 
 #### Portfolio Holdings (`GET /api/portfolio/holdings`)
 
@@ -297,14 +307,21 @@ GET /api/transactions?limit=20&page=2
 
 ## Sorting
 
-All list endpoints support sorting by multiple fields.
+List endpoints support sorting via `sortBy` / `sortOrder`. For the transactions
+endpoint the `sortBy` field is validated against an **allowlist**
+(`timestamp`, `type`, `status`); requesting any other field returns
+`400 Bad Request` rather than silently ignoring it. Ordering is always made
+total by appending a secondary `id` sort in the same direction.
 
 **Example:**
 ```bash
-# Sort by timestamp descending (newest first)
+# Sort by timestamp descending (newest first) — default
 GET /api/transactions?sortBy=timestamp&sortOrder=desc
 
-# Sort by amount ascending (smallest first)
+# Group by status, ascending
+GET /api/transactions?sortBy=status&sortOrder=asc
+
+# Rejected: amount is not an allowlisted sort field → 400 Bad Request
 GET /api/transactions?sortBy=amount&sortOrder=asc
 ```
 
@@ -328,7 +345,10 @@ Invalid pagination parameters are handled gracefully:
 - Invalid `limit` values are clamped to valid range (1-100)
 - Invalid `page` values default to page 1
 - Invalid `sortOrder` values default to 'desc'
-- Invalid `cursor` values return empty results
+- Invalid `cursor` values return empty results on public list routes, or `400`
+  on the wallet-scoped transactions route
+- On the transactions route, an unknown `sortBy`, `type`, or `status` value
+  returns `400 Bad Request` with a message listing the allowed values
 
 ## Best Practices
 
@@ -351,9 +371,9 @@ curl "http://localhost:3000/api/transactions?limit=20"
 curl "http://localhost:3000/api/transactions?limit=20&cursor=base64encodedcursor"
 ```
 
-### Get deposits only, sorted by amount
+### Get completed deposits only, sorted by status
 ```bash
-curl "http://localhost:3000/api/transactions?type=deposit&sortBy=amount&sortOrder=desc"
+curl "http://localhost:3000/api/transactions?type=deposit&status=completed&sortBy=status&sortOrder=desc"
 ```
 
 ### Get active portfolio holdings for a wallet
@@ -371,6 +391,14 @@ curl "http://localhost:3000/api/vault/history?from=2026-01-01&to=2026-03-31&limi
 All list endpoints are subject to API rate limiting. See [RATE_LIMITING.md](./RATE_LIMITING.md) for details.
 
 ## Changelog
+
+### Version 1.2.0 (2026-07-25)
+- Transactions endpoint: `sortBy` is now validated against an allowlist
+  (`timestamp`, `type`, `status`) and honored server-side; previously `sortBy`
+  was accepted but ignored (always sorted by `timestamp`). (Issue #890)
+- Transactions endpoint: `status` filter is now validated (`pending`,
+  `completed`, `failed`); unknown `sortBy`/`type`/`status` values return `400`.
+- Documented the deterministic secondary `id` tie-breaker for cursor stability.
 
 ### Version 1.1.0 (2026-06-26)
 - Add deterministic paging behavior walkthrough with concrete request/response examples

--- a/docs/runbooks/FAILED_WITHDRAWAL_INCIDENT_PLAYBOOK.md
+++ b/docs/runbooks/FAILED_WITHDRAWAL_INCIDENT_PLAYBOOK.md
@@ -1,0 +1,201 @@
+# Incident Response Playbook: Failed Vault Withdrawals
+
+**Purpose:** Detect, escalate, mitigate, and communicate incidents where user
+vault **withdrawals** fail to complete
+**Severity default:** SEV-2 (funds not lost, but user cannot access funds) —
+escalate to **SEV-1** if funds appear debited without being received
+**RTO Target:** 30 minutes to mitigation (writes restored or safely paused)
+**Owner:** Backend on-call
+**Last Updated:** July 25, 2026
+**Related:**
+[`ERROR_CODE_TROUBLESHOOTING.md`](./ERROR_CODE_TROUBLESHOOTING.md) ·
+[`RPC_FAILOVER.md`](./RPC_FAILOVER.md) ·
+[`../RPC_PROVIDER_FAILOVER_STRATEGY.md`](../RPC_PROVIDER_FAILOVER_STRATEGY.md) ·
+[`BACKEND_REDEPLOY.md`](./BACKEND_REDEPLOY.md) ·
+[`../incident_response_runbook.md`](../incident_response_runbook.md) ·
+[`../postmortem-playbook.md`](../postmortem-playbook.md)
+
+> A "failed withdrawal" is any request to `POST /api/v1/vault/withdrawals` that
+> does not reach a durable `confirmed` state — whether it errors, times out, or
+> leaves the user unsure whether their funds moved. Because withdrawals move
+> user funds, **communicate early and never guess about fund state — verify
+> on-chain.**
+
+---
+
+## 1. When to use this playbook
+
+Use this playbook when any of the following are observed:
+
+- Spike in `vault.withdrawal.failed` entries in the **vault lifecycle audit log**
+  (Issue #888) or in `5xx`/`503` responses from `/vault/withdrawals`.
+- Users report withdrawals stuck in `pending` or erroring out.
+- Circuit breaker open on the Soroban write path (`503` + `Retry-After`).
+- Withdrawals succeed on-chain but balances/history do not update (persistence
+  or reconciliation gap).
+- A withdrawal appears **debited on-chain but not received** by the user →
+  **treat as SEV-1 immediately** and page the incident commander.
+
+---
+
+## 2. Roles
+
+| Role | Responsibility |
+|------|----------------|
+| **Incident Commander (IC)** | Owns the incident, declares severity, coordinates. |
+| **Backend on-call** | Diagnosis and mitigation (this playbook). |
+| **Comms lead** | Status page + user/support messaging (§7). |
+| **Contract/chain SME** | On-chain verification, called in for suspected fund-state issues. |
+
+For SEV-2 the backend on-call may hold IC + engineer roles; SEV-1 requires a
+dedicated IC.
+
+---
+
+## 3. Detection
+
+Confirm the incident and gather scope before acting.
+
+1. **Vault audit log (fastest product-level signal).** Query the vault
+   lifecycle audit trail (Issue #888) for recent failures:
+   - Filter `operation = withdrawal`, `outcome = failure`.
+   - Note the dominant `errorCode` — it points directly at the failure class
+     (see §4). Codes: `SOROBAN_CIRCUIT_OPEN`, `SOROBAN_SIMULATION_ERROR`,
+     `IDEMPOTENCY_CONFLICT`, `VAULT_OPERATION_ERROR`.
+   - Capture `correlationId` / `traceId` for a representative failure to trace.
+2. **Metrics/dashboards.** Check `/vault/withdrawals` error rate & latency, the
+   circuit-breaker state, and RPC error/latency panels.
+3. **Logs.** Search structured logs by the captured `correlationId`/`traceId`
+   for the full request path.
+4. **Scope.** Determine: all withdrawals or a subset? One wallet or many? Since
+   when? Correlate the start time with deploys, migrations, or RPC changes.
+
+Record findings in the incident channel as you go.
+
+---
+
+## 4. Triage by failure class → mitigation
+
+Match the dominant `errorCode` / symptom to the row below.
+
+### 4.1 `SOROBAN_CIRCUIT_OPEN` — RPC unhealthy, breaker open
+
+- **Meaning:** The Soroban write path is shedding load; the RPC provider is
+  failing or slow.
+- **Mitigate:** Fail over the RPC provider — follow
+  [`RPC_FAILOVER.md`](./RPC_FAILOVER.md) and the ordering/timeout strategy in
+  [`../RPC_PROVIDER_FAILOVER_STRATEGY.md`](../RPC_PROVIDER_FAILOVER_STRATEGY.md).
+  Once a healthy provider is active the breaker resets and withdrawals resume.
+
+### 4.2 `SOROBAN_SIMULATION_ERROR` — transaction rejected
+
+- **Meaning:** The transaction failed simulation/validation (e.g. timelock not
+  elapsed, insufficient shares, contract state needs restore).
+- **Mitigate:** Use
+  [`ERROR_CODE_TROUBLESHOOTING.md`](./ERROR_CODE_TROUBLESHOOTING.md) withdrawal
+  patterns (timelock, insufficient shares, ledger restore). This is usually
+  **per-request**, not a systemic outage — do **not** fail over RPC. Guide the
+  user/support with the specific remediation.
+
+### 4.3 `IDEMPOTENCY_CONFLICT` — duplicate submission
+
+- **Meaning:** The same `Idempotency-Key` was reused with a different payload,
+  or a retry raced an in-flight request.
+- **Mitigate:** Confirm whether the original operation succeeded (audit log /
+  on-chain). If it did, the user's withdrawal is fine — reassure. If not, have
+  the client retry with a **fresh** idempotency key.
+
+### 4.4 `VAULT_OPERATION_ERROR` / `5xx` — backend fault
+
+- **Meaning:** Unhandled backend error (DB unavailable, bug, dependency down).
+- **Mitigate:** Check DB health ([`DATABASE_RESTORE.md`](./DATABASE_RESTORE.md))
+  and recent deploys. If a recent deploy correlates, **roll back** (§6).
+
+### 4.5 Succeeded on-chain but state not updated — persistence/reconciliation gap
+
+- **Meaning:** The tx confirmed on-chain but the DB transaction/vault state did
+  not update (crash between submit and persist).
+- **Mitigate:** Do **not** let the user re-submit. Run the position
+  reconciliation job to re-sync state from chain, and use
+  [`REPLAY_PROCEDURES.md`](./REPLAY_PROCEDURES.md) to replay the missed event.
+  Verify the audit log shows `submitted` without a matching `confirmed`.
+
+---
+
+## 5. Escalation
+
+| Condition | Action |
+|-----------|--------|
+| Failures isolated to one class and mitigable in-band | Backend on-call handles; keep IC informed. |
+| Broad outage (all withdrawals failing) > 15 min | Page IC; declare **SEV-2**. |
+| Funds debited on-chain but not received, or any suspected loss | Declare **SEV-1**; page IC + contract SME immediately; **pause withdrawals** (§6). |
+| Suspected contract/security issue | Page security on-call; follow [`../incident_response_runbook.md`](../incident_response_runbook.md). |
+
+Escalate on **time** as well as symptom: if not mitigated within the 30-minute
+RTO, raise severity and pull in more responders.
+
+---
+
+## 6. Mitigation actions (rollback / hotfix / pause)
+
+Prefer the **least invasive** action that stops user harm.
+
+1. **RPC failover** (§4.1) — for provider-driven failures; no deploy needed.
+2. **Pause withdrawals** — if fund safety is uncertain, stop new withdrawals
+   while investigating. Use the maintenance-mode / feature-flag controls to gate
+   the withdrawal route so users get a clear "temporarily paused" response
+   instead of ambiguous errors. **Always prefer pausing to risking double-spend
+   or loss.**
+3. **Roll back** — if a recent deploy correlates with the onset, redeploy the
+   last known-good build per [`BACKEND_REDEPLOY.md`](./BACKEND_REDEPLOY.md).
+4. **Hotfix** — for a clearly identified bug with a small, tested fix: ship
+   behind a flag where possible, verify on staging, then deploy.
+5. **Reconcile** — after service is restored, run reconciliation/replay (§4.5)
+   so any in-flight withdrawals reach a correct terminal state.
+
+**Verification after any mitigation:** submit a low-value canary withdrawal;
+confirm a clean `vault.withdrawal.confirmed` audit entry, updated balance, and
+breaker closed. Re-enable withdrawals only after the canary passes.
+
+---
+
+## 7. Communication
+
+- **T+0 (acknowledge):** Post in the incident channel — what's failing, scope,
+  severity, IC. If user-facing, publish a status-page notice ("Some withdrawals
+  may be delayed — funds are safe; investigating").
+- **During:** Update at a fixed cadence (every 15–30 min) even if "no change."
+  Give support a canned, accurate holding message. **Never tell a user funds are
+  safe until verified on-chain.**
+- **Mitigated:** Announce restoration; note whether affected withdrawals need to
+  be retried by users or were reconciled automatically.
+- **Resolved:** Close the incident; open a postmortem
+  ([`../postmortem-playbook.md`](../postmortem-playbook.md)) using the
+  [`templates/post-mortem.md`](./templates/post-mortem.md) and
+  [`templates/incident-report.md`](./templates/incident-report.md) templates.
+
+---
+
+## 8. Post-incident
+
+- [ ] Publish postmortem with timeline, root cause, and action items.
+- [ ] File follow-ups (alerting gaps, missing guardrails, flaky dependency).
+- [ ] Confirm every affected withdrawal reached a correct terminal state
+      (reconciled or retried) — reconcile the audit log `submitted` vs
+      `confirmed` counts to zero out orphans.
+- [ ] Feed any timeout/threshold learnings back into
+      [`../RPC_PROVIDER_FAILOVER_STRATEGY.md`](../RPC_PROVIDER_FAILOVER_STRATEGY.md) §3.4.
+- [ ] Update this playbook if a new failure class was discovered.
+
+---
+
+## 9. Quick reference
+
+| Symptom / `errorCode` | First action | Runbook |
+|-----------------------|--------------|---------|
+| `SOROBAN_CIRCUIT_OPEN`, 503s | Fail over RPC provider | [RPC_FAILOVER](./RPC_FAILOVER.md) |
+| `SOROBAN_SIMULATION_ERROR` | Per-request troubleshooting (timelock/shares) | [ERROR_CODE_TROUBLESHOOTING](./ERROR_CODE_TROUBLESHOOTING.md) |
+| `IDEMPOTENCY_CONFLICT` | Verify original succeeded; retry w/ new key | this doc §4.3 |
+| `VAULT_OPERATION_ERROR` / 5xx | Check DB + recent deploys; roll back | [BACKEND_REDEPLOY](./BACKEND_REDEPLOY.md) |
+| On-chain OK, state stale | Reconcile + replay; do not re-submit | [REPLAY_PROCEDURES](./REPLAY_PROCEDURES.md) |
+| Funds debited, not received | **SEV-1**, pause withdrawals, page SME | [incident_response_runbook](../incident_response_runbook.md) |

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -13,6 +13,8 @@ This directory contains operational runbooks for disaster recovery and incident 
 | [Backend Redeploy](./BACKEND_REDEPLOY.md) | 30 min | N/A | Backend service issues |
 | [Contract Upgrade & Migration](./CONTRACT_UPGRADE_PLAYBOOK.md) | N/A | N/A | Smart contract upgrade deployment and rollback |
 | [RPC Failover](./RPC_FAILOVER.md) | 5 min | N/A | Stellar RPC node failure |
+| [RPC Provider Failover Strategy](../RPC_PROVIDER_FAILOVER_STRATEGY.md) | N/A | N/A | Provider ordering, timeout/retry & switch configuration |
+| [Failed Withdrawal Incident Playbook](./FAILED_WITHDRAWAL_INCIDENT_PLAYBOOK.md) | 30 min | N/A | Withdrawals failing / stuck / debited-not-received |
 | [Full DR Procedure](./FULL_DR_PROCEDURE.md) | 4 hours | 15 min | Complete infrastructure failure |
 | [Replay & State Recovery](./REPLAY_PROCEDURES.md) | N/A | N/A | Recovering/syncing ledger events or email queue |
 | [Error Code Troubleshooting](./ERROR_CODE_TROUBLESHOOTING.md) | N/A | N/A | Diagnose and fix backend errors |


### PR DESCRIPTION
## Summary

Implements four issues on a single branch:

| Issue | Title | Type |
|-------|-------|------|
| #888 | Backend: Add structured audit logs for vault lifecycle operations | code + tests + docs |
| #890 | Backend: Add pagination, filtering, and sorting to transaction history API | code + tests + docs |
| #760 | Documentation: Add RPC provider failover strategy and configuration guide | docs |
| #915 | General: Create incident response playbook for failed vault withdrawals | docs |

## #888 — Structured vault lifecycle audit logs
- New `backend/src/vaultAuditLog.ts`: records a structured entry at each lifecycle transition (`initiated → submitted → confirmed`, or `failed`). Entries are emitted to the shared structured logger **and** kept in a bounded in-memory ring buffer (`VAULT_AUDIT_LOG_RETENTION`, default 1000) with `getVaultAuditLogs(...)` filtering and `getVaultAuditMetrics()`.
- `metadata` is passed through `redactSensitiveAttributes` so secrets are never persisted in the clear.
- Wired into `vaultEndpoints.ts` deposit/withdrawal flow, including error-code classification on failure (`SOROBAN_CIRCUIT_OPEN`, `SOROBAN_SIMULATION_ERROR`, `IDEMPOTENCY_CONFLICT`, `VAULT_OPERATION_ERROR`).
- Docs: `docs/VAULT_LIFECYCLE_AUDIT_LOG.md`.

## #890 — Transaction history pagination/filtering/sorting
- **Bug fixed:** the transactions endpoint accepted `sortBy` but **ignored it**, always ordering by `timestamp`. It now honors `sortBy` via a validated allowlist.
- New `backend/src/transactionQuery.ts` (pure/testable): sortable-field allowlist (`timestamp`, `type`, `status`), validated `type`/`status` filters, deterministic `id` tie-breaker for stable cursor paging, and a **field-aware cursor filter** so keyset pagination is correct for any sort field — not just timestamp.
- Unknown `sortBy`/`type`/`status` now return `400` with the allowed values. `amount` is intentionally excluded (persisted as a decimal string → lexical sort).
- Docs: `docs/api/PAGINATION.md` updated (allowed sort fields, validation, tie-breaker, changelog v1.2.0).

## #760 — RPC provider failover strategy & config guide
- `docs/RPC_PROVIDER_FAILOVER_STRATEGY.md`: provider ordering tiers, timeout/retry/circuit-breaker strategy documented against the real env vars (`SOROBAN_MAX_RETRIES`, `CIRCUIT_BREAKER_*`, `RETRY_BUDGET_*`), recommended per-env values, and the operational switch procedure (cross-linked to the existing `runbooks/RPC_FAILOVER.md`).

## #915 — Failed-withdrawal incident playbook
- `docs/runbooks/FAILED_WITHDRAWAL_INCIDENT_PLAYBOOK.md`: detection (using the #888 audit log as a product-level signal), triage-by-error-class → mitigation, escalation matrix, rollback/hotfix/pause guidance, communication, and post-incident steps. Linked from `docs/runbooks/README.md`.

## Tests
- `backend/src/__tests__/transactionQuery.test.ts` (14) and `backend/src/__tests__/vaultAuditLog.test.ts` (6) — **20 passing**.
- These are **self-contained** (import only the module under test), so they run without loading the Express app.

## ⚠️ Note on CI / pre-existing build state
`main` already fails `tsc`/CI due to pre-existing merge damage in `index.ts` and a few other files (undefined identifiers such as `healthProbeService`, `webhookDeduplicationStore`, `scopedAdminTokenStore`, and a mangled `buildTransactionsResponse` in `listEndpoints.ts`) that predate and are unrelated to this PR. As requested, those pre-existing errors are left untouched here — this PR does not add any new type errors and keeps its footprint to the four issues.

Closes #888
Closes #890
Closes #760
Closes #915

🤖 Generated with [Claude Code](https://claude.com/claude-code)