### PR TITLE
feat(frontend): advanced filter and sort for transaction history (#1035)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Features
+- Add advanced filter and sort to the transaction history table: multi-column sort (up to three keys) with shift-click tiebreakers, a keyboard-reachable sort panel, URL-shareable ordering with legacy single-column links still honoured, relative date presets, removable active-filter chips, and inline reporting of contradictory ranges (#1035)
 - Harden the vault comparison screen for multi-strategy selection: numeric strategy catalog with locale-aware formatting, URL-synced shareable selection and column ordering, best-in-class marking with non-colour cues, and screen-reader announcements for selection and sort changes (#1036)
 - Add journalled partial-failure recovery for multi-step withdrawals: resume-forward retries, reverse-order compensation, an operator escalation queue with admin endpoints, and a background sweeper for crashed or backed-off sagas (#954)
 - Add deterministic admin proposal nonces with replay rejection for admin rotation (#736)

--- a/docs/FRONTEND_STATE_MANAGEMENT.md
+++ b/docs/FRONTEND_STATE_MANAGEMENT.md
@@ -55,8 +55,9 @@ Critical real-time metrics use a custom `useQueryWithPolling` wrapper. For examp
 
 ### URL State Synchronization
 Complex view state, such as data tables and filters, is synchronized with the URL search parameters. 
-- **`useDataTableState`**: Syncs pagination (page, pageSize) and sorting state to the URL.
+- **`useDataTableState`**: Syncs pagination (page, pageSize) and single-column sorting state to the URL.
 - **`useTransactionFilters`**: Syncs multi-filter criteria (date ranges, statuses, types) to the URL.
+- **`useTransactionSort`**: Syncs the transaction table's multi-column ordering to the URL (`?sort=status:asc,amount:desc`), mirroring the primary key into `useDataTableState`'s legacy `sortBy`/`direction` params so older links keep working. See [Transaction History — Advanced Filter and Sort](../frontend/docs/TRANSACTION_HISTORY_FILTER_SORT.md).
 - **Deep Linking**: Components like `VaultDashboard` listen for URL parameters (e.g., `?action=deposit&amount=100`) to automatically pre-fill local state (active tab, input amount) on mount, then clean up the URL to prevent state trapping.
 
 ### Client-Side Data Derivation
@@ -112,8 +113,8 @@ Custom hooks in `frontend/src/hooks/` encapsulate all complex logic.
 ### `TransactionHistory` (`frontend/src/pages/TransactionHistory.tsx`)
 - **State Consumed:** `useTransactionHistory` (raw transaction list).
 - **Local State:** Manages `viewMode` ("paginated" | "infinite") and infinite scroll batch counts via `useState` and `useRef`. Persists user preferences for `viewMode` and `pageSize` to `localStorage`.
-- **URL Synchronization:** Binds heavily to URL parameters using `useDataTableState` and `useTransactionFilters` to ensure the view is shareable and persists across refreshes.
-- **Rendering:** Passes raw data through `useClientDataTable` for in-memory transformations. Renders either a standard paginated `DataTable` or an infinite scroll container based on `viewMode`.
+- **URL Synchronization:** Binds heavily to URL parameters using `useDataTableState` (pagination), `useTransactionFilters` (filters) and `useTransactionSort` (multi-column ordering) to ensure the view is shareable and persists across refreshes.
+- **Rendering:** Derives the visible rows with the pure `filterTransactions → sortTransactions → paginateRows` pipeline from `lib/transactionQuery`, keeping the matching and ordering rules unit-testable outside React. Renders either a standard paginated `DataTable` or an infinite scroll container based on `viewMode`.
 
 ---
 

--- a/frontend/docs/TRANSACTION_HISTORY_FILTER_SORT.md
+++ b/frontend/docs/TRANSACTION_HISTORY_FILTER_SORT.md
@@ -1,0 +1,223 @@
+# Transaction History — Advanced Filter and Sort
+
+How the transaction history table decides which rows to show and in what order.
+
+- Engine: [`frontend/src/lib/transactionQuery.ts`](../src/lib/transactionQuery.ts)
+- Filter state: [`frontend/src/hooks/useTransactionFilters.ts`](../src/hooks/useTransactionFilters.ts)
+- Sort state: [`frontend/src/hooks/useTransactionSort.ts`](../src/hooks/useTransactionSort.ts)
+- UI: [`TransactionFilterPanel`](../src/components/TransactionFilterPanel.tsx),
+  [`TransactionFilterChips`](../src/components/TransactionFilterChips.tsx),
+  [`TransactionSortControl`](../src/components/TransactionSortControl.tsx)
+- Page: [`frontend/src/pages/TransactionHistory.tsx`](../src/pages/TransactionHistory.tsx)
+
+## Architecture
+
+The page holds no filter or sort state of its own. The URL is the single source
+of truth, the hooks parse it, and the pipeline is three pure functions:
+
+```
+transactions ──filterTransactions──▶ filtered ──sortTransactions──▶ sorted ──paginateRows──▶ page
+```
+
+All three live in `lib/transactionQuery.ts` and take their inputs as arguments —
+no React, no router, no clock. That is what lets the table's behaviour be
+specified in unit tests (`transactionQuery.test.ts`) instead of only observed
+through the DOM, and it is why a change to ordering or matching rules should be
+made there rather than in the page component.
+
+Because state lives in the URL, every filtered, sorted view is bookmarkable,
+shareable, and restored correctly by browser back/forward.
+
+## URL parameters
+
+| Parameter | Meaning | Example |
+| --- | --- | --- |
+| `search` | Free-text query; space-separated terms are ANDed | `?search=xlm+failed` |
+| `types` | Comma-separated transaction types | `?types=deposit,withdrawal` |
+| `statuses` | Comma-separated statuses | `?statuses=pending,failed` |
+| `asset` | Asset code, matched case-insensitively | `?asset=usdc` |
+| `dateFrom` / `dateTo` | Inclusive `YYYY-MM-DD` bounds | `?dateFrom=2026-01-01&dateTo=2026-03-31` |
+| `amountMin` / `amountMax` | Inclusive numeric bounds | `?amountMin=100&amountMax=5000` |
+| `sort` | Ordering, highest priority first | `?sort=status:asc,amount:desc` |
+| `sortBy` / `direction` | Single-column ordering (legacy) | `?sortBy=amount&direction=asc` |
+| `page` / `pageSize` | Pagination | `?page=2&pageSize=25` |
+
+Every parameter is treated as untrusted input. Unknown types, statuses, sort
+fields and directions are dropped; malformed dates and negative amounts are
+discarded; a repeated sort field keeps only its first occurrence. A bad
+parameter therefore degrades to "filter not applied" rather than an error or an
+empty table.
+
+## Sorting
+
+### Multi-column ordering
+
+Up to **three** columns (`MAX_SORT_KEYS`) can be sorted at once, in priority
+order: later keys only decide rows that tie on every earlier key. Three is the
+point past which the ordering stops being explicable from the header row alone.
+
+Sortable fields are `date`, `amount`, `type` and `status`. `asset` and the
+transaction hash are deliberately not sortable — alphabetising either tells a
+user nothing they came to the page to learn.
+
+Two gestures build the same state:
+
+- **Click a header** — replaces the sort with that column, cycling
+  `default direction → opposite → off`. Cycling back to "off" returns to the
+  default ordering, so a user can always undo by clicking again.
+- **Shift-click a header** — appends the column as a lower-priority tiebreaker,
+  leaving existing keys and their order alone. A third shift-click on the same
+  column removes it.
+
+The **Sort** panel in the table toolbar exposes the same capability as ordinary
+buttons: it names each active key, shows its priority, and offers flip, reorder,
+remove and reset. Shift-click is a pointer gesture that has to be known in
+advance; the panel is how the feature stays reachable without it.
+
+### Ordering rules
+
+Three rules matter enough to state, because a plausible-looking refactor can
+silently break each one:
+
+1. **Total ordering.** Comparison always ends with a transaction-id comparison,
+   so a given (rows, sort keys) pair yields exactly one ordering regardless of
+   input order. Without it, rows that tie on every key reshuffle whenever the
+   upstream fetch returns them in a different sequence.
+2. **Absent values sort last in both directions.** A `null` amount or an
+   unparseable timestamp goes to the bottom whether the sort is ascending or
+   descending. Reversing "unknown" to the top on a descending sort would present
+   missing data as the largest data.
+3. **Categories sort by meaning, not alphabet.** Status orders as
+   `pending → completed → failed`, so sorting by status surfaces transactions
+   that still need attention instead of burying them between `completed` and
+   `failed`. Type orders as `deposit → withdrawal → transfer → trade`.
+
+Amounts are compared numerically. Sorting them as strings would place `1000`
+before `9`.
+
+### URL representation
+
+`sort` is written for every explicit ordering and absent when the table is on
+its default (`date:desc`); its presence is what distinguishes "the user chose
+this" from "the default". The primary key is also mirrored into the legacy
+`sortBy`/`direction` params so older links keep working and so `useDataTableState`
+— which rewrites those params on every page change — cannot contradict `sort`.
+
+A legacy pair that merely restates the default is read as "no explicit sort", so
+a page change is not mistaken for a sort choice.
+
+Changing the ordering resets to page 1: a row's page number means nothing under
+a different order.
+
+## Filtering
+
+### Matching rules
+
+- **Search** matches type, status, asset and hash, case-insensitively. Multiple
+  terms are ANDed, so adding a term narrows the result rather than widening it.
+- **Types and statuses** are OR within a filter and AND across filters: an empty
+  selection means "all", never "none".
+- **Asset** is matched case-insensitively and ignores surrounding whitespace.
+- **Date bounds are inclusive UTC calendar days** — `dateFrom` starts at
+  `T00:00:00.000Z` and `dateTo` ends at `T23:59:59.999Z`. Anchoring to UTC rather
+  than the viewer's timezone means a shared link selects the same transactions
+  for the sender and the recipient.
+- **A bounded amount range excludes rows with no amount.** A row whose amount is
+  unknown cannot be shown to satisfy "at least 100"; letting it through would
+  overstate what the filtered set contains. With no bound set, such rows appear
+  normally.
+
+### Contradictory ranges
+
+A range whose bounds cross over (`dateFrom` after `dateTo`, `amountMin` above
+`amountMax`) can only ever match zero rows. Rather than render an empty table —
+which reads as "you have no transactions", a different and alarming claim — the
+engine **skips that range** and `validateTransactionFilters` reports the issue,
+which the panel renders as an inline message with `aria-invalid` and
+`aria-describedby` on both inputs. Other filters continue to apply.
+
+The date inputs carry no native `min`/`max` bounds. Bounding each by the other
+blocks a range from being shifted earlier or later with no explanation, and
+leaves a contradictory range arriving from a shared URL undiagnosed.
+
+### Quick ranges
+
+The preset buttons (last 7 / 30 / 90 days, year to date) resolve to **absolute**
+dates that are written into the URL, so a shared link keeps the range it was
+shared with instead of drifting with the reader's clock. Rolling windows include
+today, so "last 7 days" spans today and the six days before it.
+
+Which preset is highlighted is *derived* by comparing the current range back
+against "now" (`matchDatePreset`) rather than stored, so there is no second copy
+of the state to disagree — and a range stops being highlighted exactly when it
+stops meaning "the last 7 days".
+
+`resolveDatePreset` takes `now` as an argument rather than reading the clock, so
+the mapping is deterministic and testable.
+
+### Active filter chips
+
+Every applied filter is summarised as one removable chip.
+`describeActiveFilters` returns structured descriptors, not copy — labels are
+translated in the component — and each `type`/`status` selection gets its own
+chip so one value can be dropped without clearing the rest.
+
+The chips sit **outside** the panel's collapsible body: collapsing the panel must
+not hide the fact that rows are being filtered out.
+
+## Accessibility
+
+- Sorted headers carry `aria-sort`; the priority badges and arrow glyphs are
+  `aria-hidden`, since the same information reaches assistive technology through
+  `aria-sort` and the sort panel. Keeping them out of the accessible name also
+  keeps each header's name equal to its label.
+- A polite live region announces the new ordering after every sort change —
+  `aria-sort` on an unfocused header is not announced when it changes.
+- A refused sort (the three-key cap) is announced rather than silently dropped.
+- The sort panel states each key's direction in words ("Amount: Descending"),
+  not only as an arrow.
+- Range validation messages are wired to their inputs with `aria-describedby`
+  and announced politely.
+- Sort priority is never conveyed by colour alone: the badge carries a number.
+
+## Shared table components
+
+`DataTable` and `VirtualizedDataTable` accept multi-sort through two optional
+props, additive to the existing single-column API:
+
+| Prop | Purpose |
+| --- | --- |
+| `sortKeys` | Active `{ field, direction }[]`; supersedes `sortBy`/`sortDirection` |
+| `onSortToggle` | `(columnId, additive) => void`; `additive` mirrors the Shift modifier |
+
+Header presentation is resolved by `getColumnSortState` in
+[`dataTableSort.ts`](../src/components/dataTableSort.ts), shared by both tables.
+Tables that pass only `sortBy`/`sortDirection` — Portfolio, for one — are
+unaffected.
+
+## Tests
+
+| File | Covers |
+| --- | --- |
+| `src/lib/transactionQuery.test.ts` | Filter matching, ordering rules, sort-param parsing, presets, validation, pagination |
+| `src/hooks/useTransactionSort.test.ts` | Multi-sort URL round-trip, legacy params, cap refusal, page reset |
+| `src/hooks/useTransactionFilters.test.ts` | Filter param parsing and setters |
+| `src/components/dataTableSort.test.ts` | Header sort-state resolution for both prop shapes |
+| `src/components/TransactionSortControl.test.tsx` | Sort panel behaviour and labelling |
+| `src/components/TransactionFilterChips.test.tsx` | Chip labelling and per-value removal |
+| `src/components/TransactionFilterPanel.test.tsx` | Presets, validation messaging, chips while collapsed |
+| `src/pages/TransactionHistory.test.tsx` | End-to-end filter/sort behaviour in the rendered table |
+
+## Extending
+
+- **A new sortable column**: add the field to `SORTABLE_FIELDS`, give it a
+  default direction in `DEFAULT_SORT_DIRECTION`, add a case to `sortValue`, add
+  an i18n key to `SORT_FIELD_LABEL_KEY`, and mark the column `sortable` in the
+  page's column definitions.
+- **A new filter**: extend `TransactionFilters`, parse its param in
+  `useTransactionFilters`, apply it in `filterTransactions`, and emit a chip from
+  `describeActiveFilters` so it appears in the summary.
+- **Server-side filtering**: the engine functions take rows and filters as
+  arguments, so moving the work behind the API means calling the endpoint in
+  `useTransactionHistory` and dropping the client-side call — the URL contract,
+  the panel and the sort control need no changes.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -183,9 +183,7 @@ function AppContent() {
                   }
                 />
                 <Route path="/transactions" element={<LazyTransactionHistory walletAddress={walletAddress} />} />
-                <Route path="/compare" element={<VaultComparison />} />
                 <Route path="/compare" element={<LazyVaultComparison />} />
-                <Route path="/transactions" element={<LazyTransactionHistory walletAddress={walletAddress} />} />
                 <Route path="/receipt/:txHash" element={<TransactionReceipt />} />
                 <Route path="/settings" element={<LazySettings />} />
                 <Route path="/ui-kit" element={<LazyUIPreview />} />

--- a/frontend/src/components/DataTable.tsx
+++ b/frontend/src/components/DataTable.tsx
@@ -1,10 +1,19 @@
 import type { KeyboardEvent, ReactNode } from "react";
 import { useTranslation } from "../i18n";
+import { getColumnSortState } from "./dataTableSort";
+import type { TableSortDirection, TableSortKey } from "./dataTableSort";
 import { Pagination } from "./Pagination";
 import { TableSkeleton } from "./Skeleton";
 import { useDelayedLoading } from "../hooks/useDelayedLoading";
 
-export type TableSortDirection = "asc" | "desc";
+// Sort-state types and helpers live in `dataTableSort` so both this component
+// and VirtualizedDataTable can share them. Re-exported here because this module
+// was their original home and is what the rest of the app imports from.
+export type {
+  ColumnSortState,
+  TableSortDirection,
+  TableSortKey,
+} from "./dataTableSort";
 
 export interface DataTableColumn<T> {
   id: string;
@@ -32,6 +41,17 @@ interface DataTableProps<T> {
   sortBy?: string;
   sortDirection?: TableSortDirection;
   onSortChange?: (columnId: string) => void;
+  /**
+   * Active multi-column sort. When provided it supersedes `sortBy` /
+   * `sortDirection` for rendering, and headers report their priority.
+   */
+  sortKeys?: readonly TableSortKey[];
+  /**
+   * Multi-column sort handler. `additive` is true when the activation carried a
+   * Shift modifier, meaning "add this column as a tiebreaker" rather than
+   * "sort by this column instead". Takes precedence over `onSortChange`.
+   */
+  onSortToggle?: (columnId: string, additive: boolean) => void;
   pagination?: PaginationState;
   onPageChange?: (page: number) => void;
   onPageSizeChange?: (pageSize: number) => void;
@@ -63,6 +83,8 @@ export function DataTable<T>({
   sortBy,
   sortDirection = "asc",
   onSortChange,
+  sortKeys,
+  onSortToggle,
   pagination,
   onPageChange,
   onPageSizeChange,
@@ -75,13 +97,21 @@ export function DataTable<T>({
   const { t } = useTranslation();
   const delayedLoading = useDelayedLoading(isLoading);
 
+  const activateSort = (columnId: string, additive: boolean) => {
+    if (onSortToggle) {
+      onSortToggle(columnId, additive);
+      return;
+    }
+    onSortChange?.(columnId);
+  };
+
   const handleHeaderKeyDown = (
     event: KeyboardEvent<HTMLButtonElement>,
     columnId: string,
   ) => {
     if (event.key === "Enter" || event.key === " ") {
       event.preventDefault();
-      onSortChange?.(columnId);
+      activateSort(columnId, event.shiftKey);
     }
   };
 
@@ -107,20 +137,19 @@ export function DataTable<T>({
           <thead>
             <tr>
               {columns.map((column) => {
-                const isSorted = sortBy === column.id;
-                const ariaSort = !column.sortable
-                  ? "none"
-                  : isSorted
-                    ? sortDirection === "asc"
-                      ? "ascending"
-                      : "descending"
-                    : "none";
+                const sortState = getColumnSortState(
+                  column.id,
+                  column.sortable,
+                  sortKeys,
+                  sortBy,
+                  sortDirection,
+                );
 
                 return (
                   <th
                     key={column.id}
                     scope="col"
-                    aria-sort={ariaSort}
+                    aria-sort={sortState.ariaSort}
                     style={{
                       width: column.width,
                       textAlign: getCellAlignment(column.align),
@@ -130,16 +159,36 @@ export function DataTable<T>({
                       <button
                         type="button"
                         className="data-table-sort"
-                        onClick={() => onSortChange?.(column.id)}
+                        onClick={(event) =>
+                          activateSort(column.id, event.shiftKey)
+                        }
                         onKeyDown={(event) =>
                           handleHeaderKeyDown(event, column.id)
                         }
                         aria-label={`${t("dataTable.sortBy")} ${column.header}`}
                       >
                         <span>{column.header}</span>
+                        {/*
+                          Sort state is exposed to assistive technology through
+                          aria-sort on the th, so these glyphs are decorative.
+                          Keeping them out of the accessible name also keeps the
+                          header's name equal to its label.
+                        */}
                         <span className="data-table-sort-indicator" aria-hidden="true">
-                          {isSorted ? (sortDirection === "asc" ? "↑" : "↓") : "↕"}
+                          {sortState.direction
+                            ? sortState.direction === "asc"
+                              ? "↑"
+                              : "↓"
+                            : "↕"}
                         </span>
+                        {sortState.priority !== null && (
+                          <span
+                            className="data-table-sort-priority"
+                            aria-hidden="true"
+                          >
+                            {sortState.priority}
+                          </span>
+                        )}
                       </button>
                     ) : (
                       <span>{column.header}</span>

--- a/frontend/src/components/TransactionFilterChips.test.tsx
+++ b/frontend/src/components/TransactionFilterChips.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import TransactionFilterChips from "./TransactionFilterChips";
+import { describeActiveFilters, EMPTY_TRANSACTION_FILTERS } from "../lib/transactionQuery";
+import type { ActiveFilterDescriptor } from "../lib/transactionQuery";
+
+function renderChips(chips: ActiveFilterDescriptor[]) {
+  const onRemove = vi.fn();
+  const view = render(
+    <TransactionFilterChips chips={chips} onRemove={onRemove} />,
+  );
+  return { ...view, onRemove };
+}
+
+describe("TransactionFilterChips", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing when no filters are applied", () => {
+    const { container } = renderChips([]);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("labels each chip with its filter name and value", () => {
+    renderChips(
+      describeActiveFilters({
+        ...EMPTY_TRANSACTION_FILTERS,
+        asset: "USDC",
+        amountMin: "50",
+      }),
+    );
+
+    expect(screen.getByText("Asset: USDC")).toBeInTheDocument();
+    expect(screen.getByText("Min amount: 50")).toBeInTheDocument();
+  });
+
+  it("translates type and status values rather than showing raw enum values", () => {
+    renderChips(
+      describeActiveFilters({
+        ...EMPTY_TRANSACTION_FILTERS,
+        types: ["withdrawal"],
+        statuses: ["failed"],
+      }),
+    );
+
+    expect(screen.getByText("Type: Withdrawal")).toBeInTheDocument();
+    expect(screen.getByText("Status: Failed")).toBeInTheDocument();
+  });
+
+  it("removes one filter without touching the others", () => {
+    const chips = describeActiveFilters({
+      ...EMPTY_TRANSACTION_FILTERS,
+      types: ["deposit", "withdrawal"],
+    });
+    const { onRemove } = renderChips(chips);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Type: Deposit, remove this filter/i }),
+    );
+
+    expect(onRemove).toHaveBeenCalledTimes(1);
+    expect(onRemove).toHaveBeenCalledWith(chips[0]);
+  });
+
+  it("groups the chips under an accessible name", () => {
+    renderChips(
+      describeActiveFilters({ ...EMPTY_TRANSACTION_FILTERS, search: "abc" }),
+    );
+
+    expect(
+      screen.getByRole("group", { name: /Active filters/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders one chip per selected value", () => {
+    renderChips(
+      describeActiveFilters({
+        ...EMPTY_TRANSACTION_FILTERS,
+        types: ["deposit", "withdrawal", "trade"],
+      }),
+    );
+
+    expect(screen.getAllByRole("listitem")).toHaveLength(3);
+  });
+});

--- a/frontend/src/components/TransactionFilterChips.tsx
+++ b/frontend/src/components/TransactionFilterChips.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import { useTranslation } from "../i18n";
+import type {
+  ActiveFilterDescriptor,
+  ActiveFilterKind,
+} from "../lib/transactionQuery";
+
+const KIND_LABEL_KEY: Record<ActiveFilterKind, string> = {
+  search: "txFilter.search",
+  type: "txFilter.types",
+  status: "txFilter.statuses",
+  asset: "txFilter.asset",
+  dateFrom: "txFilter.fromDate",
+  dateTo: "txFilter.toDate",
+  amountMin: "txFilter.minAmount",
+  amountMax: "txFilter.maxAmount",
+};
+
+export interface TransactionFilterChipsProps {
+  chips: readonly ActiveFilterDescriptor[];
+  onRemove: (chip: ActiveFilterDescriptor) => void;
+}
+
+/**
+ * Summary of every applied filter, each removable on its own.
+ *
+ * The filter panel can be collapsed, and several filters are set from the URL
+ * rather than by the person reading the table. Without a summary the only
+ * evidence that rows are being hidden is a row count nobody has a reference
+ * for. These chips state what is applied and let one constraint be lifted
+ * without resetting the rest.
+ */
+export const TransactionFilterChips: React.FC<TransactionFilterChipsProps> = ({
+  chips,
+  onRemove,
+}) => {
+  const { t } = useTranslation();
+
+  if (chips.length === 0) return null;
+
+  const chipValue = (chip: ActiveFilterDescriptor): string => {
+    if (chip.kind === "type") return t(`txFilter.type.${chip.value}`);
+    if (chip.kind === "status") return t(`txFilter.status.${chip.value}`);
+    return chip.value;
+  };
+
+  return (
+    <div
+      className="tx-filter-chips"
+      role="group"
+      aria-label={t("txFilter.activeFiltersAria")}
+    >
+      <span className="tx-filter-chips-label text-body-sm">
+        {t("txFilter.activeFiltersLabel")}
+      </span>
+
+      <ul className="tx-filter-chip-list">
+        {chips.map((chip) => {
+          const label = `${t(KIND_LABEL_KEY[chip.kind])}: ${chipValue(chip)}`;
+
+          return (
+            <li key={chip.id} className="tx-filter-chip">
+              <span className="tx-filter-chip-text">{label}</span>
+              <button
+                type="button"
+                className="tx-filter-chip-remove"
+                // The filter name leads, so the label reads as "what this
+                // removes" and stays distinct from the panel's own controls.
+                aria-label={`${label}, ${t("txFilter.removeFilterAria")}`}
+                onClick={() => onRemove(chip)}
+              >
+                <span aria-hidden="true">✕</span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};
+
+export default TransactionFilterChips;

--- a/frontend/src/components/TransactionFilterPanel.test.tsx
+++ b/frontend/src/components/TransactionFilterPanel.test.tsx
@@ -131,3 +131,185 @@ describe("TransactionFilterPanel", () => {
     expect(screen.getByRole("group", { name: /Filter controls/i })).toBeInTheDocument();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Date range presets
+// ---------------------------------------------------------------------------
+
+describe("TransactionFilterPanel — date presets", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("offers the relative range shortcuts", () => {
+    renderPanel({}, { onDatePreset: vi.fn() });
+
+    const group = screen.getByRole("group", { name: /Date range presets/i });
+    expect(
+      within(group).getByRole("button", { name: "Last 7 days" }),
+    ).toBeInTheDocument();
+    expect(
+      within(group).getByRole("button", { name: "Last 30 days" }),
+    ).toBeInTheDocument();
+    expect(
+      within(group).getByRole("button", { name: "Last 90 days" }),
+    ).toBeInTheDocument();
+    expect(
+      within(group).getByRole("button", { name: "Year to date" }),
+    ).toBeInTheDocument();
+  });
+
+  it("omits the preset row when the page does not supply a handler", () => {
+    renderPanel();
+
+    expect(
+      screen.queryByRole("group", { name: /Date range presets/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("reports the chosen preset", () => {
+    const onDatePreset = vi.fn();
+    renderPanel({}, { onDatePreset });
+
+    fireEvent.click(screen.getByRole("button", { name: "Last 30 days" }));
+
+    expect(onDatePreset).toHaveBeenCalledWith("30d");
+  });
+
+  it("marks the preset the current range matches as pressed", () => {
+    renderPanel({}, { onDatePreset: vi.fn(), activeDatePreset: "90d" });
+
+    expect(screen.getByRole("button", { name: "Last 90 days" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "Last 7 days" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  it("offers to clear the dates only once a range is set", () => {
+    renderPanel({}, { onDatePreset: vi.fn(), onClearDateRange: vi.fn() });
+    expect(
+      screen.queryByRole("button", { name: /Clear dates/i }),
+    ).not.toBeInTheDocument();
+
+    const onClearDateRange = vi.fn();
+    renderPanel(
+      { dateFrom: "2026-01-01" },
+      { onDatePreset: vi.fn(), onClearDateRange },
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Clear dates/i }));
+    expect(onClearDateRange).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Range validation
+// ---------------------------------------------------------------------------
+
+describe("TransactionFilterPanel — contradictory ranges", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("explains an inverted date range and marks both inputs invalid", () => {
+    renderPanel(
+      { dateFrom: "2026-06-01", dateTo: "2026-01-01" },
+      { issues: [{ range: "date", code: "dateRangeInverted" }] },
+    );
+
+    const message = screen.getByText(/from date is after the to date/i);
+    expect(message).toBeInTheDocument();
+
+    const from = screen.getByLabelText(/Filter from date/i);
+    const to = screen.getByLabelText(/Filter to date/i);
+    expect(from).toHaveAttribute("aria-invalid", "true");
+    expect(to).toHaveAttribute("aria-invalid", "true");
+    // The message is announced, and reachable from either input.
+    expect(from).toHaveAttribute("aria-describedby", message.id);
+    expect(to).toHaveAttribute("aria-describedby", message.id);
+  });
+
+  it("explains an inverted amount range and marks both inputs invalid", () => {
+    renderPanel(
+      { amountMin: "500", amountMax: "10" },
+      { issues: [{ range: "amount", code: "amountRangeInverted" }] },
+    );
+
+    const message = screen.getByText(/minimum amount is above the maximum/i);
+    expect(message).toBeInTheDocument();
+    expect(screen.getByLabelText(/Minimum transaction amount/i)).toHaveAttribute(
+      "aria-invalid",
+      "true",
+    );
+    expect(screen.getByLabelText(/Maximum transaction amount/i)).toHaveAttribute(
+      "aria-invalid",
+      "true",
+    );
+  });
+
+  it("says nothing and marks nothing invalid for a coherent range", () => {
+    renderPanel({ dateFrom: "2026-01-01", dateTo: "2026-06-01" });
+
+    expect(
+      screen.queryByText(/from date is after the to date/i),
+    ).not.toBeInTheDocument();
+    expect(screen.getByLabelText(/Filter from date/i)).not.toHaveAttribute(
+      "aria-invalid",
+    );
+  });
+
+  it("leaves the date inputs unbounded so either end can be moved past the other", () => {
+    // Bounding each input by the other blocks a range from being shifted and
+    // gives no explanation; the inline message above covers that case instead.
+    renderPanel({ dateFrom: "2026-03-01", dateTo: "2026-04-01" });
+
+    expect(screen.getByLabelText(/Filter from date/i)).not.toHaveAttribute("max");
+    expect(screen.getByLabelText(/Filter to date/i)).not.toHaveAttribute("min");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Active filter chips
+// ---------------------------------------------------------------------------
+
+describe("TransactionFilterPanel — active filter chips", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("keeps the chips visible while the panel is collapsed", () => {
+    renderPanel(
+      { asset: "USDC" },
+      {
+        hasActiveFilters: true,
+        onRemoveFilter: vi.fn(),
+        activeFilterChips: [{ id: "asset", kind: "asset", value: "USDC" }],
+      },
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Collapse filters/i }));
+
+    expect(
+      screen.queryByRole("group", { name: /Filter controls/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Asset: USDC")).toBeInTheDocument();
+  });
+
+  it("forwards a chip removal", () => {
+    const onRemoveFilter = vi.fn();
+    const chip = { id: "asset", kind: "asset" as const, value: "USDC" };
+    renderPanel(
+      { asset: "USDC" },
+      { hasActiveFilters: true, onRemoveFilter, activeFilterChips: [chip] },
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Asset: USDC, remove this filter/i }),
+    );
+
+    expect(onRemoveFilter).toHaveBeenCalledWith(chip);
+  });
+});

--- a/frontend/src/components/TransactionFilterPanel.tsx
+++ b/frontend/src/components/TransactionFilterPanel.tsx
@@ -1,6 +1,13 @@
 import React, { useState, useEffect, useCallback, useId } from "react";
 import type { TransactionFilters, TxType, TxStatus } from "../hooks/useTransactionFilters";
 import { VALID_TX_TYPES, VALID_TX_STATUSES } from "../hooks/useTransactionFilters";
+import { DATE_PRESET_IDS } from "../lib/transactionQuery";
+import type {
+  ActiveFilterDescriptor,
+  DatePresetId,
+  FilterIssue,
+} from "../lib/transactionQuery";
+import TransactionFilterChips from "./TransactionFilterChips";
 import { useTranslation, t as tStatic } from "../i18n";
 
 // ---------------------------------------------------------------------------
@@ -30,6 +37,13 @@ const STATUS_COLORS: Record<TxStatus, string> = {
   failed: "var(--text-error)",
 };
 
+const DATE_PRESET_LABEL_KEY: Record<DatePresetId, string> = {
+  "7d": "txFilter.preset.last7Days",
+  "30d": "txFilter.preset.last30Days",
+  "90d": "txFilter.preset.last90Days",
+  ytd: "txFilter.preset.yearToDate",
+};
+
 // ---------------------------------------------------------------------------
 // Props
 // ---------------------------------------------------------------------------
@@ -48,6 +62,18 @@ export interface TransactionFilterPanelProps {
   onAmountMaxChange: (value: string) => void;
   onClearAll: () => void;
   hasActiveFilters: boolean;
+  /**
+   * Contradictory ranges reported by `validateTransactionFilters`. Rendered as
+   * inline messages next to the range they concern.
+   */
+  issues?: readonly FilterIssue[];
+  /** Preset the current date range matches, for highlighting its button. */
+  activeDatePreset?: DatePresetId | null;
+  onDatePreset?: (preset: DatePresetId) => void;
+  onClearDateRange?: () => void;
+  /** Applied filters, each removable on its own. */
+  activeFilterChips?: readonly ActiveFilterDescriptor[];
+  onRemoveFilter?: (chip: ActiveFilterDescriptor) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -133,10 +159,25 @@ export const TransactionFilterPanel: React.FC<TransactionFilterPanelProps> = ({
   onAmountMaxChange,
   onClearAll,
   hasActiveFilters,
+  issues = [],
+  activeDatePreset = null,
+  onDatePreset,
+  onClearDateRange,
+  activeFilterChips = [],
+  onRemoveFilter,
 }) => {
   const uid = useId();
   const { t } = useTranslation();
   const [isExpanded, setIsExpanded] = useState(true);
+
+  const hasDateRangeIssue = issues.some(
+    (issue) => issue.code === "dateRangeInverted",
+  );
+  const hasAmountRangeIssue = issues.some(
+    (issue) => issue.code === "amountRangeInverted",
+  );
+  const dateErrorId = `${uid}-date-error`;
+  const amountErrorId = `${uid}-amount-error`;
 
   // ---------------------------------------------------------------------------
   // Local controlled state for debounced inputs
@@ -251,6 +292,17 @@ export const TransactionFilterPanel: React.FC<TransactionFilterPanelProps> = ({
         </div>
       </div>
 
+      {/*
+        Chips sit outside the collapsible body on purpose: collapsing the panel
+        must not hide the fact that rows are being filtered out.
+      */}
+      {onRemoveFilter && (
+        <TransactionFilterChips
+          chips={activeFilterChips}
+          onRemove={onRemoveFilter}
+        />
+      )}
+
       {/* ── Panel body ───────────────────────────────────────────── */}
       {isExpanded && (
         <div
@@ -324,9 +376,12 @@ export const TransactionFilterPanel: React.FC<TransactionFilterPanelProps> = ({
                   type="date"
                   className="tx-filter-input"
                   value={filters.dateFrom}
-                  max={filters.dateTo || undefined}
                   onChange={(e) => onDateFromChange(e.target.value)}
                   aria-label="Filter from date"
+                  aria-invalid={hasDateRangeIssue || undefined}
+                  aria-describedby={
+                    hasDateRangeIssue ? dateErrorId : undefined
+                  }
                 />
               </div>
             </div>
@@ -353,13 +408,70 @@ export const TransactionFilterPanel: React.FC<TransactionFilterPanelProps> = ({
                   type="date"
                   className="tx-filter-input"
                   value={filters.dateTo}
-                  min={filters.dateFrom || undefined}
                   onChange={(e) => onDateToChange(e.target.value)}
                   aria-label="Filter to date"
+                  aria-invalid={hasDateRangeIssue || undefined}
+                  aria-describedby={
+                    hasDateRangeIssue ? dateErrorId : undefined
+                  }
                 />
               </div>
             </div>
           </div>
+
+          {/*
+            The date inputs carry no native min/max bounds. Bounding each input
+            by the other blocks a range from being moved earlier or later
+            without explanation, and leaves a contradictory range — which can
+            still arrive from a shared URL — undiagnosed. An explicit message
+            covers both cases.
+          */}
+          {hasDateRangeIssue && (
+            <p
+              id={dateErrorId}
+              className="tx-filter-error"
+              role="status"
+              aria-live="polite"
+            >
+              {t("txFilter.error.dateRangeInverted")}
+            </p>
+          )}
+
+          {/* Row 1b: relative date shortcuts */}
+          {onDatePreset && (
+            <div
+              className="tx-filter-presets"
+              role="group"
+              aria-label={t("txFilter.presetsAria")}
+            >
+              <span className="tx-filter-presets-label text-body-sm">
+                {t("txFilter.presetsLabel")}
+              </span>
+              {DATE_PRESET_IDS.map((preset) => {
+                const isActive = activeDatePreset === preset;
+                return (
+                  <button
+                    key={preset}
+                    type="button"
+                    className={`tx-filter-preset${isActive ? " tx-filter-preset--active" : ""}`}
+                    aria-pressed={isActive}
+                    onClick={() => onDatePreset(preset)}
+                  >
+                    {t(DATE_PRESET_LABEL_KEY[preset])}
+                  </button>
+                );
+              })}
+              {(filters.dateFrom || filters.dateTo) && onClearDateRange && (
+                <button
+                  type="button"
+                  className="tx-filter-preset tx-filter-preset--clear"
+                  onClick={onClearDateRange}
+                >
+                  {t("txFilter.preset.clearRange")}
+                </button>
+              )}
+            </div>
+          )}
 
           {/* Row 2: Amount range */}
           <div className="tx-filter-row">
@@ -417,6 +529,10 @@ export const TransactionFilterPanel: React.FC<TransactionFilterPanelProps> = ({
                   value={localAmountMin}
                   onChange={(e) => setLocalAmountMin(e.target.value)}
                   aria-label="Minimum transaction amount"
+                  aria-invalid={hasAmountRangeIssue || undefined}
+                  aria-describedby={
+                    hasAmountRangeIssue ? amountErrorId : undefined
+                  }
                 />
               </div>
             </div>
@@ -448,10 +564,25 @@ export const TransactionFilterPanel: React.FC<TransactionFilterPanelProps> = ({
                   value={localAmountMax}
                   onChange={(e) => setLocalAmountMax(e.target.value)}
                   aria-label="Maximum transaction amount"
+                  aria-invalid={hasAmountRangeIssue || undefined}
+                  aria-describedby={
+                    hasAmountRangeIssue ? amountErrorId : undefined
+                  }
                 />
               </div>
             </div>
           </div>
+
+          {hasAmountRangeIssue && (
+            <p
+              id={amountErrorId}
+              className="tx-filter-error"
+              role="status"
+              aria-live="polite"
+            >
+              {t("txFilter.error.amountRangeInverted")}
+            </p>
+          )}
 
           {/* Row 3: Type + Status multi-select */}
           <div className="tx-filter-row tx-filter-row--checks">

--- a/frontend/src/components/TransactionSortControl.test.tsx
+++ b/frontend/src/components/TransactionSortControl.test.tsx
@@ -1,0 +1,156 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import TransactionSortControl from "./TransactionSortControl";
+import type { SortKey } from "../lib/transactionQuery";
+
+function renderControl(sortKeys: SortKey[] = [], overrides = {}) {
+  const props = {
+    sortKeys,
+    onAdd: vi.fn(),
+    onRemove: vi.fn(),
+    onDirectionChange: vi.fn(),
+    onMove: vi.fn(),
+    onClear: vi.fn(),
+    ...overrides,
+  };
+  const view = render(<TransactionSortControl {...props} />);
+  return { ...view, props };
+}
+
+describe("TransactionSortControl", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("states the default ordering when no sort is configured", () => {
+    renderControl([]);
+
+    expect(screen.getByText(/Sorted by date, newest first/i)).toBeInTheDocument();
+    expect(screen.queryByRole("list")).not.toBeInTheDocument();
+  });
+
+  it("hides the reset control while the table is on its default ordering", () => {
+    renderControl([]);
+
+    expect(
+      screen.queryByRole("button", { name: /Reset to the default sort order/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("lists the active sort keys in priority order", () => {
+    renderControl([
+      { field: "status", direction: "asc" },
+      { field: "amount", direction: "desc" },
+    ]);
+
+    const items = screen.getAllByRole("listitem");
+    expect(items).toHaveLength(2);
+    expect(items[0]).toHaveTextContent("Status");
+    expect(items[1]).toHaveTextContent("Amount");
+  });
+
+  it("names each key's direction in words, not only as an arrow", () => {
+    renderControl([{ field: "amount", direction: "desc" }]);
+
+    expect(
+      screen.getByRole("button", { name: /Amount: Descending/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("flips a key's direction to the opposite of its current one", () => {
+    const { props } = renderControl([{ field: "amount", direction: "desc" }]);
+
+    fireEvent.click(screen.getByRole("button", { name: /Amount: Descending/i }));
+
+    expect(props.onDirectionChange).toHaveBeenCalledWith("amount", "asc");
+  });
+
+  it("removes a key", () => {
+    const { props } = renderControl([{ field: "status", direction: "asc" }]);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Stop sorting by Status/i }),
+    );
+
+    expect(props.onRemove).toHaveBeenCalledWith("status");
+  });
+
+  it("reorders priority", () => {
+    const { props } = renderControl([
+      { field: "status", direction: "asc" },
+      { field: "amount", direction: "desc" },
+    ]);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Increase sort priority of Amount/i }),
+    );
+    expect(props.onMove).toHaveBeenCalledWith("amount", -1);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Decrease sort priority of Status/i }),
+    );
+    expect(props.onMove).toHaveBeenCalledWith("status", 1);
+  });
+
+  it("disables the moves that would fall off either end", () => {
+    renderControl([
+      { field: "status", direction: "asc" },
+      { field: "amount", direction: "desc" },
+    ]);
+
+    expect(
+      screen.getByRole("button", { name: /Increase sort priority of Status/i }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: /Decrease sort priority of Amount/i }),
+    ).toBeDisabled();
+  });
+
+  it("offers only the columns that are not already sorted", () => {
+    renderControl([{ field: "amount", direction: "desc" }]);
+
+    const select = screen.getByRole("combobox", { name: /Add a tiebreaker/i });
+    expect(select).toBeEnabled();
+    expect(screen.getByRole("option", { name: "Date" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Status" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "Amount" })).not.toBeInTheDocument();
+  });
+
+  it("adds the chosen column", () => {
+    const { props } = renderControl([{ field: "amount", direction: "desc" }]);
+
+    fireEvent.change(screen.getByRole("combobox", { name: /Add a tiebreaker/i }), {
+      target: { value: "status" },
+    });
+
+    expect(props.onAdd).toHaveBeenCalledWith("status");
+  });
+
+  it("says why no more columns can be added once the cap is reached", () => {
+    renderControl([
+      { field: "date", direction: "desc" },
+      { field: "amount", direction: "desc" },
+      { field: "type", direction: "asc" },
+    ]);
+
+    const select = screen.getByRole("combobox", { name: /Add a tiebreaker/i });
+    expect(select).toBeDisabled();
+    expect(screen.getByText(/Maximum of 3 columns/i)).toBeInTheDocument();
+  });
+
+  it("clears the whole sort", () => {
+    const { props } = renderControl([{ field: "amount", direction: "desc" }]);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Reset to the default sort order/i }),
+    );
+
+    expect(props.onClear).toHaveBeenCalledTimes(1);
+  });
+
+  it("documents the shift-click shortcut", () => {
+    renderControl([]);
+
+    expect(screen.getByText(/Shift-click a column header/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/TransactionSortControl.tsx
+++ b/frontend/src/components/TransactionSortControl.tsx
@@ -1,0 +1,171 @@
+import React, { useId } from "react";
+import { useTranslation } from "../i18n";
+import {
+  MAX_SORT_KEYS,
+  SORTABLE_FIELDS,
+  type SortDirection,
+  type SortField,
+  type SortKey,
+} from "../lib/transactionQuery";
+import { SORT_FIELD_LABEL_KEY } from "../lib/transactionSortLabels";
+
+export interface TransactionSortControlProps {
+  /** Active sort keys in priority order; empty means the default ordering. */
+  sortKeys: readonly SortKey[];
+  onAdd: (field: SortField) => void;
+  onRemove: (field: SortField) => void;
+  onDirectionChange: (field: SortField, direction: SortDirection) => void;
+  /** Moves a key up (-1) or down (+1) the priority list. */
+  onMove: (field: SortField, offset: number) => void;
+  onClear: () => void;
+}
+
+/**
+ * Editor for the table's multi-column sort.
+ *
+ * Shift-clicking column headers can build the same state, but only for someone
+ * who already knows the gesture and can use a pointer. This panel makes the
+ * full capability reachable: it names the active keys, shows their priority,
+ * and exposes reorder / flip / remove as ordinary buttons. It is also the only
+ * place the ordering is stated in words, which is what a screen reader user
+ * gets instead of the arrow glyphs in the header row.
+ */
+export const TransactionSortControl: React.FC<TransactionSortControlProps> = ({
+  sortKeys,
+  onAdd,
+  onRemove,
+  onDirectionChange,
+  onMove,
+  onClear,
+}) => {
+  const { t } = useTranslation();
+  const uid = useId();
+
+  const usedFields = new Set(sortKeys.map((key) => key.field));
+  const availableFields = SORTABLE_FIELDS.filter(
+    (field) => !usedFields.has(field),
+  );
+  const atCapacity = sortKeys.length >= MAX_SORT_KEYS;
+  const canAdd = availableFields.length > 0 && !atCapacity;
+
+  const directionLabel = (direction: SortDirection) =>
+    direction === "asc" ? t("txSort.ascending") : t("txSort.descending");
+
+  return (
+    <section className="tx-sort-control" aria-labelledby={`${uid}-heading`}>
+      <div className="tx-sort-header">
+        <h3 id={`${uid}-heading`} className="tx-sort-title">
+          {t("txSort.title")}
+        </h3>
+        {sortKeys.length > 0 && (
+          <button
+            type="button"
+            className="tx-sort-reset"
+            onClick={onClear}
+            aria-label={t("txSort.resetAria")}
+          >
+            {t("txSort.reset")}
+          </button>
+        )}
+      </div>
+
+      {sortKeys.length === 0 ? (
+        <p className="tx-sort-empty text-body-sm">{t("txSort.defaultOrder")}</p>
+      ) : (
+        <ol className="tx-sort-list">
+          {sortKeys.map((key, index) => {
+            const fieldLabel = t(SORT_FIELD_LABEL_KEY[key.field]);
+            const nextDirection: SortDirection =
+              key.direction === "asc" ? "desc" : "asc";
+
+            return (
+              <li key={key.field} className="tx-sort-item">
+                <span className="tx-sort-priority" aria-hidden="true">
+                  {index + 1}
+                </span>
+                <span className="tx-sort-field">{fieldLabel}</span>
+
+                <button
+                  type="button"
+                  className="tx-sort-direction"
+                  onClick={() => onDirectionChange(key.field, nextDirection)}
+                  aria-label={`${fieldLabel}: ${directionLabel(key.direction)}. ${t(
+                    "txSort.flipAria",
+                  )}`}
+                >
+                  <span aria-hidden="true">
+                    {key.direction === "asc" ? "↑" : "↓"}
+                  </span>
+                  <span className="tx-sort-direction-text">
+                    {directionLabel(key.direction)}
+                  </span>
+                </button>
+
+                <span className="tx-sort-item-actions">
+                  <button
+                    type="button"
+                    className="tx-sort-icon-btn"
+                    onClick={() => onMove(key.field, -1)}
+                    disabled={index === 0}
+                    aria-label={`${t("txSort.moveUpAria")} ${fieldLabel}`}
+                  >
+                    <span aria-hidden="true">▲</span>
+                  </button>
+                  <button
+                    type="button"
+                    className="tx-sort-icon-btn"
+                    onClick={() => onMove(key.field, 1)}
+                    disabled={index === sortKeys.length - 1}
+                    aria-label={`${t("txSort.moveDownAria")} ${fieldLabel}`}
+                  >
+                    <span aria-hidden="true">▼</span>
+                  </button>
+                  <button
+                    type="button"
+                    className="tx-sort-icon-btn tx-sort-icon-btn--remove"
+                    onClick={() => onRemove(key.field)}
+                    aria-label={`${t("txSort.removeAria")} ${fieldLabel}`}
+                  >
+                    <span aria-hidden="true">✕</span>
+                  </button>
+                </span>
+              </li>
+            );
+          })}
+        </ol>
+      )}
+
+      <div className="tx-sort-add">
+        <label htmlFor={`${uid}-add`} className="tx-sort-add-label">
+          {t("txSort.addLabel")}
+        </label>
+        <select
+          id={`${uid}-add`}
+          className="tx-sort-add-select"
+          // A select is the natural control here, but it has no "chosen"
+          // state to keep: picking a field applies it and the control returns
+          // to its placeholder, ready for the next addition.
+          value=""
+          disabled={!canAdd}
+          onChange={(event) => {
+            const field = event.target.value;
+            if (field) onAdd(field as SortField);
+          }}
+        >
+          <option value="">
+            {atCapacity ? t("txSort.maxReached") : t("txSort.addPlaceholder")}
+          </option>
+          {availableFields.map((field) => (
+            <option key={field} value={field}>
+              {t(SORT_FIELD_LABEL_KEY[field])}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <p className="tx-sort-hint text-body-sm">{t("txSort.hint")}</p>
+    </section>
+  );
+};
+
+export default TransactionSortControl;

--- a/frontend/src/components/VirtualizedDataTable.tsx
+++ b/frontend/src/components/VirtualizedDataTable.tsx
@@ -4,7 +4,9 @@ import { useTranslation } from "../i18n";
 import { Pagination } from "./Pagination";
 import { TableSkeleton } from "./Skeleton";
 import { useDelayedLoading } from "../hooks/useDelayedLoading";
-import type { DataTableColumn, TableSortDirection } from "./DataTable";
+import { getColumnSortState } from "./dataTableSort";
+import type { TableSortDirection, TableSortKey } from "./dataTableSort";
+import type { DataTableColumn } from "./DataTable";
 
 /** Row height in pixels — keep in sync with .data-table th/td padding. */
 export const VIRTUALIZED_ROW_HEIGHT = 52;
@@ -28,6 +30,10 @@ interface VirtualizedDataTableProps<T> {
   sortBy?: string;
   sortDirection?: TableSortDirection;
   onSortChange?: (columnId: string) => void;
+  /** Active multi-column sort; supersedes `sortBy` / `sortDirection`. */
+  sortKeys?: readonly TableSortKey[];
+  /** Multi-column sort handler; `additive` mirrors the Shift modifier. */
+  onSortToggle?: (columnId: string, additive: boolean) => void;
   pagination?: PaginationState;
   onPageChange?: (page: number) => void;
   onPageSizeChange?: (pageSize: number) => void;
@@ -59,6 +65,8 @@ export function VirtualizedDataTable<T>({
   sortBy,
   sortDirection = "asc",
   onSortChange,
+  sortKeys,
+  onSortToggle,
   pagination,
   onPageChange,
   onPageSizeChange,
@@ -92,13 +100,21 @@ export function VirtualizedDataTable<T>({
     overscan: 8,
   });
 
+  const activateSort = (columnId: string, additive: boolean) => {
+    if (onSortToggle) {
+      onSortToggle(columnId, additive);
+      return;
+    }
+    onSortChange?.(columnId);
+  };
+
   const handleHeaderKeyDown = (
     event: KeyboardEvent<HTMLButtonElement>,
     columnId: string,
   ) => {
     if (event.key === "Enter" || event.key === " ") {
       event.preventDefault();
-      onSortChange?.(columnId);
+      activateSort(columnId, event.shiftKey);
     }
   };
 
@@ -118,20 +134,19 @@ export function VirtualizedDataTable<T>({
           <thead>
             <tr>
               {columns.map((column) => {
-                const isSorted = sortBy === column.id;
-                const ariaSort = !column.sortable
-                  ? "none"
-                  : isSorted
-                    ? sortDirection === "asc"
-                      ? "ascending"
-                      : "descending"
-                    : "none";
+                const sortState = getColumnSortState(
+                  column.id,
+                  column.sortable,
+                  sortKeys,
+                  sortBy,
+                  sortDirection,
+                );
 
                 return (
                   <th
                     key={column.id}
                     scope="col"
-                    aria-sort={ariaSort}
+                    aria-sort={sortState.ariaSort}
                     style={{
                       width: column.width,
                       textAlign: getCellAlignment(column.align),
@@ -141,7 +156,9 @@ export function VirtualizedDataTable<T>({
                       <button
                         type="button"
                         className="data-table-sort"
-                        onClick={() => onSortChange?.(column.id)}
+                        onClick={(event) =>
+                          activateSort(column.id, event.shiftKey)
+                        }
                         onKeyDown={(event) =>
                           handleHeaderKeyDown(event, column.id)
                         }
@@ -149,8 +166,20 @@ export function VirtualizedDataTable<T>({
                       >
                         <span>{column.header}</span>
                         <span className="data-table-sort-indicator" aria-hidden="true">
-                          {isSorted ? (sortDirection === "asc" ? "↑" : "↓") : "↕"}
+                          {sortState.direction
+                            ? sortState.direction === "asc"
+                              ? "↑"
+                              : "↓"
+                            : "↕"}
                         </span>
+                        {sortState.priority !== null && (
+                          <span
+                            className="data-table-sort-priority"
+                            aria-hidden="true"
+                          >
+                            {sortState.priority}
+                          </span>
+                        )}
                       </button>
                     ) : (
                       <span>{column.header}</span>

--- a/frontend/src/components/dataTableSort.test.ts
+++ b/frontend/src/components/dataTableSort.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { getColumnSortState } from "./dataTableSort";
+import type { TableSortKey } from "./dataTableSort";
+
+describe("getColumnSortState", () => {
+  const unsorted = { ariaSort: "none", direction: null, priority: null };
+
+  it("reports a non-sortable column as unsorted, whatever the sort state says", () => {
+    expect(
+      getColumnSortState("amount", false, [{ field: "amount", direction: "asc" }], undefined, "asc"),
+    ).toEqual(unsorted);
+  });
+
+  it("reports a sortable column that is not part of the sort as unsorted", () => {
+    expect(
+      getColumnSortState("type", true, [{ field: "amount", direction: "asc" }], undefined, "asc"),
+    ).toEqual(unsorted);
+  });
+
+  it("maps direction onto the aria-sort vocabulary", () => {
+    expect(
+      getColumnSortState("amount", true, [{ field: "amount", direction: "asc" }], undefined, "desc"),
+    ).toMatchObject({ ariaSort: "ascending", direction: "asc" });
+    expect(
+      getColumnSortState("amount", true, [{ field: "amount", direction: "desc" }], undefined, "asc"),
+    ).toMatchObject({ ariaSort: "descending", direction: "desc" });
+  });
+
+  it("omits the priority when only one column is sorted", () => {
+    expect(
+      getColumnSortState("amount", true, [{ field: "amount", direction: "asc" }], undefined, "asc")
+        .priority,
+    ).toBeNull();
+  });
+
+  it("numbers priorities from one when several columns are sorted", () => {
+    const keys: TableSortKey[] = [
+      { field: "status", direction: "asc" },
+      { field: "amount", direction: "desc" },
+    ];
+    expect(getColumnSortState("status", true, keys, undefined, "asc").priority).toBe(1);
+    expect(getColumnSortState("amount", true, keys, undefined, "asc").priority).toBe(2);
+  });
+
+  it("falls back to the single-column props when no sort keys are given", () => {
+    expect(getColumnSortState("amount", true, undefined, "amount", "desc")).toEqual({
+      ariaSort: "descending",
+      direction: "desc",
+      priority: null,
+    });
+    expect(getColumnSortState("amount", true, undefined, "type", "desc")).toEqual(unsorted);
+  });
+
+  it("prefers sort keys over the single-column props", () => {
+    // An empty key list is still a multi-sort answer: nothing is sorted.
+    expect(getColumnSortState("amount", true, [], "amount", "desc")).toEqual(unsorted);
+  });
+});

--- a/frontend/src/components/dataTableSort.ts
+++ b/frontend/src/components/dataTableSort.ts
@@ -1,0 +1,73 @@
+/**
+ * Sort-state helpers shared by `DataTable` and `VirtualizedDataTable`.
+ *
+ * These live outside the component modules so both tables can share one
+ * implementation of "how should this header look" without either file exporting
+ * a non-component (which breaks fast refresh).
+ */
+
+export type TableSortDirection = "asc" | "desc";
+
+/**
+ * One column of a multi-column sort. Deliberately keyed by a plain string so
+ * the shared table components stay independent of any one page's sort field
+ * union.
+ */
+export interface TableSortKey {
+  field: string;
+  direction: TableSortDirection;
+}
+
+export interface ColumnSortState {
+  ariaSort: "ascending" | "descending" | "none";
+  /** Direction this column is sorted in, or null when it is not sorted. */
+  direction: TableSortDirection | null;
+  /**
+   * 1-based position in the sort priority list, or null when the column is not
+   * sorted or when it is the only sorted column (a lone "1" is just noise).
+   */
+  priority: number | null;
+}
+
+/**
+ * Resolves how a header should present its sort state.
+ *
+ * Two prop shapes are supported: `sortKeys` for multi-column sort, and the
+ * original single-column `sortBy` / `sortDirection` pair, which every other
+ * table in the app still uses. `sortKeys` takes precedence when provided.
+ */
+export function getColumnSortState(
+  columnId: string,
+  sortable: boolean | undefined,
+  sortKeys: readonly TableSortKey[] | undefined,
+  sortBy: string | undefined,
+  sortDirection: TableSortDirection,
+): ColumnSortState {
+  const unsorted: ColumnSortState = {
+    ariaSort: "none",
+    direction: null,
+    priority: null,
+  };
+
+  if (!sortable) return unsorted;
+
+  if (sortKeys) {
+    const index = sortKeys.findIndex((key) => key.field === columnId);
+    if (index === -1) return unsorted;
+
+    const { direction } = sortKeys[index];
+    return {
+      ariaSort: direction === "asc" ? "ascending" : "descending",
+      direction,
+      priority: sortKeys.length > 1 ? index + 1 : null,
+    };
+  }
+
+  if (sortBy !== columnId) return unsorted;
+
+  return {
+    ariaSort: sortDirection === "asc" ? "ascending" : "descending",
+    direction: sortDirection,
+    priority: null,
+  };
+}

--- a/frontend/src/components/icons.ts
+++ b/frontend/src/components/icons.ts
@@ -35,4 +35,5 @@ export {
   Inbox,
   PackageSearch,
   Columns3,
+  ArrowUpDown,
 } from "lucide-react";

--- a/frontend/src/hooks/useTransactionFilters.ts
+++ b/frontend/src/hooks/useTransactionFilters.ts
@@ -1,38 +1,28 @@
 import { useMemo, useCallback } from "react";
 import { useSearchParams } from "react-router-dom";
+import {
+  hasActiveTransactionFilters,
+  resolveDatePreset,
+  VALID_TX_STATUSES,
+  VALID_TX_TYPES,
+  type ActiveFilterDescriptor,
+  type DatePresetId,
+  type TransactionFilters,
+  type TxStatus,
+  type TxType,
+} from "../lib/transactionQuery";
 
 // ---------------------------------------------------------------------------
-// Valid filter enum values — used for safe deserialization
+// Re-exports
+//
+// The filter vocabulary and shape live in `lib/transactionQuery` so the filter
+// engine stays a pure module with no React or router dependency. They are
+// re-exported here because this hook was the original home of both, and
+// components import them from this path.
 // ---------------------------------------------------------------------------
 
-export const VALID_TX_TYPES = ["deposit", "withdrawal", "transfer", "trade"] as const;
-export const VALID_TX_STATUSES = ["pending", "completed", "failed"] as const;
-
-export type TxType = (typeof VALID_TX_TYPES)[number];
-export type TxStatus = (typeof VALID_TX_STATUSES)[number];
-
-// ---------------------------------------------------------------------------
-// Parsed filter shape
-// ---------------------------------------------------------------------------
-
-export interface TransactionFilters {
-  /** Free-text search (hash, description, counterparty) */
-  search: string;
-  /** Asset filter (exact match), or empty string for all */
-  asset: string;
-  /** Active type filters — empty array means "all" */
-  types: TxType[];
-  /** Active status filters — empty array means "all" */
-  statuses: TxStatus[];
-  /** ISO date string (YYYY-MM-DD), or "" */
-  dateFrom: string;
-  /** ISO date string (YYYY-MM-DD), or "" */
-  dateTo: string;
-  /** Minimum amount as a string, or "" */
-  amountMin: string;
-  /** Maximum amount as a string, or "" */
-  amountMax: string;
-}
+export { VALID_TX_TYPES, VALID_TX_STATUSES };
+export type { TransactionFilters, TxType, TxStatus, DatePresetId };
 
 // ---------------------------------------------------------------------------
 // URL param names
@@ -115,15 +105,7 @@ export function useTransactionFilters() {
 
   /** True when any filter is non-default */
   const hasActiveFilters = useMemo(
-    () =>
-      Boolean(filters.search) ||
-      Boolean(filters.asset) ||
-      filters.types.length > 0 ||
-      filters.statuses.length > 0 ||
-      Boolean(filters.dateFrom) ||
-      Boolean(filters.dateTo) ||
-      Boolean(filters.amountMin) ||
-      Boolean(filters.amountMax),
+    () => hasActiveTransactionFilters(filters),
     [filters],
   );
 
@@ -231,6 +213,81 @@ export function useTransactionFilters() {
     [updateParams],
   );
 
+  /**
+   * Writes the absolute date range a relative preset resolves to, in one URL
+   * update so the two bounds never land in the URL separately (which would
+   * momentarily produce an inverted range and an empty table).
+   *
+   * `now` is injectable to keep the resolution deterministic under test.
+   */
+  const applyDatePreset = useCallback(
+    (preset: DatePresetId, now: Date = new Date()) => {
+      const { dateFrom, dateTo } = resolveDatePreset(preset, now);
+      updateParams((next) => {
+        next.set(PARAM.DATE_FROM, dateFrom);
+        next.set(PARAM.DATE_TO, dateTo);
+      });
+    },
+    [updateParams],
+  );
+
+  /** Clears both date bounds in one update. */
+  const clearDateRange = useCallback(() => {
+    updateParams((next) => {
+      next.delete(PARAM.DATE_FROM);
+      next.delete(PARAM.DATE_TO);
+    });
+  }, [updateParams]);
+
+  /**
+   * Removes exactly what one summary chip stands for: the whole filter for
+   * single-valued ones, or a single selection out of `types` / `statuses`.
+   */
+  const removeFilter = useCallback(
+    (descriptor: ActiveFilterDescriptor) => {
+      switch (descriptor.kind) {
+        case "search":
+          setSearch("");
+          return;
+        case "asset":
+          setAsset("");
+          return;
+        case "dateFrom":
+          setDateFrom("");
+          return;
+        case "dateTo":
+          setDateTo("");
+          return;
+        case "amountMin":
+          setAmountMin("");
+          return;
+        case "amountMax":
+          setAmountMax("");
+          return;
+        case "type":
+          setTypes(filters.types.filter((type) => type !== descriptor.value));
+          return;
+        case "status":
+          setStatuses(
+            filters.statuses.filter((status) => status !== descriptor.value),
+          );
+          return;
+      }
+    },
+    [
+      filters.statuses,
+      filters.types,
+      setAmountMax,
+      setAmountMin,
+      setAsset,
+      setDateFrom,
+      setDateTo,
+      setSearch,
+      setStatuses,
+      setTypes,
+    ],
+  );
+
   /** Strips all filter params and resets page to 1 */
   const clearAll = useCallback(() => {
     updateParams((next) => {
@@ -256,6 +313,9 @@ export function useTransactionFilters() {
     setAmountMin,
     setAmountMax,
     setAsset,
+    applyDatePreset,
+    clearDateRange,
+    removeFilter,
     clearAll,
   };
 }

--- a/frontend/src/hooks/useTransactionSort.test.ts
+++ b/frontend/src/hooks/useTransactionSort.test.ts
@@ -1,0 +1,251 @@
+/**
+ * useTransactionSort — URL-synced multi-column sort tests.
+ *
+ * The URL is the source of truth for ordering, so these tests assert on the
+ * params the hook reads and writes: an ordering has to survive a reload, a
+ * shared link, and the legacy single-column params older links still carry.
+ */
+
+import { describe, it, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { MemoryRouter, useSearchParams } from "react-router-dom";
+import React from "react";
+import { useTransactionSort } from "./useTransactionSort";
+import { DEFAULT_SORT_KEYS } from "../lib/transactionQuery";
+
+/** Renders the hook alongside the raw params, so writes can be inspected. */
+function renderSort(initialSearch = "") {
+  return renderHook(
+    () => {
+      const [searchParams] = useSearchParams();
+      return { ...useTransactionSort(), searchParams };
+    },
+    {
+      wrapper: ({ children }: { children: React.ReactNode }) =>
+        React.createElement(
+          MemoryRouter,
+          { initialEntries: [`/?${initialSearch}`] },
+          children,
+        ),
+    },
+  );
+}
+
+describe("useTransactionSort — reading the URL", () => {
+  it("reports no explicit sort when the URL carries none", () => {
+    const { result } = renderSort("");
+    expect(result.current.sortKeys).toEqual([]);
+    expect(result.current.isDefaultSort).toBe(true);
+    expect(result.current.effectiveSortKeys).toEqual(DEFAULT_SORT_KEYS);
+  });
+
+  it("reads a multi-key sort param", () => {
+    const { result } = renderSort("sort=status:asc,amount:desc");
+    expect(result.current.sortKeys).toEqual([
+      { field: "status", direction: "asc" },
+      { field: "amount", direction: "desc" },
+    ]);
+    expect(result.current.isDefaultSort).toBe(false);
+  });
+
+  it("falls back to the legacy single-column params", () => {
+    const { result } = renderSort("sortBy=amount&direction=asc");
+    expect(result.current.sortKeys).toEqual([
+      { field: "amount", direction: "asc" },
+    ]);
+  });
+
+  it("prefers the multi-key param when both are present", () => {
+    const { result } = renderSort("sort=type:asc&sortBy=amount&direction=desc");
+    expect(result.current.sortKeys).toEqual([{ field: "type", direction: "asc" }]);
+  });
+
+  it("ignores an unusable sort param rather than throwing", () => {
+    const { result } = renderSort("sort=wallet:sideways");
+    expect(result.current.sortKeys).toEqual([]);
+    expect(result.current.effectiveSortKeys).toEqual(DEFAULT_SORT_KEYS);
+  });
+});
+
+describe("useTransactionSort — writing the URL", () => {
+  it("writes an explicit single key to sort, and mirrors it into the legacy params", () => {
+    const { result } = renderSort("");
+
+    act(() => {
+      result.current.toggleSort("amount");
+    });
+
+    expect(result.current.sortKeys).toEqual([
+      { field: "amount", direction: "desc" },
+    ]);
+    expect(result.current.searchParams.get("sort")).toBe("amount:desc");
+    expect(result.current.searchParams.get("sortBy")).toBe("amount");
+    expect(result.current.searchParams.get("direction")).toBe("desc");
+  });
+
+  it("keeps an explicitly chosen default-direction sort distinct from no sort", () => {
+    const { result } = renderSort("");
+
+    // Choosing date/desc lands on the same ordering as the default, but it is a
+    // choice: a further click has to be able to reverse it.
+    act(() => {
+      result.current.toggleSort("date");
+    });
+    expect(result.current.isDefaultSort).toBe(false);
+    expect(result.current.searchParams.get("sort")).toBe("date:desc");
+
+    act(() => {
+      result.current.toggleSort("date");
+    });
+    expect(result.current.sortKeys).toEqual([{ field: "date", direction: "asc" }]);
+  });
+
+  it("does not mistake the legacy params' default values for a sort choice", () => {
+    // This is what useDataTableState leaves behind after a page change.
+    const { result } = renderSort("sortBy=date&direction=desc&page=2");
+    expect(result.current.sortKeys).toEqual([]);
+    expect(result.current.isDefaultSort).toBe(true);
+  });
+
+  it("mirrors the primary key into the legacy params for a multi-key sort", () => {
+    const { result } = renderSort("");
+
+    act(() => {
+      result.current.toggleSort("status");
+    });
+    act(() => {
+      result.current.toggleSort("amount", true);
+    });
+
+    expect(result.current.searchParams.get("sort")).toBe("status:asc,amount:desc");
+    expect(result.current.searchParams.get("sortBy")).toBe("status");
+    expect(result.current.searchParams.get("direction")).toBe("asc");
+  });
+
+  it("returns to page 1, since a row's page is meaningless under a new order", () => {
+    const { result } = renderSort("page=4");
+
+    act(() => {
+      result.current.toggleSort("amount");
+    });
+
+    expect(result.current.searchParams.get("page")).toBe("1");
+  });
+
+  it("keeps filter params untouched", () => {
+    const { result } = renderSort("types=deposit&search=abc");
+
+    act(() => {
+      result.current.toggleSort("amount");
+    });
+
+    expect(result.current.searchParams.get("types")).toBe("deposit");
+    expect(result.current.searchParams.get("search")).toBe("abc");
+  });
+
+  it("cycles a column through both directions and back to the default order", () => {
+    const { result } = renderSort("");
+
+    act(() => {
+      result.current.toggleSort("amount");
+    });
+    expect(result.current.sortKeys).toEqual([
+      { field: "amount", direction: "desc" },
+    ]);
+
+    act(() => {
+      result.current.toggleSort("amount");
+    });
+    expect(result.current.sortKeys).toEqual([
+      { field: "amount", direction: "asc" },
+    ]);
+
+    act(() => {
+      result.current.toggleSort("amount");
+    });
+    expect(result.current.sortKeys).toEqual([]);
+    expect(result.current.effectiveSortKeys).toEqual(DEFAULT_SORT_KEYS);
+  });
+
+  it("reports refusal when the key cap is reached, and changes nothing", () => {
+    const { result } = renderSort("sort=date:desc,amount:desc,type:asc");
+
+    let accepted: boolean | undefined;
+    act(() => {
+      accepted = result.current.toggleSort("status", true);
+    });
+
+    expect(accepted).toBe(false);
+    expect(result.current.sortKeys).toHaveLength(3);
+    expect(result.current.searchParams.get("sort")).toBe(
+      "date:desc,amount:desc,type:asc",
+    );
+  });
+
+  it("reports acceptance for a change that was applied", () => {
+    const { result } = renderSort("");
+
+    let accepted: boolean | undefined;
+    act(() => {
+      accepted = result.current.toggleSort("type");
+    });
+
+    expect(accepted).toBe(true);
+  });
+
+  it("sets one key's direction without disturbing the others", () => {
+    const { result } = renderSort("sort=status:asc,amount:desc");
+
+    act(() => {
+      result.current.setSortDirection("amount", "asc");
+    });
+
+    expect(result.current.sortKeys).toEqual([
+      { field: "status", direction: "asc" },
+      { field: "amount", direction: "asc" },
+    ]);
+  });
+
+  it("removes one key and keeps the rest", () => {
+    const { result } = renderSort("sort=status:asc,amount:desc");
+
+    act(() => {
+      result.current.removeSort("status");
+    });
+
+    expect(result.current.sortKeys).toEqual([
+      { field: "amount", direction: "desc" },
+    ]);
+  });
+
+  it("reorders priority", () => {
+    const { result } = renderSort("sort=status:asc,amount:desc");
+
+    act(() => {
+      result.current.moveSort("amount", -1);
+    });
+
+    expect(result.current.sortKeys).toEqual([
+      { field: "amount", direction: "desc" },
+      { field: "status", direction: "asc" },
+    ]);
+  });
+
+  it("clears the sort back to the default ordering", () => {
+    const { result } = renderSort("sort=status:asc,amount:desc");
+
+    act(() => {
+      result.current.clearSort();
+    });
+
+    expect(result.current.sortKeys).toEqual([]);
+    expect(result.current.searchParams.get("sort")).toBeNull();
+    // The legacy params keep describing the default so they cannot contradict it.
+    expect(result.current.searchParams.get("sortBy")).toBe(
+      DEFAULT_SORT_KEYS[0].field,
+    );
+    expect(result.current.searchParams.get("direction")).toBe(
+      DEFAULT_SORT_KEYS[0].direction,
+    );
+  });
+});

--- a/frontend/src/hooks/useTransactionSort.ts
+++ b/frontend/src/hooks/useTransactionSort.ts
@@ -1,0 +1,163 @@
+import { useCallback, useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
+import {
+  DEFAULT_SORT_KEYS,
+  moveSortKey,
+  parseLegacySortParams,
+  parseSortParam,
+  removeSortKey,
+  serializeSortParam,
+  setSortKeyDirection,
+  toggleSortKey,
+  type SortDirection,
+  type SortField,
+  type SortKey,
+} from "../lib/transactionQuery";
+
+/** Multi-column sort, e.g. `?sort=status:asc,amount:desc`. */
+export const SORT_PARAM = "sort";
+/** Single-column params the table used before multi-sort; still honoured. */
+export const LEGACY_SORT_FIELD_PARAM = "sortBy";
+export const LEGACY_SORT_DIRECTION_PARAM = "direction";
+const PAGE_PARAM = "page";
+
+export interface UseTransactionSortResult {
+  /**
+   * Sort keys as configured, empty when the table is on its default ordering.
+   * Use this to decide whether a "clear sort" control is relevant.
+   */
+  sortKeys: SortKey[];
+  /** Sort keys to actually sort by — the default ordering when none are set. */
+  effectiveSortKeys: readonly SortKey[];
+  /** True when no explicit sort is configured. */
+  isDefaultSort: boolean;
+  /**
+   * Cycles a field's sort on header activation. Pass `additive` to append it as
+   * a lower-priority tiebreaker instead of replacing the sort.
+   *
+   * @returns `false` when the request was refused because {@link MAX_SORT_KEYS}
+   * is already reached, so the caller can say so rather than appear to ignore
+   * the click.
+   */
+  toggleSort: (field: SortField, additive?: boolean) => boolean;
+  setSortDirection: (field: SortField, direction: SortDirection) => void;
+  removeSort: (field: SortField) => void;
+  /** Moves a field up (-1) or down (+1) the priority list. */
+  moveSort: (field: SortField, offset: number) => void;
+  clearSort: () => void;
+}
+
+/**
+ * URL-synced multi-column sort state for the transaction history table.
+ *
+ * The URL is the single source of truth, so an ordering can be bookmarked and
+ * shared. Alongside the multi-key `sort` param the primary key is mirrored into
+ * the legacy `sortBy`/`direction` params: `useDataTableState` still writes
+ * those on every page change, and mirroring keeps the two representations from
+ * contradicting each other. `sort` wins whenever it is present.
+ */
+export function useTransactionSort(): UseTransactionSortResult {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const sortKeys = useMemo(() => {
+    // `sort` is written for every explicit ordering, so its presence — not its
+    // content — is what distinguishes "the user chose this" from "the default".
+    const fromMultiParam = parseSortParam(searchParams.get(SORT_PARAM));
+    if (fromMultiParam.length > 0) return fromMultiParam;
+
+    const legacy = parseLegacySortParams(
+      searchParams.get(LEGACY_SORT_FIELD_PARAM),
+      searchParams.get(LEGACY_SORT_DIRECTION_PARAM),
+    );
+
+    // `useDataTableState` writes the legacy params on every page change, filling
+    // them with the table's defaults. Reading those back as an explicit sort
+    // would make a page change look like a sort choice — leaving the sort panel
+    // claiming a key the user never picked. A legacy pair that merely restates
+    // the default therefore means "no explicit sort".
+    const isRestatingDefault =
+      legacy.length === 1 &&
+      legacy[0].field === DEFAULT_SORT_KEYS[0].field &&
+      legacy[0].direction === DEFAULT_SORT_KEYS[0].direction;
+
+    return isRestatingDefault ? [] : legacy;
+  }, [searchParams]);
+
+  const effectiveSortKeys = sortKeys.length > 0 ? sortKeys : DEFAULT_SORT_KEYS;
+
+  const commit = useCallback(
+    (nextKeys: readonly SortKey[]) => {
+      setSearchParams(
+        (previous) => {
+          const next = new URLSearchParams(previous);
+          const primary = nextKeys[0] ?? DEFAULT_SORT_KEYS[0];
+
+          if (nextKeys.length > 0) {
+            next.set(SORT_PARAM, serializeSortParam(nextKeys));
+          } else {
+            next.delete(SORT_PARAM);
+          }
+
+          next.set(LEGACY_SORT_FIELD_PARAM, primary.field);
+          next.set(LEGACY_SORT_DIRECTION_PARAM, primary.direction);
+          // Row 1 of the old ordering is meaningless under a new one.
+          next.set(PAGE_PARAM, "1");
+
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  const toggleSort = useCallback(
+    (field: SortField, additive = false) => {
+      const next = toggleSortKey(sortKeys, field, { additive });
+      // toggleSortKey returns its input unchanged only when it refused the
+      // change, which today means the key cap was reached.
+      if (next === sortKeys) return false;
+      commit(next);
+      return true;
+    },
+    [commit, sortKeys],
+  );
+
+  const setSortDirection = useCallback(
+    (field: SortField, direction: SortDirection) => {
+      const next = setSortKeyDirection(sortKeys, field, direction);
+      if (next !== sortKeys) commit(next);
+    },
+    [commit, sortKeys],
+  );
+
+  const removeSort = useCallback(
+    (field: SortField) => {
+      commit(removeSortKey(sortKeys, field));
+    },
+    [commit, sortKeys],
+  );
+
+  const moveSort = useCallback(
+    (field: SortField, offset: number) => {
+      const next = moveSortKey(sortKeys, field, offset);
+      if (next !== sortKeys) commit(next);
+    },
+    [commit, sortKeys],
+  );
+
+  const clearSort = useCallback(() => {
+    commit([]);
+  }, [commit]);
+
+  return {
+    sortKeys,
+    effectiveSortKeys,
+    isDefaultSort: sortKeys.length === 0,
+    toggleSort,
+    setSortDirection,
+    removeSort,
+    moveSort,
+    clearSort,
+  };
+}

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -412,6 +412,24 @@ export const en = {
     resetAmountMinAria: "Reset min amount",
     resetAmountMaxAria: "Reset max amount",
     filterByAria: "Filter by {{group}} {{option}}",
+    activeFiltersLabel: "Filtering by",
+    activeFiltersAria: "Active filters",
+    removeFilterAria: "remove this filter",
+    presetsLabel: "Quick range",
+    presetsAria: "Date range presets",
+    preset: {
+      last7Days: "Last 7 days",
+      last30Days: "Last 30 days",
+      last90Days: "Last 90 days",
+      yearToDate: "Year to date",
+      clearRange: "Clear dates",
+    },
+    error: {
+      dateRangeInverted:
+        "The from date is after the to date, so no transaction can match. The date range is being ignored until you fix it.",
+      amountRangeInverted:
+        "The minimum amount is above the maximum, so no transaction can match. The amount range is being ignored until you fix it.",
+    },
     type: {
       deposit: "Deposit",
       withdrawal: "Withdrawal",
@@ -477,6 +495,27 @@ export const en = {
       button: "Columns",
       toggle: "Customize visible transaction table columns",
     },
+  },
+  txSort: {
+    title: "Sort",
+    button: "Sort",
+    toggleAria: "Edit how the transaction table is sorted",
+    reset: "Reset sort",
+    resetAria: "Reset to the default sort order",
+    defaultOrder: "Sorted by date, newest first.",
+    ascending: "Ascending",
+    descending: "Descending",
+    flipAria: "Reverse this direction",
+    moveUpAria: "Increase sort priority of",
+    moveDownAria: "Decrease sort priority of",
+    removeAria: "Stop sorting by",
+    addLabel: "Add a tiebreaker",
+    addPlaceholder: "Choose a column…",
+    maxReached: "Maximum of 3 columns",
+    hint: "Shift-click a column header to add it as a tiebreaker.",
+    announcePrefix: "Table sorted by",
+    maxReachedAnnouncement:
+      "Cannot add another sort column. Remove one of the three first.",
   },
   txDetail: {
     title: "Transaction Details",

--- a/frontend/src/i18n/locales/es.ts
+++ b/frontend/src/i18n/locales/es.ts
@@ -398,6 +398,24 @@ export const es = {
     resetAmountMinAria: "Restablecer monto mínimo",
     resetAmountMaxAria: "Restablecer monto máximo",
     filterByAria: "Filtrar por {{group}} {{option}}",
+    activeFiltersLabel: "Filtrando por",
+    activeFiltersAria: "Filtros activos",
+    removeFilterAria: "quitar este filtro",
+    presetsLabel: "Rango rápido",
+    presetsAria: "Rangos de fecha predefinidos",
+    preset: {
+      last7Days: "Últimos 7 días",
+      last30Days: "Últimos 30 días",
+      last90Days: "Últimos 90 días",
+      yearToDate: "Año en curso",
+      clearRange: "Limpiar fechas",
+    },
+    error: {
+      dateRangeInverted:
+        "La fecha inicial es posterior a la final, por lo que ninguna transacción puede coincidir. El rango de fechas se ignora hasta que lo corrijas.",
+      amountRangeInverted:
+        "El monto mínimo es mayor que el máximo, por lo que ninguna transacción puede coincidir. El rango de montos se ignora hasta que lo corrijas.",
+    },
     type: {
       deposit: "Depósito",
       withdrawal: "Retiro",
@@ -463,6 +481,27 @@ export const es = {
       button: "Columnas",
       toggle: "Personalizar columnas visibles de la tabla de transacciones",
     },
+  },
+  txSort: {
+    title: "Orden",
+    button: "Orden",
+    toggleAria: "Editar el orden de la tabla de transacciones",
+    reset: "Restablecer orden",
+    resetAria: "Volver al orden predeterminado",
+    defaultOrder: "Ordenado por fecha, más reciente primero.",
+    ascending: "Ascendente",
+    descending: "Descendente",
+    flipAria: "Invertir esta dirección",
+    moveUpAria: "Aumentar la prioridad de orden de",
+    moveDownAria: "Reducir la prioridad de orden de",
+    removeAria: "Dejar de ordenar por",
+    addLabel: "Añadir un criterio de desempate",
+    addPlaceholder: "Elige una columna…",
+    maxReached: "Máximo de 3 columnas",
+    hint: "Mayús + clic en un encabezado para añadirlo como desempate.",
+    announcePrefix: "Tabla ordenada por",
+    maxReachedAnnouncement:
+      "No se puede añadir otra columna de orden. Quita una de las tres primero.",
   },
   txDetail: {
     title: "Detalles de la transacción",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1267,6 +1267,23 @@ details summary:hover {
   font-size: 0.95rem;
 }
 
+/* Priority number shown when several columns are sorted at once. */
+.data-table-sort-priority {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  margin-left: 2px;
+  border-radius: 999px;
+  background: var(--accent-cyan);
+  color: var(--bg-base, #05070d);
+  font-size: 0.65rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
 .data-table-empty {
   text-align: center;
   color: var(--text-secondary);
@@ -3239,11 +3256,302 @@ details summary:hover {
   border-color: rgba(2, 132, 199, 0.25);
 }
 
+/* ── Active filter chips ────────────────────────────────────────────────── */
+
+.tx-filter-chips {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 0 2px;
+}
+
+.tx-filter-chips-label {
+  color: var(--text-secondary);
+}
+
+.tx-filter-chip-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.tx-filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 6px 4px 10px;
+  border: 1px solid var(--accent-cyan);
+  border-radius: 999px;
+  background: rgba(0, 240, 255, 0.08);
+  color: var(--accent-cyan);
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+}
+
+.tx-filter-chip-text {
+  white-space: nowrap;
+}
+
+.tx-filter-chip-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font-size: 0.7rem;
+  line-height: 1;
+}
+
+.tx-filter-chip-remove:hover {
+  background: rgba(0, 240, 255, 0.2);
+}
+
+.tx-filter-chips-clear {
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: var(--text-xs);
+  text-decoration: underline;
+}
+
+.tx-filter-chips-clear:hover {
+  color: var(--text-primary);
+}
+
+/* ── Date range presets ─────────────────────────────────────────────────── */
+
+.tx-filter-presets {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin-top: 4px;
+}
+
+.tx-filter-presets-label {
+  margin-right: 2px;
+  color: var(--text-secondary);
+}
+
+.tx-filter-preset {
+  padding: 5px 12px;
+  border: 1px solid var(--border-glass);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.tx-filter-preset:hover {
+  background: var(--bg-surface-hover);
+  color: var(--text-primary);
+}
+
+.tx-filter-preset--active {
+  border-color: var(--accent-cyan);
+  background: rgba(0, 240, 255, 0.08);
+  color: var(--accent-cyan);
+}
+
+.tx-filter-preset--clear {
+  text-decoration: underline;
+}
+
+/* ── Range validation message ───────────────────────────────────────────── */
+
+.tx-filter-error {
+  margin: 6px 0 0;
+  color: var(--text-error);
+  font-size: var(--text-xs);
+}
+
+/* ── Multi-column sort control ──────────────────────────────────────────── */
+
+.tx-sort-control {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 260px;
+}
+
+.tx-sort-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.tx-sort-title {
+  margin: 0;
+  font-size: var(--text-sm);
+}
+
+.tx-sort-reset,
+.tx-sort-count {
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: var(--text-xs);
+  text-decoration: underline;
+}
+
+.tx-sort-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  background: var(--accent-cyan);
+  color: var(--bg-base, #05070d);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.tx-sort-empty,
+.tx-sort-hint {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+.tx-sort-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.tx-sort-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border: 1px solid var(--border-glass);
+  border-radius: var(--radius-sm, 8px);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.tx-sort-priority {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  background: var(--accent-cyan);
+  color: var(--bg-base, #05070d);
+  font-size: 0.65rem;
+  font-weight: 700;
+}
+
+.tx-sort-field {
+  flex: 1 1 auto;
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+}
+
+.tx-sort-direction {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 8px;
+  border: 1px solid var(--border-glass);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: var(--text-xs);
+}
+
+.tx-sort-direction:hover {
+  color: var(--text-primary);
+}
+
+.tx-sort-item-actions {
+  display: inline-flex;
+  gap: 2px;
+}
+
+.tx-sort-icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 0.6rem;
+}
+
+.tx-sort-icon-btn:hover:not(:disabled) {
+  background: var(--bg-surface-hover);
+  color: var(--text-primary);
+}
+
+.tx-sort-icon-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.35;
+}
+
+.tx-sort-icon-btn--remove:hover:not(:disabled) {
+  color: var(--text-error);
+}
+
+.tx-sort-add {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.tx-sort-add-label {
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  white-space: nowrap;
+}
+
+.tx-sort-add-select {
+  flex: 1 1 auto;
+  padding: 5px 8px;
+  border: 1px solid var(--border-glass);
+  border-radius: var(--radius-sm, 8px);
+  background: var(--bg-muted);
+  color: var(--text-primary);
+  font-size: var(--text-xs);
+}
+
+.tx-sort-add-select:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
 /* ── Responsive ─────────────────────────────────────────────────────────── */
 
 @media (max-width: 640px) {
   .tx-filter-panel {
     padding: 16px;
+  }
+
+  .tx-sort-direction-text {
+    display: none;
   }
 
   .tx-filter-field {

--- a/frontend/src/lib/transactionQuery.test.ts
+++ b/frontend/src/lib/transactionQuery.test.ts
@@ -1,0 +1,923 @@
+/**
+ * transactionQuery — filter and sort engine tests.
+ *
+ * These cover the behaviour the transaction history table depends on without
+ * mounting React: which rows survive a filter set, in what order they come out,
+ * and how sort state round-trips through the URL.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_SORT_DIRECTION,
+  DEFAULT_SORT_KEYS,
+  EMPTY_TRANSACTION_FILTERS,
+  MAX_SORT_KEYS,
+  compareTransactions,
+  countActiveFilters,
+  describeActiveFilters,
+  filterTransactions,
+  hasActiveTransactionFilters,
+  isSortField,
+  matchDatePreset,
+  moveSortKey,
+  paginateRows,
+  parseLegacySortParams,
+  parseSortParam,
+  removeSortKey,
+  resolveDatePreset,
+  serializeSortParam,
+  setSortKeyDirection,
+  sortTransactions,
+  toggleSortKey,
+  validateTransactionFilters,
+  type SortKey,
+  type TransactionFilters,
+} from "./transactionQuery";
+import type { Transaction } from "./transactionApi";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function tx(overrides: Partial<Transaction> = {}): Transaction {
+  return {
+    id: "1",
+    type: "deposit",
+    status: "completed",
+    amount: "100",
+    asset: "USDC",
+    timestamp: "2026-03-15T12:00:00Z",
+    transactionHash: "abc123",
+    ...overrides,
+  };
+}
+
+function filters(overrides: Partial<TransactionFilters> = {}): TransactionFilters {
+  return { ...EMPTY_TRANSACTION_FILTERS, ...overrides };
+}
+
+const ids = (rows: readonly Transaction[]) => rows.map((row) => row.id);
+
+// ---------------------------------------------------------------------------
+// Sort param serialisation
+// ---------------------------------------------------------------------------
+
+describe("parseSortParam", () => {
+  it("parses a multi-key param in order", () => {
+    expect(parseSortParam("status:asc,amount:desc")).toEqual([
+      { field: "status", direction: "asc" },
+      { field: "amount", direction: "desc" },
+    ]);
+  });
+
+  it("returns no keys for empty input", () => {
+    expect(parseSortParam("")).toEqual([]);
+    expect(parseSortParam(null)).toEqual([]);
+    expect(parseSortParam(undefined)).toEqual([]);
+  });
+
+  it("drops unknown fields instead of failing", () => {
+    expect(parseSortParam("wallet:asc,amount:asc")).toEqual([
+      { field: "amount", direction: "asc" },
+    ]);
+  });
+
+  it("falls back to the field's default direction when the direction is unusable", () => {
+    expect(parseSortParam("date:sideways")).toEqual([
+      { field: "date", direction: DEFAULT_SORT_DIRECTION.date },
+    ]);
+    expect(parseSortParam("type")).toEqual([
+      { field: "type", direction: DEFAULT_SORT_DIRECTION.type },
+    ]);
+  });
+
+  it("keeps only the first occurrence of a repeated field", () => {
+    expect(parseSortParam("amount:asc,amount:desc")).toEqual([
+      { field: "amount", direction: "asc" },
+    ]);
+  });
+
+  it("truncates past the key cap", () => {
+    const parsed = parseSortParam("date:asc,amount:asc,type:asc,status:asc");
+    expect(parsed).toHaveLength(MAX_SORT_KEYS);
+    expect(parsed.map((key) => key.field)).toEqual(["date", "amount", "type"]);
+  });
+
+  it("tolerates whitespace and mixed case", () => {
+    expect(parseSortParam(" DATE : DESC ")).toEqual([
+      { field: "date", direction: "desc" },
+    ]);
+  });
+
+  it("round-trips through serializeSortParam", () => {
+    const keys: SortKey[] = [
+      { field: "status", direction: "asc" },
+      { field: "date", direction: "desc" },
+    ];
+    expect(parseSortParam(serializeSortParam(keys))).toEqual(keys);
+  });
+
+  it("serialises an empty key list to an empty string", () => {
+    expect(serializeSortParam([])).toBe("");
+  });
+});
+
+describe("parseLegacySortParams", () => {
+  it("reads the pre-multi-sort single-column params", () => {
+    expect(parseLegacySortParams("amount", "asc")).toEqual([
+      { field: "amount", direction: "asc" },
+    ]);
+  });
+
+  it("ignores an unknown field", () => {
+    expect(parseLegacySortParams("hash", "asc")).toEqual([]);
+    expect(parseLegacySortParams(null, null)).toEqual([]);
+  });
+
+  it("defaults the direction when it is missing", () => {
+    expect(parseLegacySortParams("date", null)).toEqual([
+      { field: "date", direction: DEFAULT_SORT_DIRECTION.date },
+    ]);
+  });
+});
+
+describe("isSortField", () => {
+  it("accepts sortable columns and rejects the rest", () => {
+    expect(isSortField("amount")).toBe(true);
+    expect(isSortField("hash")).toBe(false);
+    expect(isSortField("asset")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sort state transitions
+// ---------------------------------------------------------------------------
+
+describe("toggleSortKey — plain activation", () => {
+  it("replaces the sort with the clicked field at its default direction", () => {
+    expect(toggleSortKey([{ field: "date", direction: "desc" }], "amount")).toEqual(
+      [{ field: "amount", direction: DEFAULT_SORT_DIRECTION.amount }],
+    );
+  });
+
+  it("flips direction on the second activation", () => {
+    const first = toggleSortKey([], "amount");
+    expect(first).toEqual([{ field: "amount", direction: "desc" }]);
+    expect(toggleSortKey(first, "amount")).toEqual([
+      { field: "amount", direction: "asc" },
+    ]);
+  });
+
+  it("returns to the default ordering on the third activation", () => {
+    const cycled = toggleSortKey(
+      toggleSortKey(toggleSortKey([], "amount"), "amount"),
+      "amount",
+    );
+    expect(cycled).toEqual([]);
+    // An empty list is what the sorter reads as "default ordering".
+    expect(sortTransactions([tx()], cycled)).toHaveLength(1);
+  });
+
+  it("discards other keys rather than keeping a stale priority list", () => {
+    const keys: SortKey[] = [
+      { field: "status", direction: "asc" },
+      { field: "amount", direction: "desc" },
+    ];
+    expect(toggleSortKey(keys, "date")).toEqual([
+      { field: "date", direction: DEFAULT_SORT_DIRECTION.date },
+    ]);
+  });
+});
+
+describe("toggleSortKey — additive activation", () => {
+  it("appends the field as a lower-priority tiebreaker", () => {
+    const keys: SortKey[] = [{ field: "status", direction: "asc" }];
+    expect(toggleSortKey(keys, "amount", { additive: true })).toEqual([
+      { field: "status", direction: "asc" },
+      { field: "amount", direction: DEFAULT_SORT_DIRECTION.amount },
+    ]);
+  });
+
+  it("flips an existing key without changing its priority", () => {
+    const keys: SortKey[] = [
+      { field: "status", direction: "asc" },
+      { field: "amount", direction: "desc" },
+    ];
+    expect(toggleSortKey(keys, "status", { additive: true })).toEqual([
+      { field: "status", direction: "desc" },
+      { field: "amount", direction: "desc" },
+    ]);
+  });
+
+  it("removes the key on the third additive activation", () => {
+    const keys: SortKey[] = [
+      { field: "date", direction: "desc" },
+      { field: "status", direction: "desc" },
+    ];
+    expect(toggleSortKey(keys, "status", { additive: true })).toEqual([
+      { field: "date", direction: "desc" },
+    ]);
+  });
+
+  it("refuses to exceed the key cap and signals it by returning the same reference", () => {
+    const keys: SortKey[] = [
+      { field: "date", direction: "desc" },
+      { field: "amount", direction: "desc" },
+      { field: "type", direction: "asc" },
+    ];
+    const result = toggleSortKey(keys, "status", { additive: true });
+    expect(result).toBe(keys);
+  });
+});
+
+describe("removeSortKey / setSortKeyDirection / moveSortKey", () => {
+  const keys: SortKey[] = [
+    { field: "date", direction: "desc" },
+    { field: "amount", direction: "asc" },
+  ];
+
+  it("removes one key and keeps the order of the rest", () => {
+    expect(removeSortKey(keys, "date")).toEqual([
+      { field: "amount", direction: "asc" },
+    ]);
+  });
+
+  it("removing an absent field is a no-op", () => {
+    expect(removeSortKey(keys, "status")).toEqual(keys);
+  });
+
+  it("sets a direction", () => {
+    expect(setSortKeyDirection(keys, "amount", "desc")).toEqual([
+      { field: "date", direction: "desc" },
+      { field: "amount", direction: "desc" },
+    ]);
+  });
+
+  it("returns the same reference when the direction already matches", () => {
+    expect(setSortKeyDirection(keys, "amount", "asc")).toBe(keys);
+  });
+
+  it("returns the same reference for a field that is not sorted", () => {
+    expect(setSortKeyDirection(keys, "status", "asc")).toBe(keys);
+  });
+
+  it("moves a key down the priority list", () => {
+    expect(moveSortKey(keys, "date", 1)).toEqual([
+      { field: "amount", direction: "asc" },
+      { field: "date", direction: "desc" },
+    ]);
+  });
+
+  it("returns the same reference when the move falls off either end", () => {
+    expect(moveSortKey(keys, "date", -1)).toBe(keys);
+    expect(moveSortKey(keys, "amount", 1)).toBe(keys);
+    expect(moveSortKey(keys, "date", 0)).toBe(keys);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sorting
+// ---------------------------------------------------------------------------
+
+describe("sortTransactions", () => {
+  it("does not mutate the input array", () => {
+    const rows = [tx({ id: "b" }), tx({ id: "a" })];
+    const snapshot = [...rows];
+    sortTransactions(rows, [{ field: "type", direction: "asc" }]);
+    expect(rows).toEqual(snapshot);
+  });
+
+  it("defaults to newest first when no keys are given", () => {
+    const rows = [
+      tx({ id: "old", timestamp: "2026-01-01T00:00:00Z" }),
+      tx({ id: "new", timestamp: "2026-06-01T00:00:00Z" }),
+    ];
+    expect(ids(sortTransactions(rows))).toEqual(["new", "old"]);
+    expect(ids(sortTransactions(rows, []))).toEqual(["new", "old"]);
+    expect(ids(sortTransactions(rows, DEFAULT_SORT_KEYS))).toEqual(["new", "old"]);
+  });
+
+  it("sorts amounts numerically, not as strings", () => {
+    const rows = [
+      tx({ id: "9", amount: "9" }),
+      tx({ id: "100", amount: "100" }),
+      tx({ id: "20", amount: "20" }),
+    ];
+    expect(ids(sortTransactions(rows, [{ field: "amount", direction: "asc" }]))).toEqual(
+      ["9", "20", "100"],
+    );
+  });
+
+  it("orders status by lifecycle rather than alphabetically", () => {
+    const rows = [
+      tx({ id: "c", status: "completed" }),
+      tx({ id: "f", status: "failed" }),
+      tx({ id: "p", status: "pending" }),
+    ];
+    expect(ids(sortTransactions(rows, [{ field: "status", direction: "asc" }]))).toEqual(
+      ["p", "c", "f"],
+    );
+  });
+
+  it("orders type by deposit, withdrawal, transfer, trade", () => {
+    const rows = [
+      tx({ id: "trade", type: "trade" }),
+      tx({ id: "withdrawal", type: "withdrawal" }),
+      tx({ id: "transfer", type: "transfer" }),
+      tx({ id: "deposit", type: "deposit" }),
+    ];
+    expect(ids(sortTransactions(rows, [{ field: "type", direction: "asc" }]))).toEqual(
+      ["deposit", "withdrawal", "transfer", "trade"],
+    );
+  });
+
+  it("applies later keys only to rows that tie on earlier ones", () => {
+    const rows = [
+      tx({ id: "a", status: "completed", amount: "10" }),
+      tx({ id: "b", status: "pending", amount: "5" }),
+      tx({ id: "c", status: "completed", amount: "50" }),
+      tx({ id: "d", status: "pending", amount: "80" }),
+    ];
+    const sorted = sortTransactions(rows, [
+      { field: "status", direction: "asc" },
+      { field: "amount", direction: "desc" },
+    ]);
+    expect(ids(sorted)).toEqual(["d", "b", "c", "a"]);
+  });
+
+  it("sorts rows with no amount last in both directions", () => {
+    const rows = [
+      tx({ id: "none", amount: null }),
+      tx({ id: "low", amount: "1" }),
+      tx({ id: "high", amount: "999" }),
+    ];
+    expect(ids(sortTransactions(rows, [{ field: "amount", direction: "asc" }]))).toEqual(
+      ["low", "high", "none"],
+    );
+    expect(ids(sortTransactions(rows, [{ field: "amount", direction: "desc" }]))).toEqual(
+      ["high", "low", "none"],
+    );
+  });
+
+  it("treats an unparseable amount as absent", () => {
+    const rows = [
+      tx({ id: "bad", amount: "not-a-number" }),
+      tx({ id: "good", amount: "5" }),
+    ];
+    expect(ids(sortTransactions(rows, [{ field: "amount", direction: "desc" }]))).toEqual(
+      ["good", "bad"],
+    );
+  });
+
+  it("sorts rows with an unreadable timestamp last", () => {
+    const rows = [
+      tx({ id: "bad", timestamp: "whenever" }),
+      tx({ id: "good", timestamp: "2026-01-01T00:00:00Z" }),
+    ];
+    expect(ids(sortTransactions(rows, [{ field: "date", direction: "asc" }]))).toEqual(
+      ["good", "bad"],
+    );
+    expect(ids(sortTransactions(rows, [{ field: "date", direction: "desc" }]))).toEqual(
+      ["good", "bad"],
+    );
+  });
+
+  it("produces one ordering for rows that tie on every key, whatever the input order", () => {
+    const a = tx({ id: "a" });
+    const b = tx({ id: "b" });
+    const keys: SortKey[] = [{ field: "type", direction: "asc" }];
+    expect(ids(sortTransactions([a, b], keys))).toEqual(["a", "b"]);
+    expect(ids(sortTransactions([b, a], keys))).toEqual(["a", "b"]);
+  });
+});
+
+describe("compareTransactions", () => {
+  it("returns 0 only for the same row identity", () => {
+    const row = tx({ id: "same" });
+    expect(compareTransactions(row, row, DEFAULT_SORT_KEYS)).toBe(0);
+  });
+
+  it("is antisymmetric for distinct rows", () => {
+    const left = tx({ id: "a", amount: "10" });
+    const right = tx({ id: "b", amount: "20" });
+    const keys: SortKey[] = [{ field: "amount", direction: "asc" }];
+    expect(compareTransactions(left, right, keys)).toBeLessThan(0);
+    expect(compareTransactions(right, left, keys)).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Date presets
+// ---------------------------------------------------------------------------
+
+describe("resolveDatePreset", () => {
+  const now = new Date("2026-07-28T09:30:00Z");
+
+  it("counts today as one of the days in a rolling window", () => {
+    expect(resolveDatePreset("7d", now)).toEqual({
+      dateFrom: "2026-07-22",
+      dateTo: "2026-07-28",
+    });
+  });
+
+  it("resolves 30 and 90 day windows", () => {
+    expect(resolveDatePreset("30d", now)).toEqual({
+      dateFrom: "2026-06-29",
+      dateTo: "2026-07-28",
+    });
+    expect(resolveDatePreset("90d", now)).toEqual({
+      dateFrom: "2026-04-30",
+      dateTo: "2026-07-28",
+    });
+  });
+
+  it("starts year-to-date on January 1", () => {
+    expect(resolveDatePreset("ytd", now)).toEqual({
+      dateFrom: "2026-01-01",
+      dateTo: "2026-07-28",
+    });
+  });
+
+  it("crosses a month boundary correctly", () => {
+    expect(resolveDatePreset("7d", new Date("2026-03-03T00:00:00Z"))).toEqual({
+      dateFrom: "2026-02-25",
+      dateTo: "2026-03-03",
+    });
+  });
+
+  it("ignores the time of day, so the range does not shift within a day", () => {
+    const early = resolveDatePreset("30d", new Date("2026-07-28T00:00:01Z"));
+    const late = resolveDatePreset("30d", new Date("2026-07-28T23:59:59Z"));
+    expect(early).toEqual(late);
+  });
+});
+
+describe("matchDatePreset", () => {
+  const now = new Date("2026-07-28T09:30:00Z");
+
+  it("identifies a range that a preset produced", () => {
+    const range = resolveDatePreset("30d", now);
+    expect(matchDatePreset(range, now)).toBe("30d");
+  });
+
+  it("returns null for a hand-picked range", () => {
+    expect(
+      matchDatePreset({ dateFrom: "2026-02-01", dateTo: "2026-02-14" }, now),
+    ).toBeNull();
+  });
+
+  it("returns null when either bound is missing", () => {
+    expect(matchDatePreset({ dateFrom: "2026-07-22", dateTo: "" }, now)).toBeNull();
+    expect(matchDatePreset({ dateFrom: "", dateTo: "2026-07-28" }, now)).toBeNull();
+  });
+
+  it("stops matching once the range no longer means the same window", () => {
+    const range = resolveDatePreset("7d", now);
+    const tomorrow = new Date("2026-07-29T09:30:00Z");
+    expect(matchDatePreset(range, tomorrow)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+describe("validateTransactionFilters", () => {
+  it("reports nothing for an empty filter set", () => {
+    expect(validateTransactionFilters(filters())).toEqual([]);
+  });
+
+  it("reports an inverted date range", () => {
+    expect(
+      validateTransactionFilters(
+        filters({ dateFrom: "2026-06-01", dateTo: "2026-01-01" }),
+      ),
+    ).toEqual([{ range: "date", code: "dateRangeInverted" }]);
+  });
+
+  it("accepts a single-day range", () => {
+    expect(
+      validateTransactionFilters(
+        filters({ dateFrom: "2026-06-01", dateTo: "2026-06-01" }),
+      ),
+    ).toEqual([]);
+  });
+
+  it("reports an inverted amount range", () => {
+    expect(
+      validateTransactionFilters(filters({ amountMin: "500", amountMax: "10" })),
+    ).toEqual([{ range: "amount", code: "amountRangeInverted" }]);
+  });
+
+  it("compares amounts numerically, so 9 is not above 100", () => {
+    expect(
+      validateTransactionFilters(filters({ amountMin: "9", amountMax: "100" })),
+    ).toEqual([]);
+  });
+
+  it("reports both ranges at once", () => {
+    expect(
+      validateTransactionFilters(
+        filters({
+          dateFrom: "2026-06-01",
+          dateTo: "2026-01-01",
+          amountMin: "500",
+          amountMax: "10",
+        }),
+      ),
+    ).toHaveLength(2);
+  });
+
+  it("says nothing when only one bound of a range is set", () => {
+    expect(validateTransactionFilters(filters({ amountMin: "500" }))).toEqual([]);
+    expect(validateTransactionFilters(filters({ dateTo: "2026-01-01" }))).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Filtering
+// ---------------------------------------------------------------------------
+
+describe("filterTransactions — search", () => {
+  const rows = [
+    tx({ id: "1", type: "deposit", asset: "USDC", transactionHash: "aaa111" }),
+    tx({
+      id: "2",
+      type: "withdrawal",
+      status: "failed",
+      asset: "XLM",
+      transactionHash: "bbb222",
+    }),
+  ];
+
+  it("returns every row when the search is empty", () => {
+    expect(filterTransactions(rows, filters())).toHaveLength(2);
+    expect(filterTransactions(rows, filters({ search: "   " }))).toHaveLength(2);
+  });
+
+  it("matches on asset, type, status and hash, case-insensitively", () => {
+    expect(ids(filterTransactions(rows, filters({ search: "usdc" })))).toEqual(["1"]);
+    expect(ids(filterTransactions(rows, filters({ search: "WITHDRAWAL" })))).toEqual([
+      "2",
+    ]);
+    expect(ids(filterTransactions(rows, filters({ search: "failed" })))).toEqual(["2"]);
+    expect(ids(filterTransactions(rows, filters({ search: "bbb" })))).toEqual(["2"]);
+  });
+
+  it("requires every term to match, so terms narrow rather than widen", () => {
+    expect(ids(filterTransactions(rows, filters({ search: "xlm failed" })))).toEqual([
+      "2",
+    ]);
+    expect(filterTransactions(rows, filters({ search: "xlm deposit" }))).toEqual([]);
+  });
+
+  it("does not match a row on a term found only in another row", () => {
+    expect(filterTransactions(rows, filters({ search: "eurc" }))).toEqual([]);
+  });
+});
+
+describe("filterTransactions — type, status and asset", () => {
+  const rows = [
+    tx({ id: "1", type: "deposit", status: "completed", asset: "USDC" }),
+    tx({ id: "2", type: "withdrawal", status: "pending", asset: "XLM" }),
+    tx({ id: "3", type: "trade", status: "failed", asset: null }),
+  ];
+
+  it("treats an empty selection as 'all'", () => {
+    expect(filterTransactions(rows, filters({ types: [], statuses: [] }))).toHaveLength(
+      3,
+    );
+  });
+
+  it("keeps rows matching any selected type", () => {
+    expect(
+      ids(filterTransactions(rows, filters({ types: ["deposit", "trade"] }))),
+    ).toEqual(["1", "3"]);
+  });
+
+  it("keeps rows matching any selected status", () => {
+    expect(
+      ids(filterTransactions(rows, filters({ statuses: ["pending", "failed"] }))),
+    ).toEqual(["2", "3"]);
+  });
+
+  it("intersects type and status rather than unioning them", () => {
+    expect(
+      filterTransactions(
+        rows,
+        filters({ types: ["deposit"], statuses: ["pending"] }),
+      ),
+    ).toEqual([]);
+  });
+
+  it("matches an asset without regard to case or padding", () => {
+    expect(ids(filterTransactions(rows, filters({ asset: "usdc" })))).toEqual(["1"]);
+    expect(ids(filterTransactions(rows, filters({ asset: " XLM " })))).toEqual(["2"]);
+  });
+
+  it("excludes rows with no asset when an asset is selected", () => {
+    expect(ids(filterTransactions(rows, filters({ asset: "USDC" })))).toEqual(["1"]);
+  });
+});
+
+describe("filterTransactions — date range", () => {
+  const rows = [
+    tx({ id: "jan", timestamp: "2026-01-15T12:00:00Z" }),
+    tx({ id: "mar", timestamp: "2026-03-15T12:00:00Z" }),
+    tx({ id: "jun", timestamp: "2026-06-15T12:00:00Z" }),
+  ];
+
+  it("filters from a lower bound inclusively", () => {
+    expect(ids(filterTransactions(rows, filters({ dateFrom: "2026-03-15" })))).toEqual([
+      "mar",
+      "jun",
+    ]);
+  });
+
+  it("filters to an upper bound inclusively", () => {
+    expect(ids(filterTransactions(rows, filters({ dateTo: "2026-03-15" })))).toEqual([
+      "jan",
+      "mar",
+    ]);
+  });
+
+  it("includes both ends of a single-day range", () => {
+    const sameDay = [
+      tx({ id: "start", timestamp: "2026-03-15T00:00:00.000Z" }),
+      tx({ id: "end", timestamp: "2026-03-15T23:59:59.999Z" }),
+      tx({ id: "next", timestamp: "2026-03-16T00:00:00.000Z" }),
+    ];
+    expect(
+      ids(
+        filterTransactions(
+          sameDay,
+          filters({ dateFrom: "2026-03-15", dateTo: "2026-03-15" }),
+        ),
+      ),
+    ).toEqual(["start", "end"]);
+  });
+
+  it("excludes rows whose timestamp cannot be read", () => {
+    const withBad = [...rows, tx({ id: "bad", timestamp: "sometime" })];
+    expect(
+      ids(filterTransactions(withBad, filters({ dateFrom: "2026-01-01" }))),
+    ).not.toContain("bad");
+  });
+
+  it("keeps unreadable timestamps when no date bound is set", () => {
+    const withBad = [tx({ id: "bad", timestamp: "sometime" })];
+    expect(ids(filterTransactions(withBad, filters()))).toEqual(["bad"]);
+  });
+
+  it("ignores an inverted range instead of matching nothing", () => {
+    expect(
+      filterTransactions(
+        rows,
+        filters({ dateFrom: "2026-06-01", dateTo: "2026-01-01" }),
+      ),
+    ).toHaveLength(3);
+  });
+
+  it("still applies other filters when the date range is ignored", () => {
+    const result = filterTransactions(
+      rows,
+      filters({
+        dateFrom: "2026-06-01",
+        dateTo: "2026-01-01",
+        search: "mar",
+      }),
+    );
+    // "mar" is not in the searchable text, so search alone rules everything out.
+    expect(result).toEqual([]);
+  });
+});
+
+describe("filterTransactions — amount range", () => {
+  const rows = [
+    tx({ id: "10", amount: "10" }),
+    tx({ id: "100", amount: "100" }),
+    tx({ id: "1000", amount: "1000" }),
+    tx({ id: "none", amount: null }),
+  ];
+
+  it("filters on a minimum inclusively", () => {
+    expect(ids(filterTransactions(rows, filters({ amountMin: "100" })))).toEqual([
+      "100",
+      "1000",
+    ]);
+  });
+
+  it("filters on a maximum inclusively", () => {
+    expect(ids(filterTransactions(rows, filters({ amountMax: "100" })))).toEqual([
+      "10",
+      "100",
+    ]);
+  });
+
+  it("compares numerically, so 1000 is above 999 and not below it", () => {
+    expect(ids(filterTransactions(rows, filters({ amountMin: "999" })))).toEqual([
+      "1000",
+    ]);
+  });
+
+  it("excludes rows with no amount once either bound is set", () => {
+    expect(ids(filterTransactions(rows, filters({ amountMin: "0" })))).not.toContain(
+      "none",
+    );
+    expect(ids(filterTransactions(rows, filters({ amountMax: "5000" })))).not.toContain(
+      "none",
+    );
+  });
+
+  it("keeps rows with no amount when the range is unbounded", () => {
+    expect(ids(filterTransactions(rows, filters()))).toContain("none");
+  });
+
+  it("excludes rows whose amount is not a number", () => {
+    const withBad = [tx({ id: "bad", amount: "one hundred" })];
+    expect(filterTransactions(withBad, filters({ amountMin: "0" }))).toEqual([]);
+  });
+
+  it("ignores an inverted range instead of matching nothing", () => {
+    expect(
+      filterTransactions(rows, filters({ amountMin: "500", amountMax: "10" })),
+    ).toHaveLength(4);
+  });
+});
+
+describe("filterTransactions — combinations", () => {
+  it("applies every filter as a conjunction", () => {
+    const rows = [
+      tx({
+        id: "match",
+        type: "withdrawal",
+        status: "failed",
+        asset: "USDC",
+        amount: "250",
+        timestamp: "2026-04-10T00:00:00Z",
+      }),
+      tx({
+        id: "wrongType",
+        type: "deposit",
+        status: "failed",
+        asset: "USDC",
+        amount: "250",
+        timestamp: "2026-04-10T00:00:00Z",
+      }),
+      tx({
+        id: "wrongAmount",
+        type: "withdrawal",
+        status: "failed",
+        asset: "USDC",
+        amount: "9",
+        timestamp: "2026-04-10T00:00:00Z",
+      }),
+      tx({
+        id: "wrongDate",
+        type: "withdrawal",
+        status: "failed",
+        asset: "USDC",
+        amount: "250",
+        timestamp: "2025-04-10T00:00:00Z",
+      }),
+    ];
+
+    expect(
+      ids(
+        filterTransactions(
+          rows,
+          filters({
+            types: ["withdrawal"],
+            statuses: ["failed"],
+            asset: "USDC",
+            amountMin: "100",
+            amountMax: "500",
+            dateFrom: "2026-01-01",
+            dateTo: "2026-12-31",
+          }),
+        ),
+      ),
+    ).toEqual(["match"]);
+  });
+
+  it("preserves input order, leaving ordering to the sorter", () => {
+    const rows = [tx({ id: "b" }), tx({ id: "a" }), tx({ id: "c" })];
+    expect(ids(filterTransactions(rows, filters()))).toEqual(["b", "a", "c"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const rows = [tx({ id: "a" }), tx({ id: "b" })];
+    const snapshot = [...rows];
+    filterTransactions(rows, filters({ search: "usdc" }));
+    expect(rows).toEqual(snapshot);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Active filter summary
+// ---------------------------------------------------------------------------
+
+describe("describeActiveFilters", () => {
+  it("describes nothing for an empty filter set", () => {
+    expect(describeActiveFilters(filters())).toEqual([]);
+    expect(hasActiveTransactionFilters(filters())).toBe(false);
+    expect(countActiveFilters(filters())).toBe(0);
+  });
+
+  it("emits one chip per selected type and status", () => {
+    const chips = describeActiveFilters(
+      filters({ types: ["deposit", "withdrawal"], statuses: ["failed"] }),
+    );
+    expect(chips).toEqual([
+      { id: "type:deposit", kind: "type", value: "deposit" },
+      { id: "type:withdrawal", kind: "type", value: "withdrawal" },
+      { id: "status:failed", kind: "status", value: "failed" },
+    ]);
+  });
+
+  it("emits a chip for every single-valued filter", () => {
+    const chips = describeActiveFilters(
+      filters({
+        search: "abc",
+        asset: "USDC",
+        dateFrom: "2026-01-01",
+        dateTo: "2026-02-01",
+        amountMin: "5",
+        amountMax: "50",
+      }),
+    );
+    expect(chips.map((chip) => chip.kind)).toEqual([
+      "search",
+      "asset",
+      "dateFrom",
+      "dateTo",
+      "amountMin",
+      "amountMax",
+    ]);
+  });
+
+  it("gives every chip a distinct id so they can be keyed and targeted", () => {
+    const chips = describeActiveFilters(
+      filters({ types: ["deposit", "trade"], statuses: ["pending"], search: "x" }),
+    );
+    expect(new Set(chips.map((chip) => chip.id)).size).toBe(chips.length);
+  });
+
+  it("ignores a whitespace-only search", () => {
+    expect(describeActiveFilters(filters({ search: "   " }))).toEqual([]);
+  });
+
+  it("treats a zero amount bound as an applied filter", () => {
+    // "" means unset; "0" is a real bound and must not be mistaken for unset.
+    expect(countActiveFilters(filters({ amountMin: "0" }))).toBe(1);
+  });
+
+  it("counts each applied filter once", () => {
+    expect(
+      countActiveFilters(filters({ types: ["deposit", "trade"], asset: "USDC" })),
+    ).toBe(3);
+    expect(hasActiveTransactionFilters(filters({ asset: "USDC" }))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pagination
+// ---------------------------------------------------------------------------
+
+describe("paginateRows", () => {
+  const rows = Array.from({ length: 12 }, (_, index) => tx({ id: String(index) }));
+
+  it("slices the requested page", () => {
+    const result = paginateRows(rows, 2, 5);
+    expect(ids(result.rows)).toEqual(["5", "6", "7", "8", "9"]);
+    expect(result).toMatchObject({ page: 2, totalItems: 12, totalPages: 3 });
+  });
+
+  it("returns a short final page", () => {
+    expect(paginateRows(rows, 3, 5).rows).toHaveLength(2);
+  });
+
+  it("clamps a page past the end rather than returning nothing", () => {
+    const result = paginateRows(rows, 99, 5);
+    expect(result.page).toBe(3);
+    expect(result.rows).toHaveLength(2);
+  });
+
+  it("clamps a page below one", () => {
+    expect(paginateRows(rows, 0, 5).page).toBe(1);
+    expect(paginateRows(rows, -4, 5).page).toBe(1);
+  });
+
+  it("reports one page for an empty result set", () => {
+    expect(paginateRows([], 1, 10)).toEqual({
+      rows: [],
+      page: 1,
+      totalItems: 0,
+      totalPages: 1,
+    });
+  });
+
+  it("survives a nonsensical page size", () => {
+    expect(paginateRows(rows, 1, 0).rows).toHaveLength(1);
+  });
+});

--- a/frontend/src/lib/transactionQuery.ts
+++ b/frontend/src/lib/transactionQuery.ts
@@ -1,0 +1,726 @@
+/**
+ * Filter and sort engine for the transaction history table.
+ *
+ * Everything here is a pure function over plain data. The table's behaviour —
+ * which rows survive a filter set, in what order they come out, which page a
+ * row lands on — is therefore testable without mounting React or a router.
+ * The React layer (`useTransactionFilters`, `useTransactionSort`,
+ * `TransactionHistory`) only reads the URL, calls into this module, and renders
+ * the result.
+ *
+ * Two properties are load-bearing and easy to lose in a refactor:
+ *
+ * - **Total ordering.** `sortTransactions` always ends with an id comparison,
+ *   so a given (rows, sortKeys) pair produces one ordering regardless of the
+ *   input order. Without it, rows that tie on every sort key shuffle between
+ *   renders as the upstream fetch returns them in a different order.
+ * - **Absent values sort last.** A `null` amount or an unparseable timestamp
+ *   goes to the bottom in *both* directions. Reversing "unknown" to the top on
+ *   a descending sort would present missing data as the largest data.
+ */
+
+import type { Transaction, TxStatus, TxType } from "./transactionApi";
+
+export type { TxStatus, TxType } from "./transactionApi";
+
+// ---------------------------------------------------------------------------
+// Filter value domains
+// ---------------------------------------------------------------------------
+
+export const VALID_TX_TYPES = [
+  "deposit",
+  "withdrawal",
+  "transfer",
+  "trade",
+] as const satisfies readonly TxType[];
+
+export const VALID_TX_STATUSES = [
+  "pending",
+  "completed",
+  "failed",
+] as const satisfies readonly TxStatus[];
+
+/** Relative date shortcuts offered by the filter panel. */
+export const DATE_PRESET_IDS = ["7d", "30d", "90d", "ytd"] as const;
+export type DatePresetId = (typeof DATE_PRESET_IDS)[number];
+
+/** Number of calendar days each rolling preset covers, today included. */
+const PRESET_DAY_SPAN: Record<Exclude<DatePresetId, "ytd">, number> = {
+  "7d": 7,
+  "30d": 30,
+  "90d": 90,
+};
+
+/**
+ * Parsed filter state. Every field is a plain string or array so the whole
+ * thing round-trips through the URL without a serializer.
+ *
+ * An empty string or empty array always means "this filter is not applied",
+ * never "match nothing".
+ */
+export interface TransactionFilters {
+  /** Free-text search over type, status, asset and hash. */
+  search: string;
+  /** Asset code to match exactly (case-insensitive), or "" for all. */
+  asset: string;
+  /** Active type filters — empty array means "all". */
+  types: TxType[];
+  /** Active status filters — empty array means "all". */
+  statuses: TxStatus[];
+  /** Inclusive lower bound as `YYYY-MM-DD`, or "". */
+  dateFrom: string;
+  /** Inclusive upper bound as `YYYY-MM-DD`, or "". */
+  dateTo: string;
+  /** Inclusive minimum amount, or "". */
+  amountMin: string;
+  /** Inclusive maximum amount, or "". */
+  amountMax: string;
+}
+
+export const EMPTY_TRANSACTION_FILTERS: TransactionFilters = {
+  search: "",
+  asset: "",
+  types: [],
+  statuses: [],
+  dateFrom: "",
+  dateTo: "",
+  amountMin: "",
+  amountMax: "",
+};
+
+// ---------------------------------------------------------------------------
+// Sorting
+// ---------------------------------------------------------------------------
+
+/**
+ * Fields the table can sort by. `asset` and `hash` are deliberately absent:
+ * alphabetising an asset code or a hash tells a user nothing they came to the
+ * page to learn.
+ */
+export const SORTABLE_FIELDS = ["date", "amount", "type", "status"] as const;
+export type SortField = (typeof SORTABLE_FIELDS)[number];
+
+export type SortDirection = "asc" | "desc";
+
+export interface SortKey {
+  field: SortField;
+  direction: SortDirection;
+}
+
+/**
+ * Cap on simultaneous sort keys. Three is the point past which the ordering
+ * stops being explicable from the header row alone.
+ */
+export const MAX_SORT_KEYS = 3;
+
+/** Applied when no sort is configured: newest activity first. */
+export const DEFAULT_SORT_KEYS: readonly SortKey[] = [
+  { field: "date", direction: "desc" },
+];
+
+/**
+ * Direction a field gets on its first click. Quantities are more useful
+ * largest-first; categories read better in their natural order.
+ */
+export const DEFAULT_SORT_DIRECTION: Record<SortField, SortDirection> = {
+  date: "desc",
+  amount: "desc",
+  type: "asc",
+  status: "asc",
+};
+
+/**
+ * Lifecycle order, not alphabetical order. Sorting by status exists so a user
+ * can surface transactions that still need attention; `completed, failed,
+ * pending` would bury the pending ones in the middle.
+ */
+export const STATUS_ORDER: Record<TxStatus, number> = {
+  pending: 0,
+  completed: 1,
+  failed: 2,
+};
+
+/** Money-in before money-out, then the rarer kinds. */
+export const TYPE_ORDER: Record<TxType, number> = {
+  deposit: 0,
+  withdrawal: 1,
+  transfer: 2,
+  trade: 3,
+};
+
+/**
+ * Narrows an arbitrary column id to a sortable field. Exported because the
+ * table components pass column ids as plain strings — they are shared with
+ * tables that have entirely different fields.
+ */
+export function isSortField(value: string): value is SortField {
+  return (SORTABLE_FIELDS as readonly string[]).includes(value);
+}
+
+function isSortDirection(value: string): value is SortDirection {
+  return value === "asc" || value === "desc";
+}
+
+/**
+ * Reads `date:desc,amount:asc` into sort keys, dropping anything unknown.
+ *
+ * The value comes from the URL, so it is untrusted: unknown fields and
+ * directions are discarded, a repeated field keeps only its first occurrence
+ * (a field cannot be sorted two ways at once), and the list is truncated to
+ * {@link MAX_SORT_KEYS}.
+ */
+export function parseSortParam(raw: string | null | undefined): SortKey[] {
+  if (!raw) return [];
+
+  const keys: SortKey[] = [];
+  const seen = new Set<SortField>();
+
+  for (const segment of raw.split(",")) {
+    const [rawField, rawDirection = ""] = segment.split(":");
+    const field = rawField.trim().toLowerCase();
+    if (!isSortField(field) || seen.has(field)) continue;
+
+    const direction = rawDirection.trim().toLowerCase();
+    keys.push({
+      field,
+      direction: isSortDirection(direction)
+        ? direction
+        : DEFAULT_SORT_DIRECTION[field],
+    });
+    seen.add(field);
+
+    if (keys.length === MAX_SORT_KEYS) break;
+  }
+
+  return keys;
+}
+
+/** Inverse of {@link parseSortParam}. Returns "" for an empty key list. */
+export function serializeSortParam(keys: readonly SortKey[]): string {
+  return keys.map((key) => `${key.field}:${key.direction}`).join(",");
+}
+
+/**
+ * Reads the single-column `sortBy` / `direction` params the table used before
+ * multi-column sort existed, so older bookmarks and shared links still land on
+ * the ordering they were saved with.
+ */
+export function parseLegacySortParams(
+  rawField: string | null | undefined,
+  rawDirection: string | null | undefined,
+): SortKey[] {
+  const field = (rawField ?? "").trim().toLowerCase();
+  if (!isSortField(field)) return [];
+
+  const direction = (rawDirection ?? "").trim().toLowerCase();
+  return [
+    {
+      field,
+      direction: isSortDirection(direction)
+        ? direction
+        : DEFAULT_SORT_DIRECTION[field],
+    },
+  ];
+}
+
+function flip(direction: SortDirection): SortDirection {
+  return direction === "asc" ? "desc" : "asc";
+}
+
+/**
+ * Advances the sort state for a header activation.
+ *
+ * A plain activation replaces the whole sort with the clicked field and cycles
+ * it through `default direction → opposite → off`. Landing on "off" returns an
+ * empty list, which the sorter reads as {@link DEFAULT_SORT_KEYS} — a user can
+ * always get back to the default ordering by clicking the same header again.
+ *
+ * An additive activation (shift-click) instead appends the field as a
+ * lower-priority tiebreaker, leaving the existing keys and their order alone.
+ *
+ * Returns the **same array reference** when nothing changed — currently only
+ * when an additive activation is refused because {@link MAX_SORT_KEYS} is
+ * already reached. Callers use reference equality to tell "rejected" from
+ * "applied" and announce the refusal instead of silently dropping the click.
+ */
+export function toggleSortKey(
+  keys: readonly SortKey[],
+  field: SortField,
+  options: { additive?: boolean } = {},
+): SortKey[] {
+  const existingIndex = keys.findIndex((key) => key.field === field);
+
+  if (options.additive) {
+    if (existingIndex === -1) {
+      if (keys.length >= MAX_SORT_KEYS) return keys as SortKey[];
+      return [...keys, { field, direction: DEFAULT_SORT_DIRECTION[field] }];
+    }
+
+    const existing = keys[existingIndex];
+    // Third activation drops this key rather than cycling forever, so an
+    // accidental shift-click is undoable with another shift-click.
+    if (existing.direction !== DEFAULT_SORT_DIRECTION[field]) {
+      return keys.filter((key) => key.field !== field);
+    }
+
+    const next = [...keys];
+    next[existingIndex] = { field, direction: flip(existing.direction) };
+    return next;
+  }
+
+  const isOnlyKey = keys.length === 1 && existingIndex === 0;
+  if (!isOnlyKey) {
+    return [{ field, direction: DEFAULT_SORT_DIRECTION[field] }];
+  }
+
+  const current = keys[0];
+  if (current.direction === DEFAULT_SORT_DIRECTION[field]) {
+    return [{ field, direction: flip(current.direction) }];
+  }
+
+  return [];
+}
+
+/** Drops a field from the sort, keeping the order of the remaining keys. */
+export function removeSortKey(
+  keys: readonly SortKey[],
+  field: SortField,
+): SortKey[] {
+  return keys.filter((key) => key.field !== field);
+}
+
+/**
+ * Sets one key's direction. Returns the same reference when the field is not
+ * part of the sort, or already points that way.
+ */
+export function setSortKeyDirection(
+  keys: readonly SortKey[],
+  field: SortField,
+  direction: SortDirection,
+): SortKey[] {
+  const index = keys.findIndex((key) => key.field === field);
+  if (index === -1 || keys[index].direction === direction) {
+    return keys as SortKey[];
+  }
+
+  const next = [...keys];
+  next[index] = { field, direction };
+  return next;
+}
+
+/**
+ * Moves a key up or down the priority list. Returns the same reference when
+ * the move would fall off either end, so a disabled control and a no-op call
+ * agree.
+ */
+export function moveSortKey(
+  keys: readonly SortKey[],
+  field: SortField,
+  offset: number,
+): SortKey[] {
+  const index = keys.findIndex((key) => key.field === field);
+  if (index === -1 || offset === 0) return keys as SortKey[];
+
+  const target = index + offset;
+  if (target < 0 || target >= keys.length) return keys as SortKey[];
+
+  const next = [...keys];
+  const [moved] = next.splice(index, 1);
+  next.splice(target, 0, moved);
+  return next;
+}
+
+/**
+ * The value a field sorts on, or `null` when the row carries no usable value.
+ * `null` is what drives the sorts-last rule in {@link compareTransactions}.
+ */
+function sortValue(row: Transaction, field: SortField): number | string | null {
+  switch (field) {
+    case "date": {
+      const parsed = Date.parse(row.timestamp);
+      return Number.isNaN(parsed) ? null : parsed;
+    }
+    case "amount": {
+      if (row.amount === null) return null;
+      const parsed = Number.parseFloat(row.amount);
+      return Number.isFinite(parsed) ? parsed : null;
+    }
+    case "type":
+      return TYPE_ORDER[row.type] ?? Number.MAX_SAFE_INTEGER;
+    case "status":
+      return STATUS_ORDER[row.status] ?? Number.MAX_SAFE_INTEGER;
+  }
+}
+
+/**
+ * Compares two rows by every sort key in priority order, falling back to id.
+ *
+ * The id fallback is what makes the ordering total: two rows that tie on all
+ * keys still have a fixed relative position, so the table does not reshuffle
+ * equal rows when the data is refetched in a different order.
+ */
+export function compareTransactions(
+  left: Transaction,
+  right: Transaction,
+  keys: readonly SortKey[],
+): number {
+  for (const key of keys) {
+    const leftValue = sortValue(left, key.field);
+    const rightValue = sortValue(right, key.field);
+
+    // Absent values sink to the bottom in both directions.
+    if (leftValue === null || rightValue === null) {
+      if (leftValue === rightValue) continue;
+      return leftValue === null ? 1 : -1;
+    }
+
+    if (leftValue === rightValue) continue;
+
+    const ascending = leftValue < rightValue ? -1 : 1;
+    return key.direction === "asc" ? ascending : -ascending;
+  }
+
+  return left.id.localeCompare(right.id);
+}
+
+/**
+ * Returns a new sorted array; never mutates the input.
+ *
+ * An empty key list means "no explicit sort" and falls back to
+ * {@link DEFAULT_SORT_KEYS} rather than leaving the rows in fetch order.
+ */
+export function sortTransactions(
+  rows: readonly Transaction[],
+  keys: readonly SortKey[] = DEFAULT_SORT_KEYS,
+): Transaction[] {
+  const effectiveKeys = keys.length > 0 ? keys : DEFAULT_SORT_KEYS;
+  return [...rows].sort((left, right) =>
+    compareTransactions(left, right, effectiveKeys),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Date presets
+// ---------------------------------------------------------------------------
+
+function toUtcDateString(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+/**
+ * Turns a relative preset into the absolute `YYYY-MM-DD` range it means at
+ * `now`. `now` is a parameter rather than a `new Date()` call so the mapping is
+ * deterministic and testable, and so the caller decides when "today" is read.
+ *
+ * Boundaries are UTC calendar days, matching {@link filterTransactions}.
+ */
+export function resolveDatePreset(
+  preset: DatePresetId,
+  now: Date,
+): { dateFrom: string; dateTo: string } {
+  const dateTo = toUtcDateString(now);
+
+  if (preset === "ytd") {
+    const yearStart = new Date(Date.UTC(now.getUTCFullYear(), 0, 1));
+    return { dateFrom: toUtcDateString(yearStart), dateTo };
+  }
+
+  // Inclusive of today, so "7d" spans today and the six days before it.
+  const start = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+  );
+  start.setUTCDate(start.getUTCDate() - (PRESET_DAY_SPAN[preset] - 1));
+  return { dateFrom: toUtcDateString(start), dateTo };
+}
+
+/**
+ * Which preset, if any, the current date range corresponds to at `now`.
+ *
+ * Applying a preset writes absolute dates into the URL rather than the preset
+ * name, so that a shared link keeps the range it was shared with instead of
+ * drifting with the reader's clock. Highlighting the matching button is then a
+ * derivation rather than a second copy of the state that could disagree — and
+ * a range stops being highlighted exactly when it stops meaning "the last 7
+ * days".
+ */
+export function matchDatePreset(
+  filters: Pick<TransactionFilters, "dateFrom" | "dateTo">,
+  now: Date,
+): DatePresetId | null {
+  if (!filters.dateFrom || !filters.dateTo) return null;
+
+  for (const preset of DATE_PRESET_IDS) {
+    const resolved = resolveDatePreset(preset, now);
+    if (
+      resolved.dateFrom === filters.dateFrom &&
+      resolved.dateTo === filters.dateTo
+    ) {
+      return preset;
+    }
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Filter validation
+// ---------------------------------------------------------------------------
+
+export type FilterIssueCode = "dateRangeInverted" | "amountRangeInverted";
+
+export interface FilterIssue {
+  /** Which range is contradictory, for placing the message next to it. */
+  range: "date" | "amount";
+  code: FilterIssueCode;
+}
+
+/**
+ * Reports ranges whose bounds cross over, e.g. a minimum above the maximum.
+ *
+ * Such a range can only match zero rows. An empty table with no explanation
+ * reads as "you have no transactions", which is a different and alarming
+ * claim, so {@link filterTransactions} skips a contradictory range and the UI
+ * shows the issue instead.
+ */
+export function validateTransactionFilters(
+  filters: TransactionFilters,
+): FilterIssue[] {
+  const issues: FilterIssue[] = [];
+
+  if (filters.dateFrom && filters.dateTo && filters.dateFrom > filters.dateTo) {
+    issues.push({ range: "date", code: "dateRangeInverted" });
+  }
+
+  if (filters.amountMin !== "" && filters.amountMax !== "") {
+    const min = Number.parseFloat(filters.amountMin);
+    const max = Number.parseFloat(filters.amountMax);
+    if (Number.isFinite(min) && Number.isFinite(max) && min > max) {
+      issues.push({ range: "amount", code: "amountRangeInverted" });
+    }
+  }
+
+  return issues;
+}
+
+// ---------------------------------------------------------------------------
+// Filtering
+// ---------------------------------------------------------------------------
+
+/** Splits a query into terms; every term must match (AND, not OR). */
+function searchTerms(search: string): string[] {
+  return search.trim().toLowerCase().split(/\s+/).filter(Boolean);
+}
+
+/** The haystack a search term is tested against. */
+function searchableText(row: Transaction): string {
+  return [row.type, row.status, row.asset ?? "", row.transactionHash]
+    .join(" ")
+    .toLowerCase();
+}
+
+function startOfUtcDay(date: string): number {
+  return Date.parse(`${date}T00:00:00.000Z`);
+}
+
+function endOfUtcDay(date: string): number {
+  return Date.parse(`${date}T23:59:59.999Z`);
+}
+
+function numericAmount(row: Transaction): number | null {
+  if (row.amount === null) return null;
+  const parsed = Number.parseFloat(row.amount);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * Applies every filter to `rows` and returns the survivors, in input order.
+ *
+ * Notable rules:
+ *
+ * - **Date bounds are UTC calendar days**, inclusive at both ends. Anchoring
+ *   to UTC rather than the viewer's timezone means a shared link selects the
+ *   same transactions for the sender and the recipient.
+ * - **A bounded amount range excludes rows with no amount.** A row whose
+ *   amount is unknown cannot be shown to satisfy "at least 100"; letting it
+ *   through would overstate what the filtered set contains.
+ * - **A contradictory range is skipped**, not applied — see
+ *   {@link validateTransactionFilters}.
+ */
+export function filterTransactions(
+  rows: readonly Transaction[],
+  filters: TransactionFilters,
+): Transaction[] {
+  const issues = validateTransactionFilters(filters);
+  const skipDateRange = issues.some((issue) => issue.range === "date");
+  const skipAmountRange = issues.some((issue) => issue.range === "amount");
+
+  const terms = searchTerms(filters.search);
+  const asset = filters.asset.trim().toLowerCase();
+
+  const fromBound =
+    !skipDateRange && filters.dateFrom ? startOfUtcDay(filters.dateFrom) : null;
+  const toBound =
+    !skipDateRange && filters.dateTo ? endOfUtcDay(filters.dateTo) : null;
+
+  const min =
+    !skipAmountRange && filters.amountMin !== ""
+      ? Number.parseFloat(filters.amountMin)
+      : null;
+  const max =
+    !skipAmountRange && filters.amountMax !== ""
+      ? Number.parseFloat(filters.amountMax)
+      : null;
+  const hasMin = min !== null && Number.isFinite(min);
+  const hasMax = max !== null && Number.isFinite(max);
+
+  return rows.filter((row) => {
+    if (terms.length > 0) {
+      const haystack = searchableText(row);
+      if (!terms.every((term) => haystack.includes(term))) return false;
+    }
+
+    if (filters.types.length > 0 && !filters.types.includes(row.type)) {
+      return false;
+    }
+
+    if (filters.statuses.length > 0 && !filters.statuses.includes(row.status)) {
+      return false;
+    }
+
+    if (asset && (row.asset ?? "").trim().toLowerCase() !== asset) {
+      return false;
+    }
+
+    if (fromBound !== null || toBound !== null) {
+      const timestamp = Date.parse(row.timestamp);
+      // A row with no readable date cannot be placed in a date range.
+      if (Number.isNaN(timestamp)) return false;
+      if (fromBound !== null && timestamp < fromBound) return false;
+      if (toBound !== null && timestamp > toBound) return false;
+    }
+
+    if (hasMin || hasMax) {
+      const amount = numericAmount(row);
+      if (amount === null) return false;
+      if (hasMin && amount < (min as number)) return false;
+      if (hasMax && amount > (max as number)) return false;
+    }
+
+    return true;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Active filter summary
+// ---------------------------------------------------------------------------
+
+/**
+ * Which filter a summary chip belongs to. `type` and `status` chips also carry
+ * a `value`, because those filters hold several selections and each is removed
+ * on its own.
+ */
+export type ActiveFilterKind =
+  | "search"
+  | "type"
+  | "status"
+  | "asset"
+  | "dateFrom"
+  | "dateTo"
+  | "amountMin"
+  | "amountMax";
+
+export interface ActiveFilterDescriptor {
+  /** Stable key for React lists and for identifying a chip in tests. */
+  id: string;
+  kind: ActiveFilterKind;
+  /** Raw value to display, and to remove for multi-value filters. */
+  value: string;
+}
+
+/**
+ * Describes every applied filter as one removable chip.
+ *
+ * Returns data, not markup or copy: the labels are translated in the component
+ * so this module stays free of i18n and rendering concerns.
+ */
+export function describeActiveFilters(
+  filters: TransactionFilters,
+): ActiveFilterDescriptor[] {
+  const chips: ActiveFilterDescriptor[] = [];
+
+  if (filters.search.trim()) {
+    chips.push({ id: "search", kind: "search", value: filters.search });
+  }
+
+  for (const type of filters.types) {
+    chips.push({ id: `type:${type}`, kind: "type", value: type });
+  }
+
+  for (const status of filters.statuses) {
+    chips.push({ id: `status:${status}`, kind: "status", value: status });
+  }
+
+  if (filters.asset) {
+    chips.push({ id: "asset", kind: "asset", value: filters.asset });
+  }
+
+  if (filters.dateFrom) {
+    chips.push({ id: "dateFrom", kind: "dateFrom", value: filters.dateFrom });
+  }
+
+  if (filters.dateTo) {
+    chips.push({ id: "dateTo", kind: "dateTo", value: filters.dateTo });
+  }
+
+  if (filters.amountMin !== "") {
+    chips.push({ id: "amountMin", kind: "amountMin", value: filters.amountMin });
+  }
+
+  if (filters.amountMax !== "") {
+    chips.push({ id: "amountMax", kind: "amountMax", value: filters.amountMax });
+  }
+
+  return chips;
+}
+
+/** How many filters are applied, counting each type/status selection once. */
+export function countActiveFilters(filters: TransactionFilters): number {
+  return describeActiveFilters(filters).length;
+}
+
+export function hasActiveTransactionFilters(
+  filters: TransactionFilters,
+): boolean {
+  return countActiveFilters(filters) > 0;
+}
+
+// ---------------------------------------------------------------------------
+// Pagination
+// ---------------------------------------------------------------------------
+
+export interface PaginatedRows<T> {
+  rows: T[];
+  /** Requested page clamped into range, so an out-of-range URL still renders. */
+  page: number;
+  totalItems: number;
+  totalPages: number;
+}
+
+export function paginateRows<T>(
+  rows: readonly T[],
+  page: number,
+  pageSize: number,
+): PaginatedRows<T> {
+  const safePageSize = pageSize > 0 ? Math.floor(pageSize) : 1;
+  const totalItems = rows.length;
+  const totalPages = Math.max(1, Math.ceil(totalItems / safePageSize));
+  const safePage = Math.min(Math.max(1, Math.floor(page) || 1), totalPages);
+  const start = (safePage - 1) * safePageSize;
+
+  return {
+    rows: rows.slice(start, start + safePageSize),
+    page: safePage,
+    totalItems,
+    totalPages,
+  };
+}

--- a/frontend/src/lib/transactionSortLabels.ts
+++ b/frontend/src/lib/transactionSortLabels.ts
@@ -1,0 +1,16 @@
+import type { SortField } from "./transactionQuery";
+
+/**
+ * i18n key for each sortable field's display name.
+ *
+ * The column header copy is reused, so a sort key reads as the column it
+ * orders. Kept out of `transactionQuery` to leave the filter/sort engine free
+ * of presentation concerns, and out of the component modules so both the sort
+ * panel and the page can import it without breaking fast refresh.
+ */
+export const SORT_FIELD_LABEL_KEY: Record<SortField, string> = {
+  date: "txHistory.dateHeader",
+  amount: "txHistory.amountHeader",
+  type: "txHistory.typeHeader",
+  status: "txHistory.statusHeader",
+};

--- a/frontend/src/pages/TransactionHistory.test.tsx
+++ b/frontend/src/pages/TransactionHistory.test.tsx
@@ -1021,3 +1021,587 @@ describe("TransactionHistory — detail drawer", () => {
     expect(row).toHaveClass("data-table-row--selected");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Advanced sort — multi-column ordering, URL sync, announcements
+// ---------------------------------------------------------------------------
+
+/** Rows that tie on status so a secondary key has something to break. */
+function makeSortFixtures(): Transaction[] {
+  return [
+    makeTransaction({
+      id: "a",
+      status: "completed",
+      amount: "10",
+      timestamp: "2026-01-01T00:00:00Z",
+      transactionHash: "aaa0000000000000000000000000000000000000",
+    }),
+    makeTransaction({
+      id: "b",
+      status: "pending",
+      amount: "5",
+      timestamp: "2026-02-01T00:00:00Z",
+      transactionHash: "bbb0000000000000000000000000000000000000",
+    }),
+    makeTransaction({
+      id: "c",
+      status: "completed",
+      amount: "50",
+      timestamp: "2026-03-01T00:00:00Z",
+      transactionHash: "ccc0000000000000000000000000000000000000",
+    }),
+    makeTransaction({
+      id: "d",
+      status: "pending",
+      amount: "80",
+      timestamp: "2026-04-01T00:00:00Z",
+      transactionHash: "ddd0000000000000000000000000000000000000",
+    }),
+  ];
+}
+
+/** Hash cell text, in the order the table renders it. */
+function renderedHashPrefixes(): string[] {
+  const table = screen.getByRole("table");
+  return within(table)
+    .getAllByRole("link")
+    .map((link) => link.getAttribute("title")?.slice(0, 3) ?? "");
+}
+
+function renderAt(initialEntries: string[], walletAddress = WALLET) {
+  return render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <QueryClientProvider
+        client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+      >
+        <ToastProvider>
+          <TransactionHistory walletAddress={walletAddress} />
+        </ToastProvider>
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("TransactionHistory — advanced sort", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    mockNetworkConfig.isTestnet = true;
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("defaults to newest first", async () => {
+    mockGetTransactions.mockResolvedValue(makeSortFixtures());
+
+    renderAt(["/"]);
+
+    await screen.findByRole("table");
+    await waitFor(() =>
+      expect(renderedHashPrefixes()).toEqual(["ddd", "ccc", "bbb", "aaa"]),
+    );
+  });
+
+  it("restores a multi-column ordering from the URL", async () => {
+    mockGetTransactions.mockResolvedValue(makeSortFixtures());
+
+    renderAt(["/?sort=status:asc,amount:desc"]);
+
+    await screen.findByRole("table");
+    // pending before completed (lifecycle order), each group by amount descending
+    await waitFor(() =>
+      expect(renderedHashPrefixes()).toEqual(["ddd", "bbb", "ccc", "aaa"]),
+    );
+  });
+
+  it("still honours the legacy single-column sort params", async () => {
+    mockGetTransactions.mockResolvedValue(makeSortFixtures());
+
+    renderAt(["/?sortBy=amount&direction=asc"]);
+
+    await screen.findByRole("table");
+    await waitFor(() =>
+      expect(renderedHashPrefixes()).toEqual(["bbb", "aaa", "ccc", "ddd"]),
+    );
+  });
+
+  it("sorts amounts numerically rather than as text", async () => {
+    mockGetTransactions.mockResolvedValue([
+      makeTransaction({
+        id: "1",
+        amount: "9",
+        transactionHash: "aaa0000000000000000000000000000000000000",
+      }),
+      makeTransaction({
+        id: "2",
+        amount: "100",
+        transactionHash: "bbb0000000000000000000000000000000000000",
+      }),
+      makeTransaction({
+        id: "3",
+        amount: "20",
+        transactionHash: "ccc0000000000000000000000000000000000000",
+      }),
+    ]);
+
+    renderAt(["/?sort=amount:asc"]);
+
+    await screen.findByRole("table");
+    await waitFor(() =>
+      expect(renderedHashPrefixes()).toEqual(["aaa", "ccc", "bbb"]),
+    );
+  });
+
+  it("marks the sorted column with aria-sort and leaves the others unsorted", async () => {
+    mockGetTransactions.mockResolvedValue(makeSortFixtures());
+
+    renderAt(["/?sort=amount:asc"]);
+
+    await screen.findByRole("table");
+    expect(
+      screen.getByRole("columnheader", { name: /^Amount$/i }),
+    ).toHaveAttribute("aria-sort", "ascending");
+    expect(screen.getByRole("columnheader", { name: /^Type$/i })).toHaveAttribute(
+      "aria-sort",
+      "none",
+    );
+  });
+
+  it("replaces the sort when a header is clicked without a modifier", async () => {
+    mockGetTransactions.mockResolvedValue(makeSortFixtures());
+
+    renderAt(["/?sort=status:asc"]);
+
+    await screen.findByRole("table");
+    fireEvent.click(screen.getByRole("button", { name: /Sort by Amount/i }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("columnheader", { name: /^Amount$/i }),
+      ).toHaveAttribute("aria-sort", "descending"),
+    );
+    expect(screen.getByRole("columnheader", { name: /^Status$/i })).toHaveAttribute(
+      "aria-sort",
+      "none",
+    );
+  });
+
+  it("adds a tiebreaker when a header is shift-clicked, keeping the first key", async () => {
+    mockGetTransactions.mockResolvedValue(makeSortFixtures());
+
+    renderAt(["/?sort=status:asc"]);
+
+    await screen.findByRole("table");
+    fireEvent.click(screen.getByRole("button", { name: /Sort by Amount/i }), {
+      shiftKey: true,
+    });
+
+    await waitFor(() =>
+      expect(renderedHashPrefixes()).toEqual(["ddd", "bbb", "ccc", "aaa"]),
+    );
+    expect(screen.getByRole("columnheader", { name: /^Status$/i })).toHaveAttribute(
+      "aria-sort",
+      "ascending",
+    );
+    expect(screen.getByRole("columnheader", { name: /^Amount$/i })).toHaveAttribute(
+      "aria-sort",
+      "descending",
+    );
+  });
+
+  it("shows sort priority numbers only while more than one column is sorted", async () => {
+    mockGetTransactions.mockResolvedValue(makeSortFixtures());
+
+    renderAt(["/?sort=status:asc,amount:desc"]);
+
+    await screen.findByRole("table");
+    const statusHeader = screen.getByRole("columnheader", { name: /^Status$/i });
+    const amountHeader = screen.getByRole("columnheader", { name: /^Amount$/i });
+    expect(
+      statusHeader.querySelector(".data-table-sort-priority"),
+    ).toHaveTextContent("1");
+    expect(
+      amountHeader.querySelector(".data-table-sort-priority"),
+    ).toHaveTextContent("2");
+
+    // Dropping back to a single key removes the now-meaningless "1".
+    fireEvent.click(screen.getByRole("button", { name: /Sort by Type/i }));
+
+    await waitFor(() =>
+      expect(
+        screen
+          .getByRole("columnheader", { name: /^Type$/i })
+          .querySelector(".data-table-sort-priority"),
+      ).toBeNull(),
+    );
+  });
+
+  it("announces the new ordering, which aria-sort alone does not do", async () => {
+    mockGetTransactions.mockResolvedValue(makeSortFixtures());
+
+    renderAt(["/"]);
+
+    await screen.findByRole("table");
+    fireEvent.click(screen.getByRole("button", { name: /Sort by Amount/i }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Table sorted by Amount Descending/i),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("explains a refused sort instead of appearing to ignore the click", async () => {
+    mockGetTransactions.mockResolvedValue(makeSortFixtures());
+
+    renderAt(["/?sort=date:desc,amount:desc,type:asc"]);
+
+    await screen.findByRole("table");
+    fireEvent.click(screen.getByRole("button", { name: /Sort by Status/i }), {
+      shiftKey: true,
+    });
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Cannot add another sort column/i),
+      ).toBeInTheDocument(),
+    );
+    // The existing three keys are untouched.
+    expect(screen.getByRole("columnheader", { name: /^Status$/i })).toHaveAttribute(
+      "aria-sort",
+      "none",
+    );
+  });
+
+  it("returns to page 1 when the ordering changes", async () => {
+    mockGetTransactions.mockResolvedValue(makeManyTransactions(15));
+
+    renderAt(["/?page=2&pageSize=10"]);
+
+    await screen.findByRole("table");
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { current: "page", name: /Go to page 2/i }),
+      ).toBeInTheDocument(),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Sort by Amount/i }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { current: "page", name: /Go to page 1/i }),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("orders rows with no amount last, in both directions", async () => {
+    mockGetTransactions.mockResolvedValue([
+      makeTransaction({
+        id: "1",
+        amount: null,
+        transactionHash: "aaa0000000000000000000000000000000000000",
+      }),
+      makeTransaction({
+        id: "2",
+        amount: "5",
+        transactionHash: "bbb0000000000000000000000000000000000000",
+      }),
+      makeTransaction({
+        id: "3",
+        amount: "500",
+        transactionHash: "ccc0000000000000000000000000000000000000",
+      }),
+    ]);
+
+    const view = renderAt(["/?sort=amount:asc"]);
+    await screen.findByRole("table");
+    await waitFor(() =>
+      expect(renderedHashPrefixes()).toEqual(["bbb", "ccc", "aaa"]),
+    );
+    view.unmount();
+
+    renderAt(["/?sort=amount:desc"]);
+    await screen.findByRole("table");
+    await waitFor(() =>
+      expect(renderedHashPrefixes()).toEqual(["ccc", "bbb", "aaa"]),
+    );
+  });
+
+  it("edits the ordering through the sort panel", async () => {
+    mockGetTransactions.mockResolvedValue(makeSortFixtures());
+
+    renderAt(["/?sort=status:asc,amount:desc"]);
+
+    await screen.findByRole("table");
+    fireEvent.click(screen.getByRole("button", { name: /Edit how the transaction table is sorted/i }));
+
+    // Promoting amount above status flips which key groups the rows.
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: /Increase sort priority of Amount/i,
+      }),
+    );
+
+    await waitFor(() =>
+      expect(renderedHashPrefixes()).toEqual(["ddd", "ccc", "aaa", "bbb"]),
+    );
+  });
+
+  it("resets to the default ordering from the sort panel", async () => {
+    mockGetTransactions.mockResolvedValue(makeSortFixtures());
+
+    renderAt(["/?sort=amount:asc"]);
+
+    await screen.findByRole("table");
+    fireEvent.click(screen.getByRole("button", { name: /Edit how the transaction table is sorted/i }));
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: /Reset to the default sort order/i,
+      }),
+    );
+
+    await waitFor(() =>
+      expect(renderedHashPrefixes()).toEqual(["ddd", "ccc", "bbb", "aaa"]),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Advanced filters — presets, chips, contradictory ranges
+// ---------------------------------------------------------------------------
+
+describe("TransactionHistory — advanced filters", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    mockNetworkConfig.isTestnet = true;
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("summarises the applied filters as removable chips", async () => {
+    mockGetTransactions.mockResolvedValue([makeTransaction()]);
+
+    renderAt(["/?types=deposit&statuses=completed&asset=USDC"]);
+
+    await screen.findByRole("table");
+    const group = screen.getByRole("group", { name: /Active filters/i });
+    expect(within(group).getByText("Type: Deposit")).toBeInTheDocument();
+    expect(within(group).getByText("Status: Completed")).toBeInTheDocument();
+    expect(within(group).getByText("Asset: USDC")).toBeInTheDocument();
+  });
+
+  it("lifts one filter from a chip and leaves the rest applied", async () => {
+    mockGetTransactions.mockResolvedValue([
+      makeTransaction({ id: "1", type: "deposit", asset: "USDC" }),
+      makeTransaction({
+        id: "2",
+        type: "withdrawal",
+        asset: "XLM",
+        transactionHash: "xlm0000000000000000000000000000000000000",
+      }),
+    ]);
+
+    renderAt(["/?types=deposit&asset=USDC"]);
+
+    await screen.findByRole("table");
+    fireEvent.click(
+      screen.getByRole("button", { name: /Asset: USDC, remove this filter/i }),
+    );
+
+    await waitFor(() =>
+      expect(screen.queryByText("Asset: USDC")).not.toBeInTheDocument(),
+    );
+    // The type filter survives, so the withdrawal stays hidden.
+    expect(screen.getByText("Type: Deposit")).toBeInTheDocument();
+    const table = screen.getByRole("table");
+    expect(within(table).queryAllByText("XLM")).toHaveLength(0);
+  });
+
+  it("removes only the clicked value from a multi-value filter", async () => {
+    mockGetTransactions.mockResolvedValue([makeTransaction()]);
+
+    renderAt(["/?types=deposit,withdrawal"]);
+
+    await screen.findByRole("table");
+    fireEvent.click(
+      screen.getByRole("button", { name: /Type: Deposit, remove this filter/i }),
+    );
+
+    await waitFor(() =>
+      expect(screen.queryByText("Type: Deposit")).not.toBeInTheDocument(),
+    );
+    expect(screen.getByText("Type: Withdrawal")).toBeInTheDocument();
+  });
+
+  it("applies a relative date range as absolute dates, so a shared link cannot drift", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date("2026-07-28T09:30:00Z"));
+    mockGetTransactions.mockResolvedValue([makeTransaction()]);
+
+    renderAt(["/"]);
+
+    await screen.findByRole("table");
+    fireEvent.click(screen.getByRole("button", { name: "Last 7 days" }));
+
+    await waitFor(() =>
+      expect(screen.getByLabelText(/Filter from date/i)).toHaveValue("2026-07-22"),
+    );
+    expect(screen.getByLabelText(/Filter to date/i)).toHaveValue("2026-07-28");
+  });
+
+  it("marks the preset that the current range corresponds to", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date("2026-07-28T09:30:00Z"));
+    mockGetTransactions.mockResolvedValue([makeTransaction()]);
+
+    renderAt(["/?dateFrom=2026-06-29&dateTo=2026-07-28"]);
+
+    await screen.findByRole("table");
+    expect(screen.getByRole("button", { name: "Last 30 days" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
+
+  it("filters by a date range on inclusive UTC day boundaries", async () => {
+    mockGetTransactions.mockResolvedValue([
+      makeTransaction({
+        id: "1",
+        timestamp: "2026-03-15T00:00:00Z",
+        transactionHash: "aaa0000000000000000000000000000000000000",
+      }),
+      makeTransaction({
+        id: "2",
+        timestamp: "2026-03-15T23:59:59Z",
+        transactionHash: "bbb0000000000000000000000000000000000000",
+      }),
+      makeTransaction({
+        id: "3",
+        timestamp: "2026-03-16T00:00:01Z",
+        transactionHash: "ccc0000000000000000000000000000000000000",
+      }),
+    ]);
+
+    renderAt(["/?dateFrom=2026-03-15&dateTo=2026-03-15&sort=date:asc"]);
+
+    await screen.findByRole("table");
+    await waitFor(() => expect(renderedHashPrefixes()).toEqual(["aaa", "bbb"]));
+  });
+
+  it("excludes rows with no amount once an amount bound is set", async () => {
+    mockGetTransactions.mockResolvedValue([
+      makeTransaction({
+        id: "1",
+        amount: null,
+        transactionHash: "aaa0000000000000000000000000000000000000",
+      }),
+      makeTransaction({
+        id: "2",
+        amount: "500",
+        transactionHash: "bbb0000000000000000000000000000000000000",
+      }),
+    ]);
+
+    renderAt(["/?amountMin=100"]);
+
+    await screen.findByRole("table");
+    await waitFor(() => expect(renderedHashPrefixes()).toEqual(["bbb"]));
+  });
+
+  it("explains a contradictory date range and keeps showing the rows", async () => {
+    mockGetTransactions.mockResolvedValue([
+      makeTransaction({ id: "1", asset: "USDC" }),
+    ]);
+
+    renderAt(["/?dateFrom=2026-06-01&dateTo=2026-01-01"]);
+
+    await screen.findByRole("table");
+    expect(
+      screen.getByText(/from date is after the to date/i),
+    ).toBeInTheDocument();
+    // An empty table here would read as "you have no transactions".
+    const table = screen.getByRole("table");
+    expect(within(table).getByText("USDC")).toBeInTheDocument();
+  });
+
+  it("explains a contradictory amount range and keeps showing the rows", async () => {
+    mockGetTransactions.mockResolvedValue([
+      makeTransaction({ id: "1", asset: "USDC", amount: "100" }),
+    ]);
+
+    renderAt(["/?amountMin=500&amountMax=10"]);
+
+    await screen.findByRole("table");
+    expect(
+      screen.getByText(/minimum amount is above the maximum/i),
+    ).toBeInTheDocument();
+    const table = screen.getByRole("table");
+    expect(within(table).getByText("USDC")).toBeInTheDocument();
+  });
+
+  it("narrows rather than widens when the search has several terms", async () => {
+    mockGetTransactions.mockResolvedValue([
+      makeTransaction({
+        id: "1",
+        type: "deposit",
+        asset: "USDC",
+        transactionHash: "aaa0000000000000000000000000000000000000",
+      }),
+      makeTransaction({
+        id: "2",
+        type: "withdrawal",
+        asset: "XLM",
+        transactionHash: "bbb0000000000000000000000000000000000000",
+      }),
+    ]);
+
+    renderAt(["/?search=xlm+withdrawal"]);
+
+    await screen.findByRole("table");
+    await waitFor(() => expect(renderedHashPrefixes()).toEqual(["bbb"]));
+  });
+
+  it("matches the asset filter regardless of case", async () => {
+    mockGetTransactions.mockResolvedValue([
+      makeTransaction({ id: "1", asset: "USDC" }),
+      makeTransaction({
+        id: "2",
+        asset: "XLM",
+        transactionHash: "xlm0000000000000000000000000000000000000",
+      }),
+    ]);
+
+    renderAt(["/?asset=usdc"]);
+
+    await screen.findByRole("table");
+    const table = screen.getByRole("table");
+    await waitFor(() =>
+      expect(within(table).getByText("USDC")).toBeInTheDocument(),
+    );
+    expect(within(table).queryAllByText("XLM")).toHaveLength(0);
+  });
+
+  it("keeps the ordering when a filter changes", async () => {
+    mockGetTransactions.mockResolvedValue(makeSortFixtures());
+
+    renderAt(["/?sort=amount:asc"]);
+
+    await screen.findByRole("table");
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: /Filter by Status Completed/i }),
+    );
+
+    await waitFor(() => expect(renderedHashPrefixes()).toEqual(["aaa", "ccc"]));
+    expect(
+      screen.getByRole("columnheader", { name: /^Amount$/i }),
+    ).toHaveAttribute("aria-sort", "ascending");
+  });
+});

--- a/frontend/src/pages/TransactionHistory.tsx
+++ b/frontend/src/pages/TransactionHistory.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
-import { useSearchParams, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import ApiStatusBanner from "../components/ApiStatusBanner";
 import Badge from "../components/Badge";
 import { DataTable, type DataTableColumn } from "../components/DataTable";
@@ -10,10 +10,17 @@ import {
 import PageHeader from "../components/PageHeader";
 import { SkeletonText } from "../components/Skeleton";
 import TransactionFilterPanel from "../components/TransactionFilterPanel";
+import TransactionSortControl from "../components/TransactionSortControl";
 import TransactionDetailDrawer from "../components/TransactionDetailDrawer";
 import EmptyState from "../components/ui/EmptyState";
 import { Popover } from "../components/ui/Popover";
-import { Activity, Loader2, Wallet, Columns3 } from "../components/icons";
+import {
+  Activity,
+  ArrowUpDown,
+  Loader2,
+  Wallet,
+  Columns3,
+} from "../components/icons";
 import {
   normalizeApiError,
   isValidationError,
@@ -24,11 +31,23 @@ import {
   truncateHash,
   type Transaction,
 } from "../lib/transactionApi";
-import { useClientDataTable } from "../hooks/useClientDataTable";
 import { useDataTableState } from "../hooks/useDataTableState";
 import { useInfiniteScroll } from "../hooks/useInfiniteScroll";
 import { useTransactionFilters } from "../hooks/useTransactionFilters";
+import { useTransactionSort } from "../hooks/useTransactionSort";
 import { useTransactionHistory } from "../hooks/useTransactionData";
+import {
+  describeActiveFilters,
+  filterTransactions,
+  isSortField,
+  matchDatePreset,
+  paginateRows,
+  serializeSortParam,
+  sortTransactions,
+  validateTransactionFilters,
+  type SortKey,
+} from "../lib/transactionQuery";
+import { SORT_FIELD_LABEL_KEY } from "../lib/transactionSortLabels";
 import { getStellarExplorerUrl } from "../lib/security";
 import { networkConfig } from "../config/network";
 
@@ -177,14 +196,14 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({
   const [hasMoreItems, setHasMoreItems] = useState(true);
   const loadMoreLockRef = useRef(false);
 
-  // ── Sort / pagination state (URL-synced via useDataTableState) ──────────
-  const { state, setSearch, setSort, setPage, setPageSize } = useDataTableState(
-    {
-      defaultSortBy: "date",
-      defaultSortDirection: "desc",
-      defaultPageSize: preferredPageSize,
-    },
-  );
+  // ── Pagination state (URL-synced via useDataTableState) ─────────────────
+  // Ordering is owned by useTransactionSort, which supports several sort keys;
+  // this hook keeps page and page size in the URL.
+  const { state, setPage, setPageSize } = useDataTableState({
+    defaultSortBy: "date",
+    defaultSortDirection: "desc",
+    defaultPageSize: preferredPageSize,
+  });
 
   // ── Multi-filter state (URL-synced via useTransactionFilters) ───────────
   const {
@@ -197,89 +216,101 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({
     setDateTo,
     setAmountMin,
     setAmountMax,
+    applyDatePreset,
+    clearDateRange,
+    removeFilter,
     clearAll,
     setAsset,
   } = useTransactionFilters();
 
-  // Keep useDataTableState's search in sync with the filter panel's search
-  // so that useClientDataTable's text-search logic still runs correctly.
-  const [searchParams] = useSearchParams();
+  // ── Multi-column sort state (URL-synced via useTransactionSort) ─────────
+  const {
+    sortKeys,
+    effectiveSortKeys,
+    toggleSort,
+    setSortDirection,
+    removeSort,
+    moveSort,
+    clearSort,
+  } = useTransactionSort();
+
+  // ── Filter → sort → paginate ────────────────────────────────────────────
+  // All three steps are pure functions from `lib/transactionQuery`, so the
+  // table's behaviour is unit-tested there rather than only through the DOM.
+  const filterIssues = React.useMemo(
+    () => validateTransactionFilters(filters),
+    [filters],
+  );
+
+  const filteredRows = React.useMemo(
+    () => filterTransactions(transactions, filters),
+    [transactions, filters],
+  );
+
+  const sortedRows = React.useMemo(
+    () => sortTransactions(filteredRows, effectiveSortKeys),
+    [filteredRows, effectiveSortKeys],
+  );
+
+  const { rows, page, totalItems, totalPages } = React.useMemo(
+    () => paginateRows(sortedRows, state.page, state.pageSize),
+    [sortedRows, state.page, state.pageSize],
+  );
+
+  const activeFilterChips = React.useMemo(
+    () => describeActiveFilters(filters),
+    [filters],
+  );
+
+  // Presets store the absolute dates they resolve to, so the matching button is
+  // highlighted by comparing the range back against "now" rather than by a
+  // second copy of the state.
+  const activeDatePreset = React.useMemo(
+    () => matchDatePreset(filters, new Date()),
+    [filters],
+  );
+
+  // ── Sort announcements ──────────────────────────────────────────────────
+  // The header row conveys sort state visually through arrows and priority
+  // numbers, and to assistive technology through aria-sort — but aria-sort on a
+  // header that is not focused is not announced when the ordering changes. This
+  // live region states the new ordering, and is also where a refused sort
+  // request is explained instead of appearing to do nothing.
+  const [sortAnnouncement, setSortAnnouncement] = useState("");
+
+  const describeSortKeys = useCallback(
+    (keys: readonly SortKey[]) =>
+      keys
+        .map((key) => {
+          const direction =
+            key.direction === "asc" ? t("txSort.ascending") : t("txSort.descending");
+          return `${t(SORT_FIELD_LABEL_KEY[key.field])} ${direction}`;
+        })
+        .join(", "),
+    [t],
+  );
+
+  const sortSignature = serializeSortParam(effectiveSortKeys);
+  const previousSortSignature = useRef(sortSignature);
+
   useEffect(() => {
-    const urlSearch = searchParams.get("search") ?? "";
-    if (urlSearch !== state.search) {
-      setSearch(urlSearch);
-    }
-  }, [searchParams, state.search, setSearch]);
+    if (previousSortSignature.current === sortSignature) return;
+    previousSortSignature.current = sortSignature;
+    setSortAnnouncement(
+      `${t("txSort.announcePrefix")} ${describeSortKeys(effectiveSortKeys)}`,
+    );
+  }, [describeSortKeys, effectiveSortKeys, sortSignature, t]);
 
-  // Client-side filtering is handled by useClientDataTable.
+  const handleSortToggle = useCallback(
+    (columnId: string, additive: boolean) => {
+      // Column ids come from the shared table component as plain strings.
+      if (!isSortField(columnId)) return;
 
-  // ── Client-side filtering ───────────────────────────────────────────────
-  const { rows, sortedRows, page, totalItems, totalPages } = useClientDataTable(
-    {
-      rows: transactions,
-      state,
-      getSearchValue: (row) =>
-        `${row.type} ${row.asset ?? ""} ${row.transactionHash}`,
-      getSortValue: (row, columnId) => {
-        switch (columnId) {
-          case "type":
-            return row.type;
-          case "status":
-            return row.status;
-          case "amount":
-            return row.amount !== null ? parseFloat(row.amount) : 0;
-          case "date":
-            return row.timestamp;
-          default:
-            return row.timestamp;
-        }
-      },
-      filterRow: (row) => {
-        // Multi-type filter (client-side)
-        if (filters.types.length > 0 && !filters.types.includes(row.type)) {
-          return false;
-        }
-
-        // Status filter (client-side)
-        if (
-          filters.statuses.length > 0 &&
-          !filters.statuses.includes(row.status)
-        ) {
-          return false;
-        }
-
-        // Date range
-        if (filters.dateFrom) {
-          const from = new Date(filters.dateFrom);
-          from.setHours(0, 0, 0, 0);
-          if (new Date(row.timestamp) < from) return false;
-        }
-        if (filters.dateTo) {
-          const to = new Date(filters.dateTo);
-          to.setHours(23, 59, 59, 999);
-          if (new Date(row.timestamp) > to) return false;
-        }
-
-        // Amount range (numeric)
-        if (filters.amountMin !== "" && row.amount !== null) {
-          const min = parseFloat(filters.amountMin);
-          const amt = parseFloat(row.amount);
-          if (!isNaN(min) && !isNaN(amt) && amt < min) return false;
-        }
-        if (filters.amountMax !== "" && row.amount !== null) {
-          const max = parseFloat(filters.amountMax);
-          const amt = parseFloat(row.amount);
-          if (!isNaN(max) && !isNaN(amt) && amt > max) return false;
-        }
-
-        // Asset filter (exact match, case-sensitive as stored)
-        if (filters.asset && row.asset !== filters.asset) {
-          return false;
-        }
-
-        return true;
-      },
+      if (!toggleSort(columnId, additive)) {
+        setSortAnnouncement(t("txSort.maxReachedAnnouncement"));
+      }
     },
+    [t, toggleSort],
   );
 
   // Available assets for the asset filter (unique, non-empty)
@@ -305,9 +336,8 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({
   useEffect(() => {
     queueMicrotask(() => setVisibleCount(INFINITE_SCROLL_BATCH_SIZE));
   }, [
-    state.search,
-    state.sortBy,
-    state.sortDirection,
+    filters.search,
+    sortSignature,
     filters.types,
     filters.dateFrom,
     filters.dateTo,
@@ -454,9 +484,8 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({
     emptyMessage,
     isLoading: delayedLoading,
     skeletonRows: state.pageSize,
-    sortBy: state.sortBy,
-    sortDirection: state.sortDirection,
-    onSortChange: setSort,
+    sortKeys: effectiveSortKeys,
+    onSortToggle: handleSortToggle,
     onRowClick: handleRowSelect,
     selectedRowKey: selectedTransaction?.id,
   } as const;
@@ -517,6 +546,12 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({
             onAmountMaxChange={setAmountMax}
             onClearAll={clearAll}
             hasActiveFilters={hasActiveFilters}
+            issues={filterIssues}
+            activeDatePreset={activeDatePreset}
+            onDatePreset={applyDatePreset}
+            onClearDateRange={clearDateRange}
+            activeFilterChips={activeFilterChips}
+            onRemoveFilter={removeFilter}
           />
 
           {/* ── Data table ────────────────────────────────────────── */}
@@ -599,6 +634,35 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({
                 </div>
 
                 <Popover
+                  title={t("txSort.title")}
+                  content={
+                    <TransactionSortControl
+                      sortKeys={sortKeys}
+                      onAdd={(field) => toggleSort(field, true)}
+                      onRemove={removeSort}
+                      onDirectionChange={setSortDirection}
+                      onMove={moveSort}
+                      onClear={clearSort}
+                    />
+                  }
+                >
+                  <button
+                    type="button"
+                    className="btn btn-secondary"
+                    style={{ alignSelf: "flex-end", height: "42px", display: "flex", gap: "8px" }}
+                    aria-label={t("txSort.toggleAria")}
+                  >
+                    <ArrowUpDown size={16} />
+                    {t("txSort.button")}
+                    {sortKeys.length > 1 && (
+                      <span className="tx-sort-count" aria-hidden="true">
+                        {sortKeys.length}
+                      </span>
+                    )}
+                  </button>
+                </Popover>
+
+                <Popover
                   title={t("txHistory.columns.title")}
                   content={
                     <div className="flex flex-col gap-sm" role="group" aria-label={t("txHistory.columns.title")}>
@@ -659,6 +723,10 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({
                   ? `Showing ${infiniteScrollRows.length} of ${sortedRows.length} transactions`
                   : `${totalItems} transactions found`}
             </div>
+
+            <p className="sr-only" role="status" aria-live="polite">
+              {sortAnnouncement}
+            </p>
 
             {viewMode === "infinite" ? (
               /* Infinite Scroll View */

--- a/frontend/src/pages/VaultComparison.test.tsx
+++ b/frontend/src/pages/VaultComparison.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen, fireEvent, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import { MemoryRouter } from "react-router-dom";
 import axe from "axe-core";
 import VaultComparison from "./VaultComparison";
@@ -52,30 +51,7 @@ function metricRowHeader(metric: string): HTMLElement {
   return header;
 }
 
-function LocationProbe() {
-  const location = useLocation();
-  return <div data-testid="location-probe">{`${location.pathname}${location.search}`}</div>;
-}
-
-function renderComparison(initialEntries: string[] = ["/compare"]) {
-  return render(
-    <MemoryRouter initialEntries={initialEntries}>
-      <Routes>
-        <Route path="/compare" element={<VaultComparison />} />
-        <Route path="/" element={<LocationProbe />} />
-      </Routes>
-    </MemoryRouter>,
-  );
-}
-
 describe("VaultComparison", () => {
-  it("renders selected strategies and lets users compare them", () => {
-    renderComparison();
-
-    expect(screen.getByRole("heading", { name: /Compare Vault Strategies/i })).toBeInTheDocument();
-    expect(screen.getByText(/Side-by-side comparison/i)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Franklin BENJI Connector/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Tokenized Treasury Ladder/i })).toBeInTheDocument();
   it("renders the default two-strategy comparison", () => {
     renderComparison();
 
@@ -122,8 +98,6 @@ describe("VaultComparison", () => {
     expect(announcement()).toMatch(/Private Credit Income removed from the comparison/i);
   });
 
-  it("shows the empty state when fewer than two strategies are selected", () => {
-    renderComparison();
   it("blocks selection past the cap and explains why instead of ignoring the click", () => {
     renderComparison("/compare?strategies=benji,treasury-ladder,credit-income");
 
@@ -160,45 +134,6 @@ describe("VaultComparison", () => {
     expect(screen.getByText(/Select at least two strategies/i)).toBeInTheDocument();
   });
 
-  it("does not add a fourth strategy once the max selection is reached", () => {
-    renderComparison();
-
-    fireEvent.click(screen.getByRole("button", { name: /Private Credit Income/i }));
-    expect(screen.getByText(/3 selected/i)).toBeInTheDocument();
-
-    const fourthCard = screen.getByRole("button", { name: /Liquidity Buffer/i });
-    expect(fourthCard).toHaveAttribute("aria-disabled", "true");
-
-    fireEvent.click(fourthCard);
-
-    expect(screen.getByText(/3 selected/i)).toBeInTheDocument();
-    expect(fourthCard).toHaveAttribute("aria-pressed", "false");
-  });
-
-  it("navigates to the deposit tab when allocating to selected strategies", () => {
-    renderComparison();
-
-    fireEvent.click(screen.getByRole("button", { name: /Allocate to selected/i }));
-
-    expect(screen.getByTestId("location-probe")).toHaveTextContent("/?tab=deposit");
-  });
-
-  it("restores the selection from the strategies URL param", () => {
-    renderComparison(["/compare?strategies=benji,credit-income"]);
-
-    expect(screen.getByText(/2 selected/i)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Franklin BENJI Connector/i })).toHaveAttribute("aria-pressed", "true");
-    expect(screen.getByRole("button", { name: /Private Credit Income/i })).toHaveAttribute("aria-pressed", "true");
-    expect(screen.getByRole("button", { name: /Tokenized Treasury Ladder/i })).toHaveAttribute("aria-pressed", "false");
-    expect(screen.getByRole("button", { name: /Liquidity Buffer/i })).toHaveAttribute("aria-pressed", "false");
-  });
-
-  it("highlights the best APY cell in the comparison table", () => {
-    renderComparison(["/compare?strategies=benji,credit-income"]);
-
-    const bestCell = screen.getByRole("table").querySelector('td[data-best="true"]');
-    expect(bestCell).not.toBeNull();
-    expect(bestCell).toHaveTextContent("9.15%");
   it("caps an over-long URL selection", () => {
     renderComparison(
       "/compare?strategies=benji,treasury-ladder,credit-income,liquidity-buffer",

--- a/frontend/src/pages/VaultComparison.tsx
+++ b/frontend/src/pages/VaultComparison.tsx
@@ -1,4 +1,3 @@
-import React, { useMemo, useState } from "react";
 import React, { useCallback, useMemo, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import PageHeader from "../components/PageHeader";
@@ -6,31 +5,6 @@ import Badge from "../components/Badge";
 import EmptyState from "../components/ui/EmptyState";
 import { Check, Layers, ShieldCheck, TrendingUp } from "../components/icons";
 import {
-  MAX_VAULT_COMPARISON_SELECTION,
-  VAULT_STRATEGIES,
-  type VaultStrategyOption,
-} from "../data/vaultStrategies";
-
-const STRATEGIES_PARAM = "strategies";
-
-function parseStrategiesParam(raw: string | null): string[] {
-  if (!raw) return [];
-  const validIds = new Set(VAULT_STRATEGIES.map((strategy) => strategy.id));
-  const seen = new Set<string>();
-  const ids: string[] = [];
-  for (const value of raw.split(",")) {
-    const id = value.trim();
-    if (validIds.has(id) && !seen.has(id)) {
-      seen.add(id);
-      ids.push(id);
-    }
-  }
-  return ids.slice(0, MAX_VAULT_COMPARISON_SELECTION);
-}
-
-function parseApy(apy: string): number {
-  const parsed = Number.parseFloat(apy.replace(/[^\d.-]/g, ""));
-  return Number.isNaN(parsed) ? Number.NEGATIVE_INFINITY : parsed;
   COMPARISON_METRICS,
   MAX_COMPARISON_SELECTION,
   MIN_COMPARISON_SELECTION,
@@ -70,10 +44,6 @@ function flipDirection(direction: SortDirection): SortDirection {
 const VaultComparison: React.FC = () => {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
-  const [selectedIds, setSelectedIds] = useState<string[]>(() => {
-    const fromUrl = parseStrategiesParam(searchParams.get(STRATEGIES_PARAM));
-    return fromUrl.length > 0 ? fromUrl : [VAULT_STRATEGIES[0].id, VAULT_STRATEGIES[1].id];
-  });
   const [announcement, setAnnouncement] = useState("");
 
   // The URL is the single source of truth for selection and ordering, so a
@@ -93,51 +63,6 @@ const VaultComparison: React.FC = () => {
   // `parseSelectionParam` already dropped unknown ids; the type guard keeps the
   // array typed without a non-null assertion.
   const selectedStrategies = useMemo(
-    () => VAULT_STRATEGIES.filter((strategy) => selectedIds.includes(strategy.id)),
-    [selectedIds],
-  );
-
-  const atMaxSelection = selectedIds.length >= MAX_VAULT_COMPARISON_SELECTION;
-
-  const bestApyId = useMemo(() => {
-    if (selectedStrategies.length === 0) return null;
-    return selectedStrategies.reduce((best, strategy) =>
-      parseApy(strategy.apy) > parseApy(best.apy) ? strategy : best,
-    ).id;
-  }, [selectedStrategies]);
-
-  const toggleStrategy = (id: string) => {
-    let next: string[];
-    if (selectedIds.includes(id)) {
-      next = selectedIds.filter((value) => value !== id);
-    } else if (atMaxSelection) {
-      return;
-    } else {
-      next = [...selectedIds, id];
-    }
-
-    setSelectedIds(next);
-    setSearchParams(
-      (params) => {
-        const nextParams = new URLSearchParams(params);
-        if (next.length > 0) {
-          nextParams.set(STRATEGIES_PARAM, next.join(","));
-        } else {
-          nextParams.delete(STRATEGIES_PARAM);
-        }
-        return nextParams;
-      },
-      { replace: true },
-    );
-  };
-
-  const comparisonRows = [
-    { label: "APY", value: (strategy: VaultStrategyOption) => strategy.apy },
-    { label: "Liquidity", value: (strategy: VaultStrategyOption) => strategy.liquidity },
-    { label: "Lockup", value: (strategy: VaultStrategyOption) => strategy.lockup },
-    { label: "Risk", value: (strategy: VaultStrategyOption) => strategy.risk },
-    { label: "Settlement", value: (strategy: VaultStrategyOption) => strategy.settlement },
-  ];
     () =>
       selectedIds
         .map((id) => findStrategy(id))
@@ -251,7 +176,6 @@ const VaultComparison: React.FC = () => {
         ]}
       />
 
-      <div style={{ display: "grid", gap: "20px", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", marginBottom: "24px" }}>
       {/* Selection and ordering changes are non-visual for screen readers, so
           every mutation is mirrored here. */}
       <p
@@ -283,7 +207,6 @@ const VaultComparison: React.FC = () => {
               type="button"
               onClick={() => handleToggle(strategy)}
               aria-pressed={selected}
-              aria-disabled={!selected && atMaxSelection ? true : undefined}
               aria-disabled={blocked || undefined}
               title={
                 blocked
@@ -301,8 +224,6 @@ const VaultComparison: React.FC = () => {
                   ? "rgba(0, 240, 255, 0.08)"
                   : "rgba(255, 255, 255, 0.03)",
                 color: "inherit",
-                cursor: !selected && atMaxSelection ? "not-allowed" : "pointer",
-                opacity: !selected && atMaxSelection ? 0.6 : 1,
                 cursor: blocked ? "not-allowed" : "pointer",
                 display: "flex",
                 flexDirection: "column",
@@ -433,12 +354,6 @@ const VaultComparison: React.FC = () => {
                 row are marked.
               </p>
             </div>
-            <div className="flex items-center gap-sm">
-              <button type="button" className="btn btn-secondary" onClick={() => navigate("/")}>Back to vault</button>
-              <button type="button" className="btn btn-primary" onClick={() => navigate("/?tab=deposit")}>
-                Allocate to selected
-              </button>
-            </div>
             <div className="flex items-center gap-sm" style={{ flexWrap: "wrap" }}>
               <button type="button" className="btn btn-secondary" onClick={handleReset}>
                 Reset
@@ -500,36 +415,6 @@ const VaultComparison: React.FC = () => {
                 </tr>
               </thead>
               <tbody>
-                {comparisonRows.map((row) => (
-                  <tr key={row.label}>
-                    <th scope="row" style={{ textAlign: "left", padding: "12px", color: "var(--text-secondary)", fontWeight: 600 }}>
-                      {row.label}
-                    </th>
-                    {selectedStrategies.map((strategy) => {
-                      const isBestApy = row.label === "APY" && strategy.id === bestApyId;
-
-                      return (
-                        <td
-                          key={`${strategy.id}-${row.label}`}
-                          data-best={isBestApy ? "true" : undefined}
-                          style={{
-                            padding: "12px",
-                            borderTop: "1px solid var(--border-glass)",
-                            ...(isBestApy
-                              ? {
-                                  color: "var(--accent-green)",
-                                  fontWeight: 700,
-                                  background: "rgba(0, 255, 163, 0.08)",
-                                }
-                              : {}),
-                          }}
-                        >
-                          {row.value(strategy)}
-                        </td>
-                      );
-                    })}
-                  </tr>
-                ))}
                 {COMPARISON_METRICS.map((metric) => {
                   const isSorted = sortMetric?.id === metric.id;
                   const bestIds = bestByMetric.get(metric.id) ?? [];


### PR DESCRIPTION
The transaction table could sort by one column and filter by six criteria, but the rules lived inside the page component as a `filterRow` closure and a `getSortValue` switch, so none of it was testable without mounting React — and several of the rules were wrong in ways an empty table does not explain.

Extracts the pipeline into `lib/transactionQuery.ts` as three pure functions (`filterTransactions` → `sortTransactions` → `paginateRows`) and builds the advanced capability on top of it.

Multi-column sort (`useTransactionSort`, `?sort=status:asc,amount:desc`):

- Up to three keys in priority order; later keys only decide rows that tie on every earlier key. Header click replaces the sort and cycles `default → opposite → off`; shift-click appends a tiebreaker.
- The ordering is a total order — comparison ends with an id comparison — so rows that tie on every key keep a fixed position instead of reshuffling when the upstream fetch returns them in a different sequence.
- Absent values (`null` amount, unparseable timestamp) sort last in *both* directions. Reversing "unknown" to the top on a descending sort would present missing data as the largest data.
- Status orders `pending → completed → failed` and type orders `deposit → withdrawal → transfer → trade`, rather than alphabetically: sorting by status exists to surface what still needs attention.
- `sort` is written for every explicit ordering and absent on the default, and the primary key is mirrored into the legacy `sortBy`/`direction` params so older links keep working and `useDataTableState` — which rewrites those on every page change — cannot contradict it. A legacy pair that merely restates the default reads as "no explicit sort", so paging is not mistaken for a sort choice.
- `TransactionSortControl` exposes the same capability as ordinary buttons (flip, reorder, remove, reset) and names each key's direction in words. Shift-click is a pointer gesture that has to be known in advance.

Advanced filtering:

- Relative date presets (7/30/90 days, YTD) resolve to absolute dates written into the URL, so a shared link keeps the range it was shared with instead of drifting with the reader's clock. The highlighted preset is derived by comparing the range back against "now", not stored as a second copy.
- Contradictory ranges (`dateFrom` after `dateTo`, `amountMin` above `amountMax`) are reported and *skipped* rather than applied. Such a range can only match zero rows, and an unexplained empty table reads as "you have no transactions" — a different and alarming claim.
- Removable chips summarise every applied filter, one per type/status selection, and sit outside the panel's collapsible body: collapsing the panel must not hide that rows are being filtered out.

Fixes in the filter rules, each covered by a test:

- Date bounds now anchor to inclusive UTC calendar days. They previously parsed `YYYY-MM-DD` as UTC midnight and then called `setHours` in local time, so which transactions a shared link selected depended on the reader's timezone.
- A bounded amount range now excludes rows with no amount. They previously passed every bound, so a row of unknown value was reported as satisfying "at least 100".
- Search matches status as well as type/asset/hash, and multiple terms are ANDed so adding a term narrows rather than widens.
- The asset filter is case-insensitive; `?asset=usdc` matched nothing before.

Accessibility: a polite live region announces each new ordering (`aria-sort` on an unfocused header is not announced when it changes) and explains a refused sort at the three-key cap; priority badges carry numbers rather than relying on colour; range messages are wired to their inputs with `aria-describedby`.

`DataTable`/`VirtualizedDataTable` gain optional `sortKeys` and `onSortToggle` props resolved through a shared `getColumnSortState`; tables still passing `sortBy`/`sortDirection`, such as Portfolio, are unaffected.

Docs: frontend/docs/TRANSACTION_HISTORY_FILTER_SORT.md, cross-referenced from docs/FRONTEND_STATE_MANAGEMENT.md.

Tests: 177 added (frontend suite 776 → 953). The 3 pre-existing failures in src/tests/routing.test.tsx and the collection failure in src/pages/VaultComparison.test.tsx are unchanged — both stem from truncated files on main that this branch deliberately leaves alone.

Closes #1035


Claude-Session: https://claude.ai/code/session_011j8qYZDC5K423bBzHVmfh2

# Pull Request Template

## 📋 Description
Add a complete environment variable matrix (`docs/ENV_VARIABLE_MATRIX.md`) covering every env var consumed across the backend and frontend, with defaults, required flags, and production recommendations. Update `README.md` and `ENV_QUICK_REFERENCE.md` to link to the new document.

## 🔗 Type of Change
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📚 Documentation update
- [ ] 🔒 Security improvement

---

## 🔒 SECURITY REVIEW (⭐ MANDATORY FOR SMART CONTRACT CHANGES)

**For all smart contract code changes, complete the following checklist.**

See [`docs/SECURITY_CHECKLIST.md`](/docs/SECURITY_CHECKLIST.md) for detailed guidance.

### Required: Security Checklist Sign-Off
- [ ] **I have reviewed this PR against the Internal Security Checklist** (`docs/SECURITY_CHECKLIST.md`)
  - [ ] Reentrancy: Verified Checks-Effects-Interactions (CEI) pattern
  - [ ] Access Control: Confirmed all sensitive functions are protected (`onlyOwner`, `onlyRole()`, etc.)
  - [ ] Input Validation: Validated all parameters have appropriate bounds checks
  - [ ] Unchecked Returns: All external calls have return value checks (`require(success, ...)`)
  - [ ] Gas Limits: No unbounded loops or potential DOS vectors
  
  **If any checkbox cannot be verified, explain below:**
  ```
  N/A — this PR contains only documentation changes. No smart contract code was modified.
  ```

### Slither Static Analysis Results
- [ ] Ran Slither locally: `slither . --config-file slither.config.json`
  - **Result**: ✅ No High/Medium findings OR 🟡 Documented false positives (see below)
  
- [ ] GitHub Actions Slither workflow passed:
  - 🟢 All High/Medium findings fixed OR
  - 🟡 All false positives documented with FP references
  
  **If this PR has security findings, document them below:**
  ```
  N/A — documentation-only PR. No contract or runtime code changed.
  ```

### Handling Security Findings

#### Option A: Fixed in This PR ✅
- [ ] Vulnerability identified and resolved
- [ ] Test case added to verify fix
- [ ] Explain fix below:
  ```
  N/A
  ```

#### Option B: False Positive 🟡
- [ ] Identified as false positive (tool limitation or misleading check)
- [ ] Added entry to `contracts/.false-positives.md` with:
  - Detector rule name
  - Technical reasoning (3+ sentences why it's safe)
  - Evidence (code snippet, test case, or reference)
- [ ] Reference number (e.g., FP-001):
  ```
  N/A
  ```
- [ ] Inline suppression added to code:
  ```solidity
  // slither-disable-next-line <detector-name>
  // Reason: [one-line reason]
  ```

#### Option C: Accepted Risk ⚠️
- [ ] Acknowledged as low-priority style issue (naming conventions, etc.)
- [ ] Added to Slither exclusions
- [ ] Explain below:
  ```
  N/A
  ```

---

## 📝 Testing

### Functional Testing
- [x] Unit tests added/updated for changes
- [x] Integration tests passing
- [x] Manual testing completed and documented below:
  ```
  - Verified all variable names, defaults, and required flags against source files:
    backend/src/index.ts, rateLimiter.ts, auth.ts, tracing.ts
  - Cross-checked every .env.example, .env.local.example, .env.production.example
    in both backend/ and frontend/
  - Confirmed links in README.md and ENV_QUICK_REFERENCE.md resolve correctly
  - No runtime code changed; no functional regression possible
  ```

### Security Testing
- For state-changing functions:
  - [ ] Reentrancy test (if applicable): Verify re-entry is blocked
  - [ ] Access control test: Verify unauthorized access is rejected
  - [ ] Boundary test: Verify edge cases are handled
  
- For external integrations:
  - [ ] Return value verification test
  - [ ] Failure scenario test

### Test Coverage
- [x] All new code paths have test coverage
- [x] Security-critical paths have comprehensive test cases
- [x] Coverage report: `N/A — documentation only, no executable code added`

---

## 🚀 Deployment Notes

No deployment steps required. This PR adds a Markdown file and updates two existing Markdown files only.

### Mainnet Readiness
- [ ] This code is ready for production deployment
- [x] All critical tests pass
- [ ] Security review approved
- [x] No temporary debug code
- [x] No TODO comments

### Breaking Changes
If this PR introduces breaking changes:
- [ ] Migration guide provided
- [ ] Deprecation period defined: `[timeframe]`
- [ ] Legacy code deprecated with warnings

---

## 📊 Automated Scan Results

<!-- GitHub Actions will update this section -->

### Slither Analysis
- ✓ Status: N/A — no contract code changed
- 🔴 High/Medium findings: 0
- 🟡 Low/Informational findings: 0
- 🟢 No issues detected: documentation-only PR

### Related Documentation
- [Security Checklist](docs/SECURITY_CHECKLIST.md) — Use for code review
- [False Positive Process](docs/FALSE_POSITIVE_HANDLING.md) — For non-vulnerabilities
- [Slither Configuration](slither.config.json) — Current scanner settings

---

## ✅ Reviewer Checklist

**For code reviewers** (use this to guide your security-focused review):

- [x] PR author completed security checklist ✓
- [x] All findings documented and categorized (fixed/false positive/excluded)
- [x] Inline security comments are clear and justified
- [ ] Tests cover security-critical code paths
- [ ] No external calls bypass return value checks
- [ ] Access control is properly enforced
- [ ] State updates follow CEI pattern
- [ ] Input validation is comprehensive
- [x] Follow-up actions (if any) tracked in issues

---

## 📞 Questions or Issues?

- 🤔 Confused about security checklist? → See [`docs/SECURITY_CHECKLIST.md`](/docs/SECURITY_CHECKLIST.md)
- 🔍 Marking finding as false positive? → Follow [`docs/FALSE_POSITIVE_HANDLING.md`](/docs/FALSE_POSITIVE_HANDLING.md)
- 🆘 Need security review help? → Tag `@security-team` in comments

---

## 📋 Pre-Submit Checklist

Before marking PR as ready for review:

- [x] Description is clear and concise
- [x] All security checklist items checked (✅ or explanation provided)
- [x] All tests passing locally: `npm test`
- [x] Linter passing: `npm run lint`
- [ ] Slither passing locally OR findings documented: `slither . --config-file slither.config.json`
- [x] Code follows project style guide
- [x] No merge conflicts
- [x] Commits are clean and well-documented
- [x] Branch is up-to-date with main/develop
- [ ] For **release PRs**: `docs/RELEASE_READINESS_CHECKLIST.md` completed and linked in PR description

---

**✅ Ready for Review?** Ensure all items above are checked before requesting review.
