### PR TITLE
[904] General: Define observability dashboard minimums (logs, metrics, traces)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This project is structured as a monorepo containing both the Stellar Soroban sma
 - `/contracts/vault/`: Contains the Rust Soroban smart contract for handling the vault logic, fractional share minting (`yvUSDC`), scaling withdrawals, and simulated yield accrual.
 - `/contracts/mock-strategy/`: Contains test mock contracts for the Korean sovereign debt strategy and price oracle.
 - `/frontend/`: Contains the React + Vite frontend application, integrating `@stellar/freighter-api` for seamless user wallet connections and a premium UI to interact with the protocol.
-- `/docs/`: Contains the Product Requirements Document (PRD), Architecture Document, [Domain Glossary](./docs/GLOSSARY.md), and tracked GitHub issues. See also the [Deposit & Withdrawal Lifecycle](./docs/DEPOSIT_WITHDRAWAL_LIFECYCLE.md) for sequence diagrams and the [Vault UX Pattern Library](./docs/VAULT_UX_PATTERN_LIBRARY.md) for approved frontend interaction rules.
+- `/docs/`: Contains the Product Requirements Document (PRD), Architecture Document, [Domain Glossary](./docs/GLOSSARY.md), [Monitoring & Observability](./docs/MONITORING_OBSERVABILITY.md) (including dashboard minimums for logs/metrics/traces), and tracked GitHub issues. See also the [Deposit & Withdrawal Lifecycle](./docs/DEPOSIT_WITHDRAWAL_LIFECYCLE.md) for sequence diagrams and the [Vault UX Pattern Library](./docs/VAULT_UX_PATTERN_LIBRARY.md) for approved frontend interaction rules.
 
 ## Architecture
 

--- a/docs/MONITORING_OBSERVABILITY.md
+++ b/docs/MONITORING_OBSERVABILITY.md
@@ -4,6 +4,53 @@ This guide explains every metric, alert, and dashboard panel used to monitor Yie
 
 ---
 
+## 0. Observability Dashboard Minimums (Logs, Metrics, Traces)
+
+Production and staging must expose a **minimum viable observability dashboard** covering three pillars. Operators may add panels beyond this list; they must not ship without these.
+
+Machine-readable checklist: [`docs/observability-dashboard-minimums.json`](./observability-dashboard-minimums.json).
+
+### 0.1 Logs (minimum)
+
+| Requirement | Source | Acceptance |
+| --- | --- | --- |
+| Structured JSON logs for every HTTP request | `structuredLoggingMiddleware` | Fields include `timestamp`, `level`, `message`, `method`, `url`, `status`, `durationMs`, `requestId`, `correlationId` |
+| Error logs for 5xx / unhandled exceptions | `errorBoundary` + logger | `level=error` with stable `errorCode` when available; no raw secrets |
+| Correlation ID on inbound and outbound calls | correlation middleware + outbound propagation | Same `correlationId` visible in API logs and webhook/email egress logs |
+| Retained search | log backend (e.g. CloudWatch / Loki) | Filter by `correlationId` and `requestId` for the last **14 days** |
+
+**Required log explorer views:** (1) errors last 1h, (2) slow requests `durationMs > SLO`, (3) lookup by `correlationId`.
+
+### 0.2 Metrics (minimum)
+
+| Panel | PromQL / source | Alert hint |
+| --- | --- | --- |
+| Request rate | `sum(rate(http_request_count[1m]))` | Sudden drop → outage |
+| 5xx error rate | `sum(rate(http_request_count{status_code=~"5.."}[5m])) / sum(rate(http_request_count[5m]))` | Sustained > 1% |
+| P95 latency | `histogram_quantile(0.95, sum(rate(http_response_time_seconds_bucket[5m])) by (le, route))` | Above read 200 ms / write 500 ms |
+| SLO breach gauge | `backend_slo_breach` | Any `1` on `tier="critical"` |
+| Vault TVL + share price | `vault_tvl_usd`, `vault_share_price_usd` | Flat/stale > 15 min while traffic exists |
+| Process health | `nodejs_eventloop_lag_seconds`, heap, CPU | Lag > 100 ms |
+
+Full panel layout: [§4 Dashboard Panel Layout](#4-dashboard-panel-layout-grafana).
+
+### 0.3 Traces (minimum)
+
+| Requirement | Source | Acceptance |
+| --- | --- | --- |
+| OTLP export enabled in staging/prod | `backend/src/tracing.ts` (`OTEL_ENABLED`, `OTEL_EXPORTER_OTLP_ENDPOINT`) | Spans arrive in the collector within 60 s of traffic |
+| HTTP + Express auto-instrumentation | OpenTelemetry HTTP/Express instrumentations | Each inbound request has a root server span |
+| Manual spans on critical paths | `withSpan` / `getCurrentTraceId` in transaction & reconciliation flows | Deposit/withdraw and reconciliation jobs appear as named spans |
+| Trace ↔ log join | `traceId` / correlation fields | From a failing log line, open the matching trace in ≤ 2 clicks |
+
+**Required trace views:** (1) slowest endpoints last 15 m, (2) error traces (`status=ERROR`), (3) service map for `yieldvault-backend`.
+
+### 0.4 Go / No-Go gate
+
+A release is observability-ready only when all three pillars above are green in the target environment. Track sign-off with the checklist JSON `minimums` entries set to `required: true` (all current entries).
+
+---
+
 ## 1. Metrics Reference
 
 All metrics are exposed in Prometheus format at `GET /metrics`. The backend uses `prom-client` with the label `app="yieldvault-backend"` applied to every series.

--- a/docs/observability-dashboard-minimums.json
+++ b/docs/observability-dashboard-minimums.json
@@ -1,0 +1,85 @@
+{
+  "version": 1,
+  "title": "YieldVault observability dashboard minimums",
+  "pillars": ["logs", "metrics", "traces"],
+  "minimums": [
+    {
+      "id": "logs.structured-http",
+      "pillar": "logs",
+      "required": true,
+      "description": "Structured JSON HTTP request logs with requestId and correlationId"
+    },
+    {
+      "id": "logs.error-level",
+      "pillar": "logs",
+      "required": true,
+      "description": "Error-level logs for 5xx and unhandled exceptions without secrets"
+    },
+    {
+      "id": "logs.correlation-lookup",
+      "pillar": "logs",
+      "required": true,
+      "description": "Log explorer views for errors, slow requests, and correlationId lookup (14-day retention)"
+    },
+    {
+      "id": "metrics.request-rate",
+      "pillar": "metrics",
+      "required": true,
+      "description": "Request rate panel from http_request_count"
+    },
+    {
+      "id": "metrics.error-rate",
+      "pillar": "metrics",
+      "required": true,
+      "description": "5xx error rate panel with >1% sustained alert"
+    },
+    {
+      "id": "metrics.p95-latency",
+      "pillar": "metrics",
+      "required": true,
+      "description": "P95 latency panel with read/write SLO thresholds"
+    },
+    {
+      "id": "metrics.slo-breach",
+      "pillar": "metrics",
+      "required": true,
+      "description": "backend_slo_breach gauge for critical routes"
+    },
+    {
+      "id": "metrics.vault-gauges",
+      "pillar": "metrics",
+      "required": true,
+      "description": "vault_tvl_usd and vault_share_price_usd panels"
+    },
+    {
+      "id": "metrics.process-health",
+      "pillar": "metrics",
+      "required": true,
+      "description": "Event-loop lag, heap, and CPU panels"
+    },
+    {
+      "id": "traces.otlp-export",
+      "pillar": "traces",
+      "required": true,
+      "description": "OTLP trace export enabled for staging/production"
+    },
+    {
+      "id": "traces.http-express",
+      "pillar": "traces",
+      "required": true,
+      "description": "HTTP and Express auto-instrumentation root spans"
+    },
+    {
+      "id": "traces.critical-paths",
+      "pillar": "traces",
+      "required": true,
+      "description": "Manual spans on deposit/withdraw and reconciliation paths"
+    },
+    {
+      "id": "traces.log-join",
+      "pillar": "traces",
+      "required": true,
+      "description": "Join from correlation/trace fields in logs to the matching trace"
+    }
+  ]
+}

--- a/scripts/observability-dashboard-minimums.test.ts
+++ b/scripts/observability-dashboard-minimums.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const checklistPath = resolve(__dirname, '../docs/observability-dashboard-minimums.json');
+
+describe('observability dashboard minimums', () => {
+  it('defines required logs, metrics, and traces entries', () => {
+    const checklist = JSON.parse(readFileSync(checklistPath, 'utf8')) as {
+      pillars: string[];
+      minimums: Array<{ id: string; pillar: string; required: boolean }>;
+    };
+
+    expect(checklist.pillars).toEqual(['logs', 'metrics', 'traces']);
+
+    for (const pillar of checklist.pillars) {
+      const required = checklist.minimums.filter((m) => m.pillar === pillar && m.required);
+      expect(required.length, `expected required minimums for ${pillar}`).toBeGreaterThan(0);
+    }
+
+    const ids = checklist.minimums.map((m) => m.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});


### PR DESCRIPTION
## Summary
- Define logs/metrics/traces dashboard minimums in `docs/MONITORING_OBSERVABILITY.md`.
- Add `docs/observability-dashboard-minimums.json` plus a unit test for required pillar coverage.

Closes #904

## Test plan
- [x] `npm run test:validate-frontend-env` (includes observability checklist test)

Made with [Cursor](https://cursor.com)