### PR TITLE
feat(backend): idempotent retry-safe transfer orchestration (#1043)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Features
+- Harden the transfer orchestration service to be idempotent and retry-safe: wallet-scoped idempotency keys, request validation and canonicalisation, submission-boundary failure classification that never blindly resubmits a transfer whose outcome is unknown, stored terminal rejections, circuit-breaker fail-fast, a submission timeout, and an operator reconciliation queue with metrics (#1043)
 - Harden the vault comparison screen for multi-strategy selection: numeric strategy catalog with locale-aware formatting, URL-synced shareable selection and column ordering, best-in-class marking with non-colour cues, and screen-reader announcements for selection and sort changes (#1036)
 - Add journalled partial-failure recovery for multi-step withdrawals: resume-forward retries, reverse-order compensation, an operator escalation queue with admin endpoints, and a background sweeper for crashed or backed-off sagas (#954)
 - Add deterministic admin proposal nonces with replay rejection for admin rotation (#736)

--- a/backend/docs/TRANSFER_ORCHESTRATION.md
+++ b/backend/docs/TRANSFER_ORCHESTRATION.md
@@ -1,0 +1,185 @@
+# Idempotent Retry-Safe Transfer Orchestration (Issue #1043)
+
+A vault transfer moves money. `submitVaultOperation` builds a **fresh**
+transaction — fresh sequence number, fresh signature — and pushes it to the
+network. So retrying that call is not a repeat of the first attempt; it is a
+second transaction.
+
+That makes "just retry it" the wrong default. `src/transferOrchestrator.ts` is
+the service that decides, for every failure, whether a retry is safe.
+
+## What the previous implementation covered, and what it didn't
+
+The original service wrapped the RPC in `IdempotencyStore.execute`. That gives
+the happy path: same key twice → one transaction, second caller replays the
+stored response. Everything else was open:
+
+| Gap | Consequence |
+| --- | --- |
+| Client key used verbatim as the store key | Wallet A's key `"1"` occupied wallet B's slot — B replayed A's transaction hash or got a spurious 409 |
+| No request validation | A negative or `NaN` amount reached the signing path |
+| Every failure retried blind | A failure *after* the envelope hit the network was retried, which can transfer twice |
+| Terminal rejections not stored | A guaranteed-to-fail 422 re-ran the full build/simulate path on every retry |
+| No fail-fast, no timeout | A dead RPC absorbed the whole retry budget per request; a hung call held the key's in-flight slot for the life of the process |
+| No metrics, no alert | None of the above was visible |
+
+## The retry-safety contract
+
+> For a given **(wallet, idempotency key)** pair, at most one transaction is ever
+> submitted. Every later call either replays the stored outcome or fails loudly.
+> It never silently submits a second transaction.
+
+## Failure classification
+
+Everything rests on one question: *did the signed envelope reach the network?*
+
+| Class | Meaning | Stored under the key? | Caller may retry? |
+| --- | --- | --- | --- |
+| `retryable` | Proven to have failed **before** submission. Nothing moved. | No — so the retry re-executes | Yes, same key |
+| `terminal` | The request itself is invalid; retrying cannot help. | Yes, as a `rejected` record | Retrying replays the same rejection |
+| `indeterminate` | The envelope may or may not have landed. | Yes, as an `in_doubt` record | **No** — blocked until reconciled |
+
+The mapping comes from reading `submitVaultOperation`'s own error codes:
+
+| Soroban code | Class | Why |
+| --- | --- | --- |
+| `INVALID_ADDRESS`, `INVALID_AMOUNT` | `terminal` | Argument validation, raised before anything is built |
+| `SIMULATION_ERROR` | `retryable` | Raised on the simulate path; no envelope was sent |
+| `RESTORE_REQUIRED` | `retryable` | Simulation asked for a ledger restore; nothing was sent |
+| `RPC_ERROR` | `retryable` | RPC returned `status === 'ERROR'` — an explicit rejection, so no transaction exists |
+| `SOROBAN_CIRCUIT_OPEN` | `retryable` | Fail-fast; the RPC was never called |
+| `SUBMISSION_FAILED` | `indeterminate` | Submit returned an unexpected status — the envelope was already handed over |
+| `INTERNAL_ERROR` | `indeterminate` | Catch-all wrapper; may be a socket error mid-submit |
+| `TRANSFER_TIMEOUT` | `indeterminate` | The call never settled; silence is not proof |
+
+**Unknown failures default to `indeterminate`.** This is deliberately the
+opposite of `classifyWithdrawalFailure`, which defaults to `retryable`. That
+coordinator retries *idempotent* steps; a retry here mints a new transaction.
+When we cannot prove nothing moved, we refuse to move again.
+
+## Wallet-scoped keys
+
+The client's key never reaches the store directly:
+
+```
+transfer:<sha256(normalizedWallet)[0..16]>:<clientKey>
+```
+
+Two wallets can therefore both use `"checkout-1"` without colliding. The wallet
+is hashed rather than embedded so the key stays bounded and no address leaks into
+a Redis `KEYS`/`SCAN` listing. Normalisation is case-insensitive, so
+`gabc…`/`GABC…` are one wallet.
+
+Keys must be 8–255 characters (`TRANSFER_ORCHESTRATION_MAX_KEY_LENGTH`) from
+`[A-Za-z0-9._:~-]`. The charset rules out whitespace and newlines, which are
+unsafe in a Redis key segment; the minimum length rules out trivially guessable
+keys that invite cross-request collisions within one wallet.
+
+## Request canonicalisation
+
+Before fingerprinting, the request is canonicalised: wallet upper-cased, asset
+upper-cased, amount trimmed. Two spellings of the same transfer therefore share
+one fingerprint and replay correctly instead of raising a false conflict.
+
+Amounts must match `^\d+(\.\d+)?$` and be `> 0`. Strings are used so JSON cannot
+round the value, and the pattern rejects `NaN`, `Infinity`, `1e3` and signed
+values — all of which `Number()` would otherwise coerce further down the stack.
+
+## The in-doubt window
+
+When a failure is `indeterminate`, the orchestrator:
+
+1. Stores an `in_doubt` record under the key. **This is the mechanism that stops
+   a retry** — the next call hits the stored record instead of the RPC.
+2. Registers the transfer in the in-doubt registry with everything an operator
+   needs to reconcile it: wallet, operation, amount, asset, failing code, the
+   original idempotency key, and the trace ID.
+3. Logs at `error` with `alert: "transfer-in-doubt"` and raises the in-doubt
+   gauge.
+4. Throws `TransferInDoubtError` (409) — to the caller that opened the window and
+   to every caller after it.
+
+### Reconciling
+
+An operator checks the chain, then calls:
+
+```ts
+// The transfer did land — replays of the original key now return this hash.
+await resolveInDoubtTransfer(storeKey, { transactionHash: 'abc…' });
+
+// Nothing landed — release the key so the client may retry from scratch.
+await resolveInDoubtTransfer(storeKey, { discard: true });
+```
+
+`listInDoubtTransfers()` and `getInDoubtTransfer(storeKey)` expose the queue.
+Neither leaks the internal fingerprint.
+
+## Errors
+
+Every failure is a `TransferOrchestrationError` subclass carrying `code`,
+`statusCode` and `classification`, so an HTTP layer can map them uniformly.
+
+| Error | Status | When |
+| --- | --- | --- |
+| `TransferValidationError` | 400 / 422 | Malformed key or request; never reaches the network |
+| `TransferConflictError` | 409 | Key reused with a different body |
+| `TransferInDoubtError` | 409 | Outcome unknown; needs reconciliation |
+| `TransferUnavailableError` | 503 | Dependency down, nothing submitted (`retryAfterMs` set when the circuit is open) |
+| `TransferOrchestrationError` | 422 (stored) | A replayed terminal rejection |
+
+## Metrics
+
+| Metric | Type | Labels |
+| --- | --- | --- |
+| `transfer_orchestration_total` | counter | `operation`, `outcome` |
+| `transfer_orchestration_replay_total` | counter | `operation`, `replay_of` |
+| `transfer_orchestration_failure_total` | counter | `operation`, `classification`, `code` |
+| `transfer_orchestration_duration_ms` | histogram | `operation`, `outcome` |
+| `transfer_orchestration_in_doubt` | gauge | — |
+
+`transfer_orchestration_in_doubt > 0` is the page-worthy signal: money may have
+moved without a ledger record. Pair it with the `transfer-in-doubt` log alert.
+
+## Configuration
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `TRANSFER_ORCHESTRATION_TIMEOUT_MS` | `45000` | Caps a single submission so a hung RPC cannot pin the key's in-flight slot. A timeout is classified `indeterminate`. |
+| `TRANSFER_ORCHESTRATION_MAX_KEY_LENGTH` | `255` | Upper bound on a client-supplied key. |
+
+Both are read per call, so an operator can change them without a restart-time
+re-import. The circuit breaker and idempotency TTL are configured by their own
+modules (`CIRCUIT_BREAKER_*`, `IDEMPOTENCY_KEY_TTL_MS`).
+
+## Durability note
+
+The in-doubt registry is in-process, the same trade-off the withdrawal saga
+journal and the dead-letter queue make. The `in_doubt` record that actually
+enforces retry-safety lives in the idempotency store, which **is** shared across
+replicas via Redis — so a pod recycle cannot turn a parked transfer back into a
+resubmittable one. What a recycle loses is the operator *queue* view, not the
+guarantee. Mirror the `transfer-in-doubt` alert to durable storage if you need
+the queue to survive a restart.
+
+## Usage
+
+```ts
+import { orchestrateTransfer } from './transferOrchestrator';
+
+const { transactionHash, replayed } = await orchestrateTransfer(
+  { operationType: 'deposit', walletAddress, amount: '1000', asset: 'USDC' },
+  request.header('Idempotency-Key')!,
+);
+```
+
+Call sites adopt the service by calling `orchestrateTransfer` in place of
+`submitVaultOperation` and mapping the typed errors above onto responses.
+
+## Tests
+
+`src/__tests__/transferOrchestrator.test.ts` covers submission and replay,
+concurrent coalescing, canonicalisation, wallet-scoped key isolation, conflict
+detection, key/amount/wallet validation, each classification branch, fail-fast on
+an open circuit, stored terminal rejections, the timeout path, and both in-doubt
+resolutions — including the central assertion that a retry after an
+indeterminate failure does **not** call the RPC a second time.

--- a/backend/src/__tests__/transferOrchestrator.test.ts
+++ b/backend/src/__tests__/transferOrchestrator.test.ts
@@ -1,58 +1,449 @@
 // src/__tests__/transferOrchestrator.test.ts
-import { orchestrateTransfer } from '../transferOrchestrator';
-import { submitVaultOperation } from '../sorobanClient';
-import { idempotencyStore, buildIdempotencyFingerprint } from '../idempotency';
+//
+// The orchestrator imports './sorobanClient', which jest.config.js remaps to
+// src/__tests__/mocks/sorobanClient.js. The previous version of this file called
+// jest.mock('../sorobanClient') instead — a different module id, which the
+// mapper does not redirect — so the spy it asserted on was never the function
+// the orchestrator called and the assertion could not pass. Drive the mapped
+// mock directly.
+import {
+  orchestrateTransfer,
+  buildTransferStoreKey,
+  classifyTransferFailure,
+  listInDoubtTransfers,
+  getInDoubtTransfer,
+  resolveInDoubtTransfer,
+  resetTransferOrchestratorForTests,
+  TransferValidationError,
+  TransferConflictError,
+  TransferInDoubtError,
+  TransferUnavailableError,
+  TransferOrchestrationError,
+  type TransferParams,
+} from '../transferOrchestrator';
+import { idempotencyStore } from '../idempotency';
+import { sorobanCircuitBreaker, CircuitOpenError } from '../circuitBreaker';
+import { VALID_TEST_WALLET, SECOND_TEST_WALLET } from './setup';
 
-jest.mock('../sorobanClient', () => ({ submitVaultOperation: jest.fn() }));
-jest.mock('../idempotency', () => {
-  const original = jest.requireActual('../idempotency');
-  return {
-    ...original,
-    idempotencyStore: {
-      execute: jest.fn(),
-    },
-    buildIdempotencyFingerprint: jest.fn().mockReturnValue('fingerprint'),
-  };
-});
+// Requiring the mock by its own path lands on the same module-registry entry
+// the mapper hands the orchestrator, so this spy really is the function under
+// test. Requiring '../sorobanClient' would resolve the *real* module instead —
+// the mapper only rewrites the './sorobanClient' specifier.
+const sorobanClient = require('./mocks/sorobanClient') as {
+  submitVaultOperation: jest.Mock;
+};
 
-describe('orchestrateTransfer', () => {
-  const params = {
-    operationType: 'deposit' as const,
-    walletAddress: 'GABCDEF1234567890',
-    amount: '1000',
-    asset: 'USDC',
-  };
-  const key = 'test-idempotency-key';
+/** Mirrors SorobanSimulationError's shape (code + statusCode). */
+class FakeSorobanError extends Error {
+  code: string;
+  statusCode: number;
+  constructor(message: string, code: string, statusCode = 502) {
+    super(message);
+    this.name = 'SorobanSimulationError';
+    this.code = code;
+    this.statusCode = statusCode;
+  }
+}
 
+const params: TransferParams = {
+  operationType: 'deposit',
+  walletAddress: VALID_TEST_WALLET,
+  amount: '1000',
+  asset: 'USDC',
+};
+
+let keyCounter = 0;
+/** Unique per test so the shared idempotency store never leaks across cases. */
+const freshKey = () => `idem-key-${Date.now()}-${keyCounter++}`;
+
+describe('transferOrchestrator', () => {
   beforeEach(() => {
-    (submitVaultOperation as jest.Mock).mockResolvedValue('txhash-123');
-    (idempotencyStore.execute as jest.Mock).mockImplementation(async (k, fp, op) => {
-      const result = await op();
-      return { result, replayed: false };
+    jest.restoreAllMocks();
+    sorobanClient.submitVaultOperation.mockReset();
+    sorobanClient.submitVaultOperation.mockResolvedValue('txhash-123');
+    idempotencyStore.clear();
+    resetTransferOrchestratorForTests();
+    // Keep the shared breaker CLOSED regardless of what other suites did.
+    jest.spyOn(sorobanCircuitBreaker, 'execute').mockImplementation((fn) => fn());
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  // ── Happy path & replay ─────────────────────────────────────────────────────
+
+  describe('submission and replay', () => {
+    test('submits once and returns the transaction hash', async () => {
+      const res = await orchestrateTransfer(params, freshKey());
+
+      expect(sorobanClient.submitVaultOperation).toHaveBeenCalledTimes(1);
+      expect(sorobanClient.submitVaultOperation).toHaveBeenCalledWith(
+        'deposit',
+        VALID_TEST_WALLET,
+        '1000',
+        'USDC',
+      );
+      expect(res.result).toEqual({ statusCode: 200, body: 'txhash-123' });
+      expect(res.transactionHash).toBe('txhash-123');
+      expect(res.replayed).toBe(false);
+      expect(res.outcome).toBe('submitted');
+    });
+
+    test('a repeat with the same key replays without a second submission', async () => {
+      const key = freshKey();
+      const first = await orchestrateTransfer(params, key);
+      const second = await orchestrateTransfer(params, key);
+
+      expect(sorobanClient.submitVaultOperation).toHaveBeenCalledTimes(1);
+      expect(second.transactionHash).toBe(first.transactionHash);
+      expect(second.replayed).toBe(true);
+      expect(second.outcome).toBe('replayed');
+    });
+
+    test('concurrent calls with the same key coalesce into one submission', async () => {
+      const key = freshKey();
+      let release!: (hash: string) => void;
+      sorobanClient.submitVaultOperation.mockImplementation(
+        () => new Promise<string>((resolve) => { release = resolve; }),
+      );
+
+      const inFlight = Promise.all([
+        orchestrateTransfer(params, key),
+        orchestrateTransfer(params, key),
+        orchestrateTransfer(params, key),
+      ]);
+      // Let all three reach the store before the RPC settles.
+      await new Promise((resolve) => setImmediate(resolve));
+      release('txhash-concurrent');
+
+      const results = await inFlight;
+      expect(sorobanClient.submitVaultOperation).toHaveBeenCalledTimes(1);
+      expect(results.map((r) => r.transactionHash)).toEqual([
+        'txhash-concurrent',
+        'txhash-concurrent',
+        'txhash-concurrent',
+      ]);
+      expect(results.filter((r) => r.replayed)).toHaveLength(2);
+    });
+
+    test('canonicalises the request so equivalent spellings share one key', async () => {
+      const key = freshKey();
+      await orchestrateTransfer(params, key);
+      // Lower-case wallet, lower-case asset, padded amount — same transfer.
+      const replay = await orchestrateTransfer(
+        {
+          operationType: 'deposit',
+          walletAddress: VALID_TEST_WALLET.toLowerCase(),
+          amount: ' 1000 ',
+          asset: 'usdc',
+        },
+        key,
+      );
+
+      expect(sorobanClient.submitVaultOperation).toHaveBeenCalledTimes(1);
+      expect(replay.replayed).toBe(true);
+    });
+
+    test('the same key trims to the same store key', async () => {
+      const key = freshKey();
+      await orchestrateTransfer(params, key);
+      const replay = await orchestrateTransfer(params, `  ${key}  `);
+      expect(replay.replayed).toBe(true);
+      expect(sorobanClient.submitVaultOperation).toHaveBeenCalledTimes(1);
     });
   });
 
-  test('executes operation and stores result', async () => {
-    const { result, replayed } = await orchestrateTransfer(params, key);
+  // ── Key scoping ─────────────────────────────────────────────────────────────
 
-    expect(buildIdempotencyFingerprint).toHaveBeenCalledWith(params);
-    expect(idempotencyStore.execute).toHaveBeenCalledWith(key, 'fingerprint', expect.any(Function));
-    expect(submitVaultOperation).toHaveBeenCalledWith(
-      params.operationType,
-      params.walletAddress,
-      params.amount,
-      params.asset,
-    );
-    expect(result).toEqual({ statusCode: 200, body: 'txhash-123' });
-    expect(replayed).toBe(false);
+  describe('key scoping', () => {
+    test('the same client key on two wallets does not collide', async () => {
+      const key = freshKey();
+      sorobanClient.submitVaultOperation
+        .mockResolvedValueOnce('txhash-wallet-a')
+        .mockResolvedValueOnce('txhash-wallet-b');
+
+      const a = await orchestrateTransfer(params, key);
+      const b = await orchestrateTransfer(
+        { ...params, walletAddress: SECOND_TEST_WALLET },
+        key,
+      );
+
+      expect(sorobanClient.submitVaultOperation).toHaveBeenCalledTimes(2);
+      expect(a.transactionHash).toBe('txhash-wallet-a');
+      expect(b.transactionHash).toBe('txhash-wallet-b');
+      expect(a.storeKey).not.toBe(b.storeKey);
+    });
+
+    test('store keys are wallet-scoped, case-insensitively, and hide the address', () => {
+      const upper = buildTransferStoreKey(VALID_TEST_WALLET, 'abcdefgh');
+      const lower = buildTransferStoreKey(VALID_TEST_WALLET.toLowerCase(), 'abcdefgh');
+      const other = buildTransferStoreKey(SECOND_TEST_WALLET, 'abcdefgh');
+
+      expect(upper).toBe(lower);
+      expect(upper).not.toBe(other);
+      expect(upper).toMatch(/^transfer:[0-9a-f]{16}:abcdefgh$/);
+      expect(upper).not.toContain(VALID_TEST_WALLET);
+    });
+
+    test('reusing a key with a different body is a conflict, not a second transfer', async () => {
+      const key = freshKey();
+      await orchestrateTransfer(params, key);
+
+      await expect(orchestrateTransfer({ ...params, amount: '2000' }, key)).rejects.toThrow(
+        TransferConflictError,
+      );
+      expect(sorobanClient.submitVaultOperation).toHaveBeenCalledTimes(1);
+    });
   });
 
-  test('returns replayed flag when idempotent store reports replay', async () => {
-    (idempotencyStore.execute as jest.Mock).mockResolvedValue({
-      result: { statusCode: 200, body: 'txhash-123' },
-      replayed: true,
+  // ── Validation ──────────────────────────────────────────────────────────────
+
+  describe('validation', () => {
+    const rejects = async (
+      overrides: Partial<TransferParams>,
+      key: string | undefined,
+      code: string,
+    ) => {
+      await expect(
+        orchestrateTransfer({ ...params, ...overrides } as TransferParams, key as string),
+      ).rejects.toMatchObject({ name: expect.stringContaining('Transfer'), code });
+      expect(sorobanClient.submitVaultOperation).not.toHaveBeenCalled();
+    };
+
+    test.each([
+      ['missing', undefined, 'TRANSFER_IDEMPOTENCY_KEY_REQUIRED'],
+      ['empty', '   ', 'TRANSFER_IDEMPOTENCY_KEY_REQUIRED'],
+      ['too short', 'abc', 'TRANSFER_IDEMPOTENCY_KEY_TOO_SHORT'],
+      ['whitespace-bearing', 'abc def ghi', 'TRANSFER_IDEMPOTENCY_KEY_INVALID'],
+      ['newline-injecting', 'abcdefgh\nx', 'TRANSFER_IDEMPOTENCY_KEY_INVALID'],
+    ])('rejects a %s idempotency key', async (_label, key, code) => {
+      await rejects({}, key as string | undefined, code);
     });
-    const { replayed } = await orchestrateTransfer(params, key);
-    expect(replayed).toBe(true);
+
+    test('rejects an over-long idempotency key', async () => {
+      await rejects({}, 'a'.repeat(256), 'TRANSFER_IDEMPOTENCY_KEY_TOO_LONG');
+    });
+
+    test.each([
+      ['a negative amount', { amount: '-1' }, 'TRANSFER_AMOUNT_INVALID'],
+      ['a zero amount', { amount: '0' }, 'TRANSFER_AMOUNT_INVALID'],
+      ['a NaN amount', { amount: 'NaN' }, 'TRANSFER_AMOUNT_INVALID'],
+      ['an Infinity amount', { amount: 'Infinity' }, 'TRANSFER_AMOUNT_INVALID'],
+      ['an exponent amount', { amount: '1e3' }, 'TRANSFER_AMOUNT_INVALID'],
+      ['an empty amount', { amount: '' }, 'TRANSFER_AMOUNT_INVALID'],
+      ['a malformed wallet', { walletAddress: 'not-a-wallet' }, 'TRANSFER_WALLET_INVALID'],
+      ['an empty asset', { asset: '  ' }, 'TRANSFER_ASSET_INVALID'],
+      [
+        'an unknown operation',
+        { operationType: 'transfer' as unknown as 'deposit' },
+        'TRANSFER_OPERATION_INVALID',
+      ],
+    ])('rejects %s before signing', async (_label, overrides, code) => {
+      await rejects(overrides as Partial<TransferParams>, freshKey(), code);
+    });
+
+    test('validation errors are TransferValidationError with a 4xx status', async () => {
+      await expect(orchestrateTransfer(params, 'x')).rejects.toBeInstanceOf(
+        TransferValidationError,
+      );
+      await expect(
+        orchestrateTransfer({ ...params, amount: '-5' }, freshKey()),
+      ).rejects.toMatchObject({ statusCode: 422, classification: 'terminal' });
+    });
+  });
+
+  // ── Failure classification ──────────────────────────────────────────────────
+
+  describe('classifyTransferFailure', () => {
+    test.each([
+      ['SIMULATION_ERROR', 'retryable'],
+      ['RESTORE_REQUIRED', 'retryable'],
+      ['RPC_ERROR', 'retryable'],
+      ['SOROBAN_CIRCUIT_OPEN', 'retryable'],
+      ['INVALID_ADDRESS', 'terminal'],
+      ['INVALID_AMOUNT', 'terminal'],
+      ['SUBMISSION_FAILED', 'indeterminate'],
+      ['INTERNAL_ERROR', 'indeterminate'],
+    ])('classifies %s as %s', (code, expected) => {
+      expect(classifyTransferFailure(new FakeSorobanError('boom', code))).toBe(expected);
+    });
+
+    test('an open circuit is retryable', () => {
+      expect(classifyTransferFailure(new CircuitOpenError(1000))).toBe('retryable');
+    });
+
+    test('an unrecognised failure defaults to indeterminate, never retryable', () => {
+      expect(classifyTransferFailure(new Error('socket hang up'))).toBe('indeterminate');
+      expect(classifyTransferFailure(undefined)).toBe('indeterminate');
+      expect(classifyTransferFailure('a string')).toBe('indeterminate');
+    });
+
+    test('a 4xx status without a known code is terminal', () => {
+      expect(classifyTransferFailure(new FakeSorobanError('bad', 'WEIRD', 422))).toBe('terminal');
+    });
+  });
+
+  // ── Retryable failures ──────────────────────────────────────────────────────
+
+  describe('retryable failures', () => {
+    test('a pre-submission failure stores nothing and the retry re-executes', async () => {
+      const key = freshKey();
+      sorobanClient.submitVaultOperation
+        .mockRejectedValueOnce(new FakeSorobanError('sim failed', 'SIMULATION_ERROR'))
+        .mockResolvedValueOnce('txhash-after-retry');
+
+      await expect(orchestrateTransfer(params, key)).rejects.toBeInstanceOf(
+        TransferUnavailableError,
+      );
+
+      const retried = await orchestrateTransfer(params, key);
+      expect(retried.transactionHash).toBe('txhash-after-retry');
+      expect(retried.replayed).toBe(false);
+      expect(sorobanClient.submitVaultOperation).toHaveBeenCalledTimes(2);
+    });
+
+    test('an open circuit fails fast with a retry hint and never calls the RPC', async () => {
+      jest
+        .spyOn(sorobanCircuitBreaker, 'execute')
+        .mockRejectedValue(new CircuitOpenError(5000) as never);
+
+      await expect(orchestrateTransfer(params, freshKey())).rejects.toMatchObject({
+        code: 'TRANSFER_CIRCUIT_OPEN',
+        statusCode: 503,
+        retryAfterMs: 5000,
+        classification: 'retryable',
+      });
+      expect(sorobanClient.submitVaultOperation).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Terminal rejections ─────────────────────────────────────────────────────
+
+  describe('terminal rejections', () => {
+    test('a rejection is stored and replayed without re-submitting', async () => {
+      const key = freshKey();
+      sorobanClient.submitVaultOperation.mockRejectedValue(
+        new FakeSorobanError('Invalid Stellar wallet address', 'INVALID_ADDRESS', 422),
+      );
+
+      const expected = { code: 'INVALID_ADDRESS', statusCode: 422, classification: 'terminal' };
+      await expect(orchestrateTransfer(params, key)).rejects.toMatchObject(expected);
+      await expect(orchestrateTransfer(params, key)).rejects.toMatchObject(expected);
+
+      expect(sorobanClient.submitVaultOperation).toHaveBeenCalledTimes(1);
+    });
+
+    test('a replayed rejection is a TransferOrchestrationError, not a success', async () => {
+      const key = freshKey();
+      sorobanClient.submitVaultOperation.mockRejectedValue(
+        new FakeSorobanError('bad amount', 'INVALID_AMOUNT', 422),
+      );
+      await expect(orchestrateTransfer(params, key)).rejects.toThrow(TransferOrchestrationError);
+      await expect(orchestrateTransfer(params, key)).rejects.toThrow('bad amount');
+    });
+  });
+
+  // ── In-doubt window ─────────────────────────────────────────────────────────
+
+  describe('in-doubt handling', () => {
+    test('an indeterminate failure parks the key and refuses to resubmit', async () => {
+      const key = freshKey();
+      sorobanClient.submitVaultOperation.mockRejectedValue(
+        new FakeSorobanError('Unexpected transaction status: TRY_AGAIN_LATER', 'SUBMISSION_FAILED'),
+      );
+
+      await expect(orchestrateTransfer(params, key)).rejects.toBeInstanceOf(TransferInDoubtError);
+      // The critical assertion: a retry must NOT mint a second transaction.
+      await expect(orchestrateTransfer(params, key)).rejects.toBeInstanceOf(TransferInDoubtError);
+      await expect(orchestrateTransfer(params, key)).rejects.toMatchObject({
+        code: 'TRANSFER_IN_DOUBT',
+        statusCode: 409,
+        classification: 'indeterminate',
+      });
+
+      expect(sorobanClient.submitVaultOperation).toHaveBeenCalledTimes(1);
+    });
+
+    test('a hung submission times out and is treated as in-doubt', async () => {
+      const previous = process.env.TRANSFER_ORCHESTRATION_TIMEOUT_MS;
+      process.env.TRANSFER_ORCHESTRATION_TIMEOUT_MS = '1000';
+      sorobanClient.submitVaultOperation.mockImplementation(() => new Promise<string>(() => {}));
+
+      try {
+        await expect(orchestrateTransfer(params, freshKey())).rejects.toBeInstanceOf(
+          TransferInDoubtError,
+        );
+        expect(listInDoubtTransfers()[0]).toMatchObject({ code: 'TRANSFER_TIMEOUT' });
+      } finally {
+        if (previous === undefined) delete process.env.TRANSFER_ORCHESTRATION_TIMEOUT_MS;
+        else process.env.TRANSFER_ORCHESTRATION_TIMEOUT_MS = previous;
+      }
+    });
+
+    test('a parked transfer is exposed to operators with reconciliation context', async () => {
+      const key = freshKey();
+      sorobanClient.submitVaultOperation.mockRejectedValue(
+        new FakeSorobanError('socket hang up', 'INTERNAL_ERROR'),
+      );
+      await expect(orchestrateTransfer(params, key)).rejects.toBeInstanceOf(TransferInDoubtError);
+
+      const parked = listInDoubtTransfers();
+      expect(parked).toHaveLength(1);
+      expect(parked[0]).toMatchObject({
+        idempotencyKey: key,
+        walletAddress: VALID_TEST_WALLET,
+        operationType: 'deposit',
+        amount: '1000',
+        asset: 'USDC',
+        code: 'INTERNAL_ERROR',
+        message: 'socket hang up',
+      });
+      expect(getInDoubtTransfer(parked[0].storeKey)).not.toBeNull();
+      // The internal fingerprint must not leak through the operator view.
+      expect(parked[0]).not.toHaveProperty('fingerprint');
+    });
+
+    test('confirming an in-doubt transfer makes replays return the real hash', async () => {
+      const key = freshKey();
+      sorobanClient.submitVaultOperation.mockRejectedValue(
+        new FakeSorobanError('unknown', 'SUBMISSION_FAILED'),
+      );
+      await expect(orchestrateTransfer(params, key)).rejects.toBeInstanceOf(TransferInDoubtError);
+      const { storeKey } = listInDoubtTransfers()[0];
+
+      expect(await resolveInDoubtTransfer(storeKey, { transactionHash: 'txhash-onchain' })).toBe(
+        true,
+      );
+      expect(listInDoubtTransfers()).toHaveLength(0);
+
+      const replay = await orchestrateTransfer(params, key);
+      expect(replay.transactionHash).toBe('txhash-onchain');
+      expect(replay.replayed).toBe(true);
+      // Still exactly the one original attempt.
+      expect(sorobanClient.submitVaultOperation).toHaveBeenCalledTimes(1);
+    });
+
+    test('discarding an in-doubt transfer releases the key for a fresh attempt', async () => {
+      const key = freshKey();
+      sorobanClient.submitVaultOperation.mockRejectedValueOnce(
+        new FakeSorobanError('unknown', 'SUBMISSION_FAILED'),
+      );
+      await expect(orchestrateTransfer(params, key)).rejects.toBeInstanceOf(TransferInDoubtError);
+      const { storeKey } = listInDoubtTransfers()[0];
+
+      expect(await resolveInDoubtTransfer(storeKey, { discard: true })).toBe(true);
+      expect(listInDoubtTransfers()).toHaveLength(0);
+
+      sorobanClient.submitVaultOperation.mockResolvedValueOnce('txhash-second-attempt');
+      const retried = await orchestrateTransfer(params, key);
+      expect(retried.transactionHash).toBe('txhash-second-attempt');
+      expect(retried.replayed).toBe(false);
+      expect(sorobanClient.submitVaultOperation).toHaveBeenCalledTimes(2);
+    });
+
+    test('resolving an unknown key is a no-op', async () => {
+      expect(await resolveInDoubtTransfer('transfer:deadbeef:nope', { discard: true })).toBe(false);
+    });
   });
 });

--- a/backend/src/metrics.ts
+++ b/backend/src/metrics.ts
@@ -255,3 +255,40 @@ export const withdrawalSagaManualInterventionRequired = new Gauge({
   help: 'Withdrawal sagas with irreversible partial state awaiting an operator',
   registers: [register],
 });
+
+// --- Transfer Orchestration Metrics (Issue #1043) ---
+
+export const transferOrchestrationTotal = new Counter({
+  name: 'transfer_orchestration_total',
+  help: 'Terminal outcomes of orchestrated vault transfers',
+  labelNames: ['operation', 'outcome'],
+  registers: [register],
+});
+
+export const transferOrchestrationReplayTotal = new Counter({
+  name: 'transfer_orchestration_replay_total',
+  help: 'Orchestrated transfers served from a stored idempotent result instead of re-submitting',
+  labelNames: ['operation', 'replay_of'],
+  registers: [register],
+});
+
+export const transferOrchestrationFailureTotal = new Counter({
+  name: 'transfer_orchestration_failure_total',
+  help: 'Orchestrated transfer submission failures by classification and error code',
+  labelNames: ['operation', 'classification', 'code'],
+  registers: [register],
+});
+
+export const transferOrchestrationDurationMs = new Histogram({
+  name: 'transfer_orchestration_duration_ms',
+  help: 'Wall-clock duration of an orchestrated transfer submission attempt in milliseconds',
+  labelNames: ['operation', 'outcome'],
+  buckets: [50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000, 60000],
+  registers: [register],
+});
+
+export const transferOrchestrationInDoubt = new Gauge({
+  name: 'transfer_orchestration_in_doubt',
+  help: 'Orchestrated transfers whose on-chain outcome is unknown and awaiting operator reconciliation',
+  registers: [register],
+});

--- a/backend/src/transferOrchestrator.ts
+++ b/backend/src/transferOrchestrator.ts
@@ -1,15 +1,63 @@
-// src/transferOrchestrator.ts
 /**
- * Idempotent retry‑safe transfer orchestration service.
+ * @file transferOrchestrator.ts
+ * Idempotent, retry-safe transfer orchestration service (Issue #1043).
  *
- * It wraps the low‑level `submitVaultOperation` RPC call with the
- * `IdempotencyStore` ensuring that repeated attempts with the same
- * idempotency key result in a single on‑chain transaction and that the
- * original response is replayed safely.
+ * A vault transfer is a *money-moving* call: `submitVaultOperation` builds a
+ * fresh transaction (fresh sequence number), signs it, and pushes it to the
+ * network. Retrying that call is therefore not free — a second call is a second
+ * transaction, not a repeat of the first one.
+ *
+ * The previous implementation wrapped the RPC in `IdempotencyStore.execute` and
+ * stopped there. That covers the happy path (same key twice → one transaction,
+ * replayed response) but leaves the failure paths open:
+ *
+ *   - **Unscoped keys.** The client-supplied key was used verbatim as the store
+ *     key, so a trivial key (`"1"`) from wallet A occupied the same slot as
+ *     wallet B's, and B either replayed A's transaction hash or got a spurious
+ *     409. Keys are now scoped per wallet before they reach the store.
+ *   - **Unvalidated input.** An empty key, or a negative/NaN amount, reached the
+ *     signing path and produced a cached result or an opaque 500.
+ *   - **Blind retries through the in-doubt window.** A failure *after* the
+ *     envelope reached the network (unexpected submit status, socket error, or a
+ *     hung call) is not evidence that nothing moved. Retrying it can transfer
+ *     twice. Those failures are now classified `indeterminate`, parked, and
+ *     refused until an operator reconciles them.
+ *   - **Re-doing terminally rejected work.** A 422 was re-executed on every
+ *     retry. Terminal rejections are now stored under the key and replayed.
+ *   - **No fail-fast, no timeout, no signal.** A dead RPC was hammered with the
+ *     full retry budget on every request, a hung call held the key's pending
+ *     slot forever, and none of it was observable.
+ *
+ * Retry-safety contract
+ * ---------------------
+ * For a given (wallet, idempotency key) pair, at most one transaction is ever
+ * submitted. Every subsequent call either replays the stored outcome or fails
+ * loudly; it never silently submits a second transaction. A caller may retry
+ * freely on `retryable` failures — those are proven pre-submission, so nothing
+ * moved.
  */
+
+import crypto from 'crypto';
 import { submitVaultOperation } from './sorobanClient';
-import { idempotencyStore, buildIdempotencyFingerprint } from './idempotency';
-import { IdempotentOperationResult } from './idempotency';
+import {
+  idempotencyStore,
+  buildIdempotencyFingerprint,
+  IdempotencyConflictError,
+  IdempotentOperationResult,
+} from './idempotency';
+import { sorobanCircuitBreaker, CircuitOpenError } from './circuitBreaker';
+import { isValidStellarAddress, normalizeWalletAddress } from './walletUtils';
+import { logger } from './middleware/structuredLogging';
+import { getCurrentTraceId } from './tracing';
+import {
+  transferOrchestrationTotal,
+  transferOrchestrationReplayTotal,
+  transferOrchestrationFailureTotal,
+  transferOrchestrationDurationMs,
+  transferOrchestrationInDoubt,
+} from './metrics';
+
+// ─── Public types ─────────────────────────────────────────────────────────────
 
 export interface TransferParams {
   operationType: 'deposit' | 'withdrawal';
@@ -19,27 +67,692 @@ export interface TransferParams {
 }
 
 /**
- * Orchestrates a vault transfer with idempotency.
+ * How a submission failure may be handled.
  *
- * @param params - transfer details
- * @param idempotencyKey - unique key supplied by the client (e.g., UUID)
- * @returns result of the vault operation and a flag indicating if the result
- *          was replayed from a previous execution.
+ * - `retryable`    – proven to have failed *before* the envelope reached the
+ *                    network. Nothing moved; the caller may retry with the same
+ *                    key and it will re-execute.
+ * - `terminal`     – the request itself is invalid. Retrying cannot help, so the
+ *                    rejection is stored and replayed under the same key.
+ * - `indeterminate` – the envelope may or may not have reached the network. The
+ *                    key is parked as in-doubt and never auto-resubmitted.
+ */
+export type TransferFailureClass = 'retryable' | 'terminal' | 'indeterminate';
+
+export interface TransferOrchestrationResult {
+  /** Preserved shape: `body` is the on-chain transaction hash. */
+  result: IdempotentOperationResult<string>;
+  /** True when the response came from the idempotency store, not a new submission. */
+  replayed: boolean;
+  outcome: 'submitted' | 'replayed';
+  transactionHash: string;
+  /** The wallet-scoped key the store was keyed on. */
+  storeKey: string;
+}
+
+/** An orchestrated transfer whose on-chain outcome is unknown. */
+export interface InDoubtTransfer {
+  storeKey: string;
+  idempotencyKey: string;
+  walletAddress: string;
+  operationType: 'deposit' | 'withdrawal';
+  amount: string;
+  asset: string;
+  /** Failure that opened the in-doubt window. */
+  code: string;
+  message: string;
+  detectedAt: string;
+  correlationId: string | null;
+}
+
+// ─── Errors ───────────────────────────────────────────────────────────────────
+
+/** Base class so the HTTP layer can map every orchestration failure uniformly. */
+export class TransferOrchestrationError extends Error {
+  public readonly code: string;
+  public readonly statusCode: number;
+  public readonly classification: TransferFailureClass;
+
+  constructor(
+    message: string,
+    code: string,
+    statusCode: number,
+    classification: TransferFailureClass,
+  ) {
+    super(message);
+    this.name = 'TransferOrchestrationError';
+    this.code = code;
+    this.statusCode = statusCode;
+    this.classification = classification;
+  }
+}
+
+/** The request or its idempotency key is malformed. Never reaches the network. */
+export class TransferValidationError extends TransferOrchestrationError {
+  constructor(message: string, code = 'TRANSFER_VALIDATION_FAILED', statusCode = 400) {
+    super(message, code, statusCode, 'terminal');
+    this.name = 'TransferValidationError';
+  }
+}
+
+/** The key was already used for a *different* request body. */
+export class TransferConflictError extends TransferOrchestrationError {
+  constructor(message = 'Idempotency key already used for a different transfer') {
+    super(message, 'TRANSFER_IDEMPOTENCY_CONFLICT', 409, 'terminal');
+    this.name = 'TransferConflictError';
+  }
+}
+
+/**
+ * The transfer may or may not have been submitted on chain. The key is parked
+ * and will keep failing this way until an operator reconciles it — auto-retrying
+ * could move funds twice.
+ */
+export class TransferInDoubtError extends TransferOrchestrationError {
+  public readonly storeKey: string;
+
+  constructor(storeKey: string, cause: string) {
+    super(
+      `Transfer outcome is unknown and requires reconciliation before retry: ${cause}`,
+      'TRANSFER_IN_DOUBT',
+      409,
+      'indeterminate',
+    );
+    this.name = 'TransferInDoubtError';
+    this.storeKey = storeKey;
+  }
+}
+
+/** The dependency is unavailable and the transfer was not submitted. Safe to retry. */
+export class TransferUnavailableError extends TransferOrchestrationError {
+  public readonly retryAfterMs: number;
+
+  constructor(message: string, retryAfterMs: number, code = 'TRANSFER_DEPENDENCY_UNAVAILABLE') {
+    super(message, code, 503, 'retryable');
+    this.name = 'TransferUnavailableError';
+    this.retryAfterMs = retryAfterMs;
+  }
+}
+
+// ─── Config ───────────────────────────────────────────────────────────────────
+
+function parseIntEnv(raw: string | undefined, fallback: number, min = 1): number {
+  const parsed = parseInt(raw ?? '', 10);
+  if (Number.isNaN(parsed) || parsed < min) return fallback;
+  return parsed;
+}
+
+/**
+ * Read at call time rather than module load so tests and operators can change
+ * the value without re-importing the module.
+ */
+function submissionTimeoutMs(): number {
+  return parseIntEnv(process.env.TRANSFER_ORCHESTRATION_TIMEOUT_MS, 45_000, 1_000);
+}
+
+function maxKeyLength(): number {
+  return parseIntEnv(process.env.TRANSFER_ORCHESTRATION_MAX_KEY_LENGTH, 255, 8);
+}
+
+/** Printable ASCII without whitespace — safe as a Redis key segment. */
+const KEY_CHARSET = /^[A-Za-z0-9._:~-]+$/;
+const MIN_KEY_LENGTH = 8;
+const STORE_KEY_PREFIX = 'transfer';
+
+// ─── Failure classification ───────────────────────────────────────────────────
+
+/**
+ * Soroban error codes that are proven to have failed *before* the signed
+ * envelope was handed to the network. See `submitVaultOperation`: each of these
+ * is raised on the build/simulate path, or is an explicit RPC rejection
+ * (`status === 'ERROR'`), so no transaction exists to duplicate.
+ */
+const PRE_SUBMISSION_CODES = new Set([
+  'SIMULATION_ERROR',
+  'RESTORE_REQUIRED',
+  'RPC_ERROR',
+  'SOROBAN_CIRCUIT_OPEN',
+]);
+
+/** Codes describing a request that cannot succeed however often it is retried. */
+const TERMINAL_CODES = new Set(['INVALID_ADDRESS', 'INVALID_AMOUNT']);
+
+/**
+ * Classify a submission failure.
+ *
+ * Unknown failures default to **`indeterminate`**, which is the opposite of the
+ * default used by the withdrawal saga coordinator and deliberately so: that
+ * coordinator retries idempotent steps, whereas a retry here mints a *new*
+ * transaction. When we cannot prove nothing moved, we refuse to move again and
+ * escalate to an operator instead.
+ */
+export function classifyTransferFailure(err: unknown): TransferFailureClass {
+  if (err instanceof CircuitOpenError) return 'retryable';
+  if (err instanceof TransferOrchestrationError) return err.classification;
+
+  if (!err || typeof err !== 'object') return 'indeterminate';
+  const e = err as { code?: unknown; statusCode?: unknown };
+
+  const code = typeof e.code === 'string' ? e.code : undefined;
+  if (code) {
+    if (TERMINAL_CODES.has(code)) return 'terminal';
+    if (PRE_SUBMISSION_CODES.has(code)) return 'retryable';
+  }
+
+  // A 4xx that is not one of the codes above is still a rejected request.
+  const status = typeof e.statusCode === 'number' ? e.statusCode : undefined;
+  if (status !== undefined && status >= 400 && status < 500 && status !== 409) {
+    return 'terminal';
+  }
+
+  return 'indeterminate';
+}
+
+// ─── Stored record ────────────────────────────────────────────────────────────
+
+/**
+ * What is persisted under the idempotency key.
+ *
+ * `rejected` and `in_doubt` records are stored deliberately: replaying them is
+ * how a retry is stopped from re-submitting. `retryable` failures are *not*
+ * stored — they throw out of the operation so the store keeps nothing and the
+ * next attempt re-executes.
+ */
+interface StoredTransfer {
+  outcome: 'submitted' | 'rejected' | 'in_doubt';
+  transactionHash: string | null;
+  code: string | null;
+  message: string | null;
+  /** HTTP status to replay for a stored rejection. */
+  statusCode: number | null;
+  submittedAt: string;
+}
+
+// ─── In-doubt registry ────────────────────────────────────────────────────────
+
+const inDoubtTransfers = new Map<string, InDoubtTransfer & { fingerprint: string }>();
+
+function recordInDoubt(entry: InDoubtTransfer & { fingerprint: string }): void {
+  inDoubtTransfers.set(entry.storeKey, entry);
+  transferOrchestrationInDoubt.set(inDoubtTransfers.size);
+}
+
+/** Project the operator-facing view, dropping the internal fingerprint. */
+function toOperatorView(entry: InDoubtTransfer & { fingerprint: string }): InDoubtTransfer {
+  return {
+    storeKey: entry.storeKey,
+    idempotencyKey: entry.idempotencyKey,
+    walletAddress: entry.walletAddress,
+    operationType: entry.operationType,
+    amount: entry.amount,
+    asset: entry.asset,
+    code: entry.code,
+    message: entry.message,
+    detectedAt: entry.detectedAt,
+    correlationId: entry.correlationId,
+  };
+}
+
+/** Snapshot of transfers awaiting operator reconciliation. */
+export function listInDoubtTransfers(): InDoubtTransfer[] {
+  return Array.from(inDoubtTransfers.values()).map(toOperatorView);
+}
+
+export function getInDoubtTransfer(storeKey: string): InDoubtTransfer | null {
+  const entry = inDoubtTransfers.get(storeKey);
+  return entry ? toOperatorView(entry) : null;
+}
+
+/**
+ * Close an in-doubt window after an operator has checked the chain.
+ *
+ * - `{ transactionHash }` – the transfer *did* land. The stored record becomes a
+ *   normal success so any replay of the original key returns that hash.
+ * - `{ discard: true }` – nothing landed. The key is released so the client may
+ *   retry the transfer from scratch.
+ */
+export async function resolveInDoubtTransfer(
+  storeKey: string,
+  resolution: { transactionHash: string } | { discard: true },
+): Promise<boolean> {
+  const entry = inDoubtTransfers.get(storeKey);
+  if (!entry) return false;
+
+  // Drop the parked record first; both resolutions replace or release it.
+  await idempotencyStore.deleteKey(storeKey);
+
+  if ('discard' in resolution) {
+    inDoubtTransfers.delete(storeKey);
+    transferOrchestrationInDoubt.set(inDoubtTransfers.size);
+    logger.log('warn', 'In-doubt transfer discarded; key released for retry', {
+      storeKey,
+      walletAddress: entry.walletAddress,
+      operationType: entry.operationType,
+      traceId: getCurrentTraceId(),
+    });
+    return true;
+  }
+
+  const confirmed: StoredTransfer = {
+    outcome: 'submitted',
+    transactionHash: resolution.transactionHash,
+    code: null,
+    message: null,
+    statusCode: null,
+    submittedAt: new Date().toISOString(),
+  };
+
+  // Re-seed the key with the confirmed hash. The operation body never runs a
+  // submission — it only writes the record the operator supplied.
+  await idempotencyStore.execute<StoredTransfer>(storeKey, entry.fingerprint, async () => ({
+    statusCode: 200,
+    body: confirmed,
+  }));
+
+  inDoubtTransfers.delete(storeKey);
+  transferOrchestrationInDoubt.set(inDoubtTransfers.size);
+  logger.log('info', 'In-doubt transfer confirmed as submitted', {
+    storeKey,
+    transactionHash: resolution.transactionHash,
+    walletAddress: entry.walletAddress,
+    operationType: entry.operationType,
+    traceId: getCurrentTraceId(),
+  });
+  return true;
+}
+
+/** Test hook: clears the in-doubt registry and its gauge. */
+export function resetTransferOrchestratorForTests(): void {
+  inDoubtTransfers.clear();
+  transferOrchestrationInDoubt.set(0);
+}
+
+// ─── Validation ───────────────────────────────────────────────────────────────
+
+/**
+ * Amounts arrive as strings to survive JSON without float rounding. Accept a
+ * plain positive decimal only — no exponents, no signs, no `Infinity`/`NaN`,
+ * all of which `Number()` would happily coerce further down the stack.
+ */
+const AMOUNT_PATTERN = /^\d+(\.\d+)?$/;
+
+function assertValidKey(idempotencyKey: unknown): string {
+  if (typeof idempotencyKey !== 'string' || idempotencyKey.trim() === '') {
+    throw new TransferValidationError(
+      'An idempotency key is required for transfer orchestration',
+      'TRANSFER_IDEMPOTENCY_KEY_REQUIRED',
+    );
+  }
+
+  const key = idempotencyKey.trim();
+  if (key.length < MIN_KEY_LENGTH) {
+    throw new TransferValidationError(
+      `Idempotency key must be at least ${MIN_KEY_LENGTH} characters`,
+      'TRANSFER_IDEMPOTENCY_KEY_TOO_SHORT',
+    );
+  }
+  if (key.length > maxKeyLength()) {
+    throw new TransferValidationError(
+      `Idempotency key must be at most ${maxKeyLength()} characters`,
+      'TRANSFER_IDEMPOTENCY_KEY_TOO_LONG',
+    );
+  }
+  if (!KEY_CHARSET.test(key)) {
+    throw new TransferValidationError(
+      'Idempotency key may only contain letters, digits and the characters . _ : ~ -',
+      'TRANSFER_IDEMPOTENCY_KEY_INVALID',
+    );
+  }
+  return key;
+}
+
+function assertValidParams(params: TransferParams): TransferParams {
+  if (params?.operationType !== 'deposit' && params?.operationType !== 'withdrawal') {
+    throw new TransferValidationError(
+      'operationType must be "deposit" or "withdrawal"',
+      'TRANSFER_OPERATION_INVALID',
+      422,
+    );
+  }
+  if (!isValidStellarAddress(params.walletAddress)) {
+    throw new TransferValidationError(
+      'walletAddress is not a valid Stellar public key',
+      'TRANSFER_WALLET_INVALID',
+      422,
+    );
+  }
+  if (typeof params.amount !== 'string' || !AMOUNT_PATTERN.test(params.amount.trim())) {
+    throw new TransferValidationError(
+      'amount must be a positive decimal string',
+      'TRANSFER_AMOUNT_INVALID',
+      422,
+    );
+  }
+  if (Number(params.amount) <= 0) {
+    throw new TransferValidationError(
+      'amount must be greater than zero',
+      'TRANSFER_AMOUNT_INVALID',
+      422,
+    );
+  }
+  if (typeof params.asset !== 'string' || params.asset.trim() === '') {
+    throw new TransferValidationError('asset is required', 'TRANSFER_ASSET_INVALID', 422);
+  }
+
+  // Canonicalise so two spellings of the same request share one fingerprint.
+  return {
+    operationType: params.operationType,
+    walletAddress: normalizeWalletAddress(params.walletAddress),
+    amount: params.amount.trim(),
+    asset: params.asset.trim().toUpperCase(),
+  };
+}
+
+/**
+ * Scope the caller's key to the wallet so a guessed or trivially-chosen key
+ * cannot collide across wallets. The wallet is hashed rather than embedded so
+ * the key stays a bounded length and does not leak an address into Redis
+ * keyspace listings.
+ */
+export function buildTransferStoreKey(walletAddress: string, idempotencyKey: string): string {
+  const walletScope = crypto
+    .createHash('sha256')
+    .update(normalizeWalletAddress(walletAddress))
+    .digest('hex')
+    .slice(0, 16);
+  return `${STORE_KEY_PREFIX}:${walletScope}:${idempotencyKey}`;
+}
+
+// ─── Timeout guard ────────────────────────────────────────────────────────────
+
+class TransferTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`Transfer submission did not settle within ${timeoutMs}ms`);
+    this.name = 'TransferTimeoutError';
+  }
+}
+
+/**
+ * Bound the submission so a hung RPC cannot pin the key's in-flight slot for the
+ * lifetime of the process. A timeout is *not* proof that nothing was submitted,
+ * so it is classified `indeterminate` by the caller.
+ */
+async function withTimeout<T>(operation: () => Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      operation(),
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new TransferTimeoutError(timeoutMs)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+// ─── Orchestration ────────────────────────────────────────────────────────────
+
+/**
+ * Orchestrate a vault transfer idempotently and retry-safely.
+ *
+ * @param params - transfer details; canonicalised before fingerprinting
+ * @param idempotencyKey - stable client-supplied key (e.g. a UUID)
+ *
+ * @throws {TransferValidationError}   malformed request or key (400/422)
+ * @throws {TransferConflictError}     key reused with a different body (409)
+ * @throws {TransferInDoubtError}      outcome unknown; needs reconciliation (409)
+ * @throws {TransferUnavailableError}  dependency down, nothing submitted (503)
+ * @throws {TransferOrchestrationError} stored terminal rejection, replayed
  */
 export async function orchestrateTransfer(
   params: TransferParams,
   idempotencyKey: string,
-): Promise<{ result: IdempotentOperationResult<string>; replayed: boolean }> {
-  const fingerprint = buildIdempotencyFingerprint(params);
+): Promise<TransferOrchestrationResult> {
+  const key = assertValidKey(idempotencyKey);
+  const canonical = assertValidParams(params);
+  const storeKey = buildTransferStoreKey(canonical.walletAddress, key);
+  const fingerprint = buildIdempotencyFingerprint(canonical);
+  const operation = canonical.operationType;
+  const startedAt = Date.now();
 
-  return idempotencyStore.execute<string>(idempotencyKey, fingerprint, async () => {
-    const txHash = await submitVaultOperation(
-      params.operationType,
-      params.walletAddress,
-      params.amount,
-      params.asset,
+  let stored: { result: IdempotentOperationResult<StoredTransfer>; replayed: boolean };
+  try {
+    stored = await idempotencyStore.execute<StoredTransfer>(storeKey, fingerprint, async () => {
+      const record = await submitOnce(canonical, storeKey, key, fingerprint);
+      return { statusCode: 200, body: record };
+    });
+  } catch (err) {
+    if (err instanceof IdempotencyConflictError) {
+      transferOrchestrationTotal.inc({ operation, outcome: 'conflict' });
+      logger.log('warn', 'Transfer idempotency key reused with a different body', {
+        storeKey,
+        operationType: operation,
+        walletAddress: canonical.walletAddress,
+        traceId: getCurrentTraceId(),
+      });
+      throw new TransferConflictError();
+    }
+    // A retryable failure: nothing was stored, so the next call re-executes.
+    throw toPublicError(err, storeKey, operation, startedAt);
+  }
+
+  const record = stored.result.body;
+
+  if (record.outcome === 'in_doubt') {
+    // Raised for the caller that opened the window *and* for every later replay
+    // of the parked key, so no caller ever sees a success-shaped result.
+    if (stored.replayed) transferOrchestrationReplayTotal.inc({ operation, replay_of: 'in_doubt' });
+    throw new TransferInDoubtError(storeKey, record.message ?? record.code ?? 'unknown failure');
+  }
+
+  if (record.outcome === 'rejected') {
+    if (stored.replayed) transferOrchestrationReplayTotal.inc({ operation, replay_of: 'rejected' });
+    throw new TransferOrchestrationError(
+      record.message ?? 'Transfer was rejected',
+      record.code ?? 'TRANSFER_REJECTED',
+      record.statusCode ?? 422,
+      'terminal',
     );
-    // The service returns the transaction hash as the body.
-    return { statusCode: 200, body: txHash };
+  }
+
+  const outcome = stored.replayed ? 'replayed' : 'submitted';
+  transferOrchestrationTotal.inc({ operation, outcome });
+  transferOrchestrationDurationMs.observe({ operation, outcome }, Date.now() - startedAt);
+  if (stored.replayed) {
+    transferOrchestrationReplayTotal.inc({ operation, replay_of: 'submitted' });
+  }
+
+  logger.log('info', `Transfer orchestration ${outcome}`, {
+    storeKey,
+    operationType: operation,
+    walletAddress: canonical.walletAddress,
+    amount: canonical.amount,
+    asset: canonical.asset,
+    transactionHash: record.transactionHash,
+    replayed: stored.replayed,
+    traceId: getCurrentTraceId(),
   });
+
+  return {
+    result: { statusCode: 200, body: record.transactionHash as string },
+    replayed: stored.replayed,
+    outcome,
+    transactionHash: record.transactionHash as string,
+    storeKey,
+  };
+}
+
+/**
+ * Submit exactly once, translating the outcome into a record to store or an
+ * error to propagate.
+ *
+ * Returning a record means "store this under the key"; throwing means "store
+ * nothing, this may be retried".
+ */
+async function submitOnce(
+  canonical: TransferParams,
+  storeKey: string,
+  idempotencyKey: string,
+  fingerprint: string,
+): Promise<StoredTransfer> {
+  const operation = canonical.operationType;
+  const attemptStartedAt = Date.now();
+
+  try {
+    const transactionHash = await withTimeout(
+      () =>
+        sorobanCircuitBreaker.execute(() =>
+          submitVaultOperation(
+            canonical.operationType,
+            canonical.walletAddress,
+            canonical.amount,
+            canonical.asset,
+          ),
+        ),
+      submissionTimeoutMs(),
+    );
+
+    return {
+      outcome: 'submitted',
+      transactionHash,
+      code: null,
+      message: null,
+      statusCode: null,
+      submittedAt: new Date().toISOString(),
+    };
+  } catch (err) {
+    const classification = classifyTransferFailure(err);
+    const code = errorCode(err);
+    const message = err instanceof Error ? err.message : String(err);
+
+    transferOrchestrationFailureTotal.inc({ operation, classification, code });
+    transferOrchestrationDurationMs.observe(
+      { operation, outcome: classification },
+      Date.now() - attemptStartedAt,
+    );
+
+    if (classification === 'terminal') {
+      logger.log('warn', 'Transfer rejected terminally; caching rejection under key', {
+        storeKey,
+        operationType: operation,
+        walletAddress: canonical.walletAddress,
+        code,
+        error: message,
+        traceId: getCurrentTraceId(),
+      });
+      transferOrchestrationTotal.inc({ operation, outcome: 'rejected' });
+      return {
+        outcome: 'rejected',
+        transactionHash: null,
+        code,
+        message,
+        statusCode: httpStatusOf(err, 422),
+        submittedAt: new Date().toISOString(),
+      };
+    }
+
+    if (classification === 'indeterminate') {
+      // Park the key. Storing an `in_doubt` record is what stops a retry from
+      // minting a second transaction; the alert is what gets it reconciled.
+      recordInDoubt({
+        storeKey,
+        idempotencyKey,
+        walletAddress: canonical.walletAddress,
+        operationType: canonical.operationType,
+        amount: canonical.amount,
+        asset: canonical.asset,
+        code,
+        message,
+        detectedAt: new Date().toISOString(),
+        correlationId: getCurrentTraceId() ?? null,
+        fingerprint,
+      });
+      transferOrchestrationTotal.inc({ operation, outcome: 'in_doubt' });
+      logger.log('error', 'Transfer outcome unknown; parked for reconciliation', {
+        alert: 'transfer-in-doubt',
+        storeKey,
+        operationType: operation,
+        walletAddress: canonical.walletAddress,
+        amount: canonical.amount,
+        asset: canonical.asset,
+        code,
+        error: message,
+        traceId: getCurrentTraceId(),
+      });
+      return {
+        outcome: 'in_doubt',
+        transactionHash: null,
+        code,
+        message,
+        statusCode: 409,
+        submittedAt: new Date().toISOString(),
+      };
+    }
+
+    // Retryable: throw so the store keeps nothing and a retry re-executes.
+    logger.log('warn', 'Transfer failed before submission; safe to retry', {
+      storeKey,
+      operationType: operation,
+      walletAddress: canonical.walletAddress,
+      code,
+      error: message,
+      traceId: getCurrentTraceId(),
+    });
+    throw err;
+  }
+}
+
+/**
+ * Map a thrown (i.e. retryable, nothing-stored) failure onto the public error
+ * surface, so callers get a 503 with a retry hint instead of a raw RPC error.
+ */
+function toPublicError(
+  err: unknown,
+  storeKey: string,
+  operation: 'deposit' | 'withdrawal',
+  startedAt: number,
+): Error {
+  if (err instanceof TransferOrchestrationError) return err;
+
+  transferOrchestrationTotal.inc({ operation, outcome: 'retryable_failure' });
+  transferOrchestrationDurationMs.observe(
+    { operation, outcome: 'retryable_failure' },
+    Date.now() - startedAt,
+  );
+
+  if (err instanceof CircuitOpenError) {
+    return new TransferUnavailableError(
+      'Soroban RPC circuit breaker is open; transfer was not submitted',
+      err.retryAfterMs,
+      'TRANSFER_CIRCUIT_OPEN',
+    );
+  }
+
+  const message = err instanceof Error ? err.message : String(err);
+  return new TransferUnavailableError(
+    `Transfer was not submitted: ${message}`,
+    0,
+    errorCode(err) || 'TRANSFER_DEPENDENCY_UNAVAILABLE',
+  );
+}
+
+function errorCode(err: unknown): string {
+  if (err instanceof CircuitOpenError) return 'SOROBAN_CIRCUIT_OPEN';
+  if (err instanceof TransferTimeoutError) return 'TRANSFER_TIMEOUT';
+  if (err && typeof err === 'object') {
+    const code = (err as { code?: unknown }).code;
+    if (typeof code === 'string' && code) return code;
+    const name = (err as { name?: unknown }).name;
+    if (typeof name === 'string' && name) return name;
+  }
+  return 'UNKNOWN';
+}
+
+function httpStatusOf(err: unknown, fallback: number): number {
+  if (err && typeof err === 'object') {
+    const status = (err as { statusCode?: unknown }).statusCode;
+    if (typeof status === 'number' && status >= 400 && status < 600) return status;
+  }
+  return fallback;
 }

--- a/docs/BACKEND_MODULE_OWNERSHIP.md
+++ b/docs/BACKEND_MODULE_OWNERSHIP.md
@@ -104,6 +104,7 @@ Modules are grouped by **functional domain**. Each entry lists:
 | Retry budget (circuit-breaker adjunct) | `@reliability-owner` | `@backend-lead` | **Medium** | [retryBudget.ts](file:///c:/Users/USER/Desktop/YieldVault-RWA/backend/src/retryBudget.ts) | — | `backend`, `reliability` |
 | Soroban RPC circuit breaker | `@integrations-owner` | `@reliability-owner` | **High** | [circuitBreaker.ts](file:///c:/Users/USER/Desktop/YieldVault-RWA/backend/src/circuitBreaker.ts) | [circuitBreaker.test.ts](file:///c:/Users/USER/Desktop/YieldVault-RWA/backend/src/__tests__/circuitBreaker.test.ts) | `backend`, `reliability`, `stellar` |
 | Withdrawal partial-failure recovery (saga journal) | `@reliability-owner` | `@vault-domain-owner` | **Core** | [withdrawalRecovery.ts](file:///c:/Users/USER/Desktop/YieldVault-RWA/backend/src/withdrawalRecovery.ts) | [withdrawalRecovery.test.ts](file:///c:/Users/USER/Desktop/YieldVault-RWA/backend/src/__tests__/withdrawalRecovery.test.ts), [withdrawalRecoveryEndpoint.test.ts](file:///c:/Users/USER/Desktop/YieldVault-RWA/backend/src/__tests__/withdrawalRecoveryEndpoint.test.ts) | `backend`, `reliability`, `vault` |
+| Transfer orchestration (idempotent, retry-safe) | `@reliability-owner` | `@vault-domain-owner` | **Core** | [transferOrchestrator.ts](file:///c:/Users/USER/Desktop/YieldVault-RWA/backend/src/transferOrchestrator.ts) | [transferOrchestrator.test.ts](file:///c:/Users/USER/Desktop/YieldVault-RWA/backend/src/__tests__/transferOrchestrator.test.ts) | `backend`, `reliability`, `idempotency` |
 
 ---
 
@@ -209,7 +210,7 @@ Use this table when you only know the source filename and need to find the ownin
 | `middleware/cors.ts`, `middleware/geofencing.ts`, `middleware/allowlist.ts`, `middleware/validate.ts`, `middleware/payloadLimit.ts` | Security middleware | `@auth-owner` |
 | `middleware/cache.ts` | Cache middleware | `@reliability-owner` |
 | `middleware/withdrawalDailyLimit.ts` | Vault limits | `@vault-domain-owner` |
-| `rateLimiter.ts`, `idempotency.ts`, `idempotencyRetention.ts`, `retryBudget.ts`, `circuitBreaker.ts`, `withdrawalRecovery.ts` | Resilience & Throttling | `@reliability-owner` |
+| `rateLimiter.ts`, `idempotency.ts`, `idempotencyRetention.ts`, `retryBudget.ts`, `circuitBreaker.ts`, `withdrawalRecovery.ts`, `transferOrchestrator.ts` | Resilience & Throttling | `@reliability-owner` |
 | `vaultEndpoints.ts`, `apySnapshot.ts` | Vault domain | `@vault-domain-owner` |
 | `transactionEndpoints.ts`, `transactionBackfill.ts` | Transactions | `@vault-domain-owner` |
 | `listEndpoints.ts`, `pagination.ts`, `dateRange.ts` | Data & pagination | `@data-owner` |
@@ -241,7 +242,7 @@ When opening a PR, auto-assign reviewers based on which **top-level directories 
 |---------------------|-------------------|----------------------|
 | `backend/src/auth.ts` OR `backend/src/wallet*.ts` OR `backend/src/scopedAdminTokens.ts` OR `backend/src/middleware/{apiKeyAuth,rbac,tenantGuard,walletQueryGuard,walletSignedAction}.ts` | `backend`, `auth`, `security` | `@auth-owner` (Primary), `@backend-lead` (Secondary) |
 | `backend/src/middleware/*.ts` (any middleware) | `backend`, `middleware` | Primary = owner per module above; Secondary = `@backend-lead` |
-| `backend/src/{rateLimiter,circuitBreaker,idempotency*,retryBudget,withdrawalRecovery}.ts` | `backend`, `reliability` | `@reliability-owner` (Primary), `@auth-owner` (Secondary) |
+| `backend/src/{rateLimiter,circuitBreaker,idempotency*,retryBudget,withdrawalRecovery,transferOrchestrator}.ts` | `backend`, `reliability` | `@reliability-owner` (Primary), `@auth-owner` (Secondary) |
 | `backend/src/{vaultEndpoints,transactionEndpoints,apySnapshot,listEndpoints,referral*,walletAlias*}.ts` | `backend`, `vault` or `backend`, `transactions` | `@vault-domain-owner` (Primary), `@data-owner` (Secondary) |
 | `backend/prisma/schema.prisma` OR `backend/migrations/` OR `backend/scripts/{migrate-postgres,check-postgres-drift}.js` | `backend`, `database`, `migrations` | `@data-owner` (Primary), `@backend-lead` (Secondary) — 2 approvals required for schema changes |
 | `backend/src/{export*,bulkExport*,exportManifest,apiContractSnapshots,governanceSnapshotExport,pagination,dateRange}.ts` OR `backend/schema-snapshots/` | `backend`, `data` | `@data-owner` (Primary), `@vault-domain-owner` (Secondary) |

--- a/docs/DEPOSIT_WITHDRAWAL_LIFECYCLE.md
+++ b/docs/DEPOSIT_WITHDRAWAL_LIFECYCLE.md
@@ -287,6 +287,18 @@ recovery handle rather than a misleading `500`.
 See [Withdrawal Partial-Failure Recovery](../backend/docs/WITHDRAWAL_PARTIAL_FAILURE_RECOVERY.md)
 for the state machine, admin endpoints, metrics, and the operator runbook.
 
+#### Retrying a Submission
+
+Retrying a transfer is not a repeat of the first attempt — each call to
+`submitVaultOperation` builds a new transaction with a new sequence number, so a
+blind retry can move funds twice. The transfer orchestration service decides per
+failure whether a retry is safe: pre-submission failures re-execute, invalid
+requests replay their rejection, and a failure whose outcome cannot be determined
+is parked for operator reconciliation rather than resubmitted.
+
+See [Transfer Orchestration](../backend/docs/TRANSFER_ORCHESTRATION.md) for the
+classification table, the wallet-scoped key format, and the in-doubt runbook.
+
 ---
 
 ## Share Price Mechanics
@@ -324,5 +336,6 @@ See [WEBHOOK_INTEGRATION.md](./WEBHOOK_INTEGRATION.md) for full event schema and
 
 - [Contracts Architecture](./CONTRACTS_ARCHITECTURE.md) — Full contract interface and storage layout
 - [Withdrawal Partial-Failure Recovery](../backend/docs/WITHDRAWAL_PARTIAL_FAILURE_RECOVERY.md) — Saga journal, recovery states, and operator runbook
+- [Transfer Orchestration](../backend/docs/TRANSFER_ORCHESTRATION.md) — Idempotency keys, retry-safety contract, and in-doubt reconciliation
 - [Webhook Integration Guide](./WEBHOOK_INTEGRATION.md) — Consuming on-chain events
 - [Local Development Quickstart](./LOCAL_DEVELOPMENT_QUICKSTART.md) — Running the stack locally

--- a/docs/ENV_VARIABLE_MATRIX.md
+++ b/docs/ENV_VARIABLE_MATRIX.md
@@ -135,6 +135,15 @@ See [Withdrawal Partial-Failure Recovery](../backend/docs/WITHDRAWAL_PARTIAL_FAI
 | `WITHDRAWAL_RECOVERY_MAX_PER_SWEEP` | `25` | ⬜ optional | `25` |
 | `WITHDRAWAL_RECOVERY_RETENTION` | `1000` | ⬜ optional | `1000` |
 
+### Transfer Orchestration
+
+See [Transfer Orchestration](../backend/docs/TRANSFER_ORCHESTRATION.md).
+
+| Variable | Default | Required | Production Recommendation |
+|---|---|---|---|
+| `TRANSFER_ORCHESTRATION_TIMEOUT_MS` | `45000` (45 s) | ⬜ optional | `45000` (a timeout is treated as in-doubt, never auto-retried) |
+| `TRANSFER_ORCHESTRATION_MAX_KEY_LENGTH` | `255` | ⬜ optional | `255` |
+
 ### OpenTelemetry (Tracing)
 
 | Variable | Default | Required | Production Recommendation |


### PR DESCRIPTION
A vault transfer moves money. `submitVaultOperation` builds a fresh transaction with a fresh sequence number, so retrying it is not a repeat of the first attempt — it is a second transaction. The previous service wrapped the RPC in `IdempotencyStore.execute` and stopped there, which covers the happy path and leaves every failure path open.

Harden it into a service that decides, per failure, whether a retry is safe:

- Scope idempotency keys per wallet (`transfer:<sha256(wallet)>:<key>`) so a trivial key from one wallet no longer occupies another's slot. The wallet is hashed so no address leaks into a Redis key listing.
- Validate the key (length, charset) and the request, and canonicalise wallet/asset/amount so equivalent spellings share one fingerprint instead of raising a false conflict. Amounts must be positive plain decimals, which rejects NaN/Infinity/exponent forms that `Number()` would otherwise coerce further down the stack.
- Classify failures at the submission boundary. Pre-submission failures are `retryable` and store nothing, so a retry re-executes. Invalid requests are `terminal` and their rejection is stored and replayed. Anything that may already have reached the network is `indeterminate`: the key is parked, the transfer is never auto-resubmitted, and an operator reconciles it. Unknown failures default to `indeterminate` — deliberately the opposite of the withdrawal saga default, because a retry here mints a new transaction rather than repeating an idempotent step.
- Fail fast through the Soroban circuit breaker and bound each submission with a timeout, so a dead RPC no longer absorbs the retry budget per request and a hung call no longer pins the key's in-flight slot for the life of the process.
- Add typed errors carrying code/status/classification, an in-doubt registry with confirm/discard resolution, and metrics including a `transfer_orchestration_in_doubt` gauge plus a `transfer-in-doubt` log alert.

Also fixes the existing test, which asserted on a spy that could never be called: it mocked `../sorobanClient` while the orchestrator imports `./sorobanClient`, and only the latter specifier is remapped to the shared mock by jest.config.js.

Closes #1043

# Pull Request Template

## 📋 Description
Add a complete environment variable matrix (`docs/ENV_VARIABLE_MATRIX.md`) covering every env var consumed across the backend and frontend, with defaults, required flags, and production recommendations. Update `README.md` and `ENV_QUICK_REFERENCE.md` to link to the new document.

## 🔗 Type of Change
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📚 Documentation update
- [ ] 🔒 Security improvement

---

## 🔒 SECURITY REVIEW (⭐ MANDATORY FOR SMART CONTRACT CHANGES)

**For all smart contract code changes, complete the following checklist.**

See [`docs/SECURITY_CHECKLIST.md`](/docs/SECURITY_CHECKLIST.md) for detailed guidance.

### Required: Security Checklist Sign-Off
- [ ] **I have reviewed this PR against the Internal Security Checklist** (`docs/SECURITY_CHECKLIST.md`)
  - [ ] Reentrancy: Verified Checks-Effects-Interactions (CEI) pattern
  - [ ] Access Control: Confirmed all sensitive functions are protected (`onlyOwner`, `onlyRole()`, etc.)
  - [ ] Input Validation: Validated all parameters have appropriate bounds checks
  - [ ] Unchecked Returns: All external calls have return value checks (`require(success, ...)`)
  - [ ] Gas Limits: No unbounded loops or potential DOS vectors
  
  **If any checkbox cannot be verified, explain below:**
  ```
  N/A — this PR contains only documentation changes. No smart contract code was modified.
  ```

### Slither Static Analysis Results
- [ ] Ran Slither locally: `slither . --config-file slither.config.json`
  - **Result**: ✅ No High/Medium findings OR 🟡 Documented false positives (see below)
  
- [ ] GitHub Actions Slither workflow passed:
  - 🟢 All High/Medium findings fixed OR
  - 🟡 All false positives documented with FP references
  
  **If this PR has security findings, document them below:**
  ```
  N/A — documentation-only PR. No contract or runtime code changed.
  ```

### Handling Security Findings

#### Option A: Fixed in This PR ✅
- [ ] Vulnerability identified and resolved
- [ ] Test case added to verify fix
- [ ] Explain fix below:
  ```
  N/A
  ```

#### Option B: False Positive 🟡
- [ ] Identified as false positive (tool limitation or misleading check)
- [ ] Added entry to `contracts/.false-positives.md` with:
  - Detector rule name
  - Technical reasoning (3+ sentences why it's safe)
  - Evidence (code snippet, test case, or reference)
- [ ] Reference number (e.g., FP-001):
  ```
  N/A
  ```
- [ ] Inline suppression added to code:
  ```solidity
  // slither-disable-next-line <detector-name>
  // Reason: [one-line reason]
  ```

#### Option C: Accepted Risk ⚠️
- [ ] Acknowledged as low-priority style issue (naming conventions, etc.)
- [ ] Added to Slither exclusions
- [ ] Explain below:
  ```
  N/A
  ```

---

## 📝 Testing

### Functional Testing
- [x] Unit tests added/updated for changes
- [x] Integration tests passing
- [x] Manual testing completed and documented below:
  ```
  - Verified all variable names, defaults, and required flags against source files:
    backend/src/index.ts, rateLimiter.ts, auth.ts, tracing.ts
  - Cross-checked every .env.example, .env.local.example, .env.production.example
    in both backend/ and frontend/
  - Confirmed links in README.md and ENV_QUICK_REFERENCE.md resolve correctly
  - No runtime code changed; no functional regression possible
  ```

### Security Testing
- For state-changing functions:
  - [ ] Reentrancy test (if applicable): Verify re-entry is blocked
  - [ ] Access control test: Verify unauthorized access is rejected
  - [ ] Boundary test: Verify edge cases are handled
  
- For external integrations:
  - [ ] Return value verification test
  - [ ] Failure scenario test

### Test Coverage
- [x] All new code paths have test coverage
- [x] Security-critical paths have comprehensive test cases
- [x] Coverage report: `N/A — documentation only, no executable code added`

---

## 🚀 Deployment Notes

No deployment steps required. This PR adds a Markdown file and updates two existing Markdown files only.

### Mainnet Readiness
- [ ] This code is ready for production deployment
- [x] All critical tests pass
- [ ] Security review approved
- [x] No temporary debug code
- [x] No TODO comments

### Breaking Changes
If this PR introduces breaking changes:
- [ ] Migration guide provided
- [ ] Deprecation period defined: `[timeframe]`
- [ ] Legacy code deprecated with warnings

---

## 📊 Automated Scan Results

<!-- GitHub Actions will update this section -->

### Slither Analysis
- ✓ Status: N/A — no contract code changed
- 🔴 High/Medium findings: 0
- 🟡 Low/Informational findings: 0
- 🟢 No issues detected: documentation-only PR

### Related Documentation
- [Security Checklist](docs/SECURITY_CHECKLIST.md) — Use for code review
- [False Positive Process](docs/FALSE_POSITIVE_HANDLING.md) — For non-vulnerabilities
- [Slither Configuration](slither.config.json) — Current scanner settings

---

## ✅ Reviewer Checklist

**For code reviewers** (use this to guide your security-focused review):

- [x] PR author completed security checklist ✓
- [x] All findings documented and categorized (fixed/false positive/excluded)
- [x] Inline security comments are clear and justified
- [ ] Tests cover security-critical code paths
- [ ] No external calls bypass return value checks
- [ ] Access control is properly enforced
- [ ] State updates follow CEI pattern
- [ ] Input validation is comprehensive
- [x] Follow-up actions (if any) tracked in issues

---

## 📞 Questions or Issues?

- 🤔 Confused about security checklist? → See [`docs/SECURITY_CHECKLIST.md`](/docs/SECURITY_CHECKLIST.md)
- 🔍 Marking finding as false positive? → Follow [`docs/FALSE_POSITIVE_HANDLING.md`](/docs/FALSE_POSITIVE_HANDLING.md)
- 🆘 Need security review help? → Tag `@security-team` in comments

---

## 📋 Pre-Submit Checklist

Before marking PR as ready for review:

- [x] Description is clear and concise
- [x] All security checklist items checked (✅ or explanation provided)
- [x] All tests passing locally: `npm test`
- [x] Linter passing: `npm run lint`
- [ ] Slither passing locally OR findings documented: `slither . --config-file slither.config.json`
- [x] Code follows project style guide
- [x] No merge conflicts
- [x] Commits are clean and well-documented
- [x] Branch is up-to-date with main/develop
- [ ] For **release PRs**: `docs/RELEASE_READINESS_CHECKLIST.md` completed and linked in PR description

---

**✅ Ready for Review?** Ensure all items above are checked before requesting review.
