### PR TITLE
Backend: add query performance budgets and slow-query alerts

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -79,6 +79,20 @@ PRISMA_QUERY_TIMEOUT_MS=5000
 PRISMA_TX_MAX_WAIT_MS=5000
 PRISMA_TX_TIMEOUT_MS=10000
 
+# ── Query performance budgets and slow-query alerts ──────────────────────────
+# Per-query defaults; exact model/action overrides use a JSON object.
+# QUERY_READ_BUDGET_MS=100
+# QUERY_WRITE_BUDGET_MS=200
+# QUERY_BUDGETS_JSON={"User.findUnique":50,"Transaction.findMany":150}
+# A breach at or above this multiple of its budget is critical.
+# SLOW_QUERY_CRITICAL_MULTIPLIER=3
+# SLOW_QUERY_ALERT_COOLDOWN_MS=900000
+# SLOW_QUERY_ALERT_TIMEOUT_MS=5000
+# QUERY_ALERT_TYPE=both                 # slack | pagerduty | both
+# SLOW_QUERY_SLACK_WEBHOOK_URL=         # falls back to SLACK_WEBHOOK_URL
+# SLOW_QUERY_PAGERDUTY_INTEGRATION_KEY= # falls back to PAGERDUTY_INTEGRATION_KEY
+# REDIS_URL below shares alert cooldowns across backend replicas.
+
 # ── Cache Configuration ───────────────────────────────────────────────────────
 # Redis-backed response cache for price and vault summary endpoints.
 # When REDIS_URL is set, GET responses for /api/v1/vault/summary, /api/v1/vault/apy,

--- a/backend/docs/QUERY_PERFORMANCE_BUDGETS.md
+++ b/backend/docs/QUERY_PERFORMANCE_BUDGETS.md
@@ -1,0 +1,95 @@
+# Query Performance Budgets and Slow-Query Alerts
+
+Issue #1050 establishes a single performance-budget boundary for both Prisma
+operations and raw PostgreSQL queries routed through `DatabaseManager`.
+
+## Runtime behavior
+
+Every query records `db_query_duration_seconds` and publishes its active budget
+through `db_query_budget_ms`. When duration is at least the budget:
+
+1. `db_query_budget_breach_total` increments.
+2. A structured `Database query exceeded budget` log is emitted without SQL
+   text or bind parameters.
+3. The breach is classified as `warning` or `critical`.
+4. Slack and/or PagerDuty delivery is attempted after cooldown acquisition.
+
+Alert delivery is asynchronous and never delays or changes the query result.
+Failed queries are measured too, because a slow failure is still operationally
+important.
+
+## Budget resolution
+
+Budget priority is:
+
+1. Valid `QUERY_BUDGETS_JSON` exact override.
+2. Built-in hot-path budget in `QUERY_BUDGETS`.
+3. `QUERY_READ_BUDGET_MS` or `QUERY_WRITE_BUDGET_MS`.
+
+Example:
+
+```env
+QUERY_READ_BUDGET_MS=100
+QUERY_WRITE_BUDGET_MS=200
+QUERY_BUDGETS_JSON={"User.findUnique":50,"Transaction.findMany":150,"raw_replica.select":400}
+```
+
+Override keys must use `Model.action` with alphanumeric/underscore segments.
+Values must be finite positive numbers. Invalid entries are logged and ignored.
+
+Raw PostgreSQL models are `raw_primary` and `raw_replica`. Their action is the
+leading SQL keyword after comments, such as `select`, `with`, or `update`.
+Neither SQL text nor parameters are placed in metrics or slow-query alerts.
+
+## Severity and routing
+
+A breach becomes critical when:
+
+```text
+duration / budget >= SLOW_QUERY_CRITICAL_MULTIPLIER
+```
+
+The default multiplier is `3`. Warning and critical alerts have separate
+cooldowns, so a warning cannot suppress a later critical escalation.
+
+```env
+SLOW_QUERY_CRITICAL_MULTIPLIER=3
+SLOW_QUERY_ALERT_COOLDOWN_MS=900000
+SLOW_QUERY_ALERT_TIMEOUT_MS=5000
+QUERY_ALERT_TYPE=both
+SLOW_QUERY_SLACK_WEBHOOK_URL=https://hooks.slack.com/...
+SLOW_QUERY_PAGERDUTY_INTEGRATION_KEY=...
+```
+
+Dedicated slow-query credentials fall back to the existing
+`SLACK_WEBHOOK_URL` and `PAGERDUTY_INTEGRATION_KEY`. Non-2xx responses, network
+failures, and timeouts are recorded as `delivery_failed`.
+
+## Multi-instance cooldowns
+
+When `REDIS_URL` is configured, cooldown acquisition uses atomic
+`SET key 1 PX <cooldown> NX`. This limits a given query/severity alert to one
+delivery across all backend replicas. If Redis is unavailable, the process
+falls back to an in-memory cooldown so a single replica still cannot create an
+alert storm.
+
+## Operator response
+
+For a warning:
+
+1. Identify `model` and `action` in the alert.
+2. Compare the budget gauge with P95 latency over the same interval.
+3. Check database saturation, replica lag, connection-pool waits, and recent
+   deployments.
+4. Inspect an approved database query-statistics source. Application alerts
+   intentionally omit SQL and parameters.
+
+For a critical alert:
+
+1. Follow the warning checks immediately.
+2. Assess user-facing latency and error rate.
+3. Consider disabling the affected background job or expensive endpoint.
+4. Page the database/backend owner if the breach persists for two windows.
+
+Do not raise budgets merely to silence alerts. Budget changes should include
+before/after measurements and review of the affected query plan.

--- a/backend/src/__tests__/queryBudgets.test.ts
+++ b/backend/src/__tests__/queryBudgets.test.ts
@@ -1,75 +1,284 @@
 import {
-  getQueryBudget,
-  triggerSlowQueryAlert,
-  resetAlertCooldowns,
   DEFAULT_READ_QUERY_BUDGET_MS,
   DEFAULT_WRITE_QUERY_BUDGET_MS,
+  evaluateQueryPerformance,
+  getQueryBudget,
+  InMemoryAlertCooldownStore,
+  recordQueryPerformance,
+  RedisAlertCooldownStore,
+  resetAlertCooldowns,
+  triggerSlowQueryAlert,
 } from '../queryBudgets';
+import type Redis from 'ioredis';
+import { classifySqlAction, DatabaseManager, type IDatabasePool } from '../database';
+import { dbQueryBudgetBreachTotal } from '../metrics';
+
+const QUERY_ENV_KEYS = [
+  'ALERT_TYPE',
+  'PAGERDUTY_INTEGRATION_KEY',
+  'QUERY_ALERT_TYPE',
+  'QUERY_BUDGETS_JSON',
+  'QUERY_READ_BUDGET_MS',
+  'QUERY_WRITE_BUDGET_MS',
+  'REDIS_URL',
+  'SLACK_WEBHOOK_URL',
+  'SLOW_QUERY_ALERT_COOLDOWN_MS',
+  'SLOW_QUERY_ALERT_TIMEOUT_MS',
+  'SLOW_QUERY_CRITICAL_MULTIPLIER',
+  'SLOW_QUERY_PAGERDUTY_INTEGRATION_KEY',
+  'SLOW_QUERY_SLACK_WEBHOOK_URL',
+] as const;
 
 describe('Query Performance Budgets and Slow Query Alerts', () => {
   const originalFetch = global.fetch;
 
   beforeEach(() => {
+    for (const key of QUERY_ENV_KEYS) delete process.env[key];
+    process.env.SLOW_QUERY_ALERT_COOLDOWN_MS = '1000';
     resetAlertCooldowns();
-    process.env.SLOW_QUERY_ALERT_COOLDOWN_MS = '1000'; // 1s for testing
   });
 
   afterEach(() => {
     global.fetch = originalFetch;
+    for (const key of QUERY_ENV_KEYS) delete process.env[key];
+    resetAlertCooldowns();
   });
 
   describe('getQueryBudget()', () => {
-    it('returns custom budget for configured model and action', () => {
+    it('returns built-in budgets for known model/action pairs', () => {
       expect(getQueryBudget('User', 'findUnique')).toBe(50);
       expect(getQueryBudget('SharePriceSnapshot', 'create')).toBe(150);
     });
 
-    it('returns default read budget for unconfigured read actions', () => {
-      expect(getQueryBudget('UnknownModel', 'findMany')).toBe(DEFAULT_READ_QUERY_BUDGET_MS);
-      expect(getQueryBudget('UnknownModel', 'count')).toBe(DEFAULT_READ_QUERY_BUDGET_MS);
+    it('returns configurable read and write defaults', () => {
+      process.env.QUERY_READ_BUDGET_MS = '75';
+      process.env.QUERY_WRITE_BUDGET_MS = '250';
+
+      expect(getQueryBudget('UnknownModel', 'findMany')).toBe(75);
+      expect(getQueryBudget('raw_primary', 'select')).toBe(75);
+      expect(getQueryBudget('UnknownModel', 'update')).toBe(250);
     });
 
-    it('returns default write budget for unconfigured write actions', () => {
+    it('falls back when default budget configuration is invalid', () => {
+      process.env.QUERY_READ_BUDGET_MS = '-1';
+      process.env.QUERY_WRITE_BUDGET_MS = 'not-a-number';
+
+      expect(getQueryBudget('UnknownModel', 'count')).toBe(DEFAULT_READ_QUERY_BUDGET_MS);
       expect(getQueryBudget('UnknownModel', 'create')).toBe(DEFAULT_WRITE_QUERY_BUDGET_MS);
-      expect(getQueryBudget('UnknownModel', 'update')).toBe(DEFAULT_WRITE_QUERY_BUDGET_MS);
+    });
+
+    it('applies validated JSON overrides ahead of built-in budgets', () => {
+      process.env.QUERY_BUDGETS_JSON = JSON.stringify({
+        'User.findUnique': 25,
+        'raw_replica.select': 400,
+      });
+
+      expect(getQueryBudget('User', 'findUnique')).toBe(25);
+      expect(getQueryBudget('raw_replica', 'select')).toBe(400);
+    });
+
+    it('ignores malformed or unsafe overrides', () => {
+      process.env.QUERY_BUDGETS_JSON = JSON.stringify({
+        'User.findUnique': -5,
+        'bad key': 1,
+      });
+
+      expect(getQueryBudget('User', 'findUnique')).toBe(50);
+      expect(getQueryBudget('bad key', 'unknown')).toBe(DEFAULT_WRITE_QUERY_BUDGET_MS);
+    });
+  });
+
+  describe('evaluateQueryPerformance()', () => {
+    it('classifies warning and critical breaches by budget ratio', () => {
+      const warning = evaluateQueryPerformance({
+        model: 'User',
+        action: 'findUnique',
+        durationMs: 75,
+        source: 'prisma',
+      });
+      const critical = evaluateQueryPerformance({
+        model: 'User',
+        action: 'findUnique',
+        durationMs: 151,
+        source: 'prisma',
+      });
+
+      expect(warning).toMatchObject({ breached: true, severity: 'warning', budgetMs: 50 });
+      expect(critical).toMatchObject({ breached: true, severity: 'critical', budgetMs: 50 });
+    });
+
+    it('normalizes metric labels and invalid durations', () => {
+      const result = evaluateQueryPerformance({
+        model: ' raw model ',
+        action: 'find-many!',
+        durationMs: Number.NaN,
+        source: 'postgres',
+      });
+
+      expect(result).toMatchObject({
+        model: 'raw_model',
+        action: 'find_many_',
+        durationMs: 0,
+        breached: false,
+      });
     });
   });
 
   describe('triggerSlowQueryAlert()', () => {
-    it('sends Slack alert when budget is breached and Slack is configured', async () => {
-      process.env.ALERT_TYPE = 'slack';
-      process.env.SLACK_WEBHOOK_URL = 'https://hooks.slack.com/services/test';
+    it('delivers Slack alerts and returns the delivery outcome', async () => {
+      process.env.QUERY_ALERT_TYPE = 'slack';
+      process.env.SLOW_QUERY_SLACK_WEBHOOK_URL = 'https://hooks.slack.test/query';
+      global.fetch = jest.fn().mockResolvedValue({ ok: true, status: 200 });
 
-      const calls: any[] = [];
-      global.fetch = jest.fn().mockImplementation(async (url, opts) => {
-        calls.push({ url, body: JSON.parse(opts.body) });
-        return { ok: true, status: 200 } as any;
-      });
+      const result = await triggerSlowQueryAlert('User', 'findUnique', 120, 50);
 
-      await triggerSlowQueryAlert('User', 'findUnique', 120, 50);
-
-      expect(calls.length).toBe(1);
-      expect(calls[0].url).toBe('https://hooks.slack.com/services/test');
-      expect(calls[0].body.text).toContain('User.findUnique');
+      expect(result).toEqual({ outcome: 'delivered', channels: ['slack'] });
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      const [, options] = (global.fetch as jest.Mock).mock.calls[0];
+      expect(JSON.parse(options.body).text).toContain('User.findUnique');
     });
 
-    it('respects cooldown and suppresses duplicate alerts within cooldown window', async () => {
-      process.env.ALERT_TYPE = 'slack';
-      process.env.SLACK_WEBHOOK_URL = 'https://hooks.slack.com/services/test';
+    it('atomically suppresses concurrent duplicate alerts during cooldown', async () => {
+      process.env.QUERY_ALERT_TYPE = 'slack';
+      process.env.SLOW_QUERY_SLACK_WEBHOOK_URL = 'https://hooks.slack.test/query';
+      global.fetch = jest.fn().mockResolvedValue({ ok: true, status: 200 });
 
-      const calls: any[] = [];
-      global.fetch = jest.fn().mockImplementation(async (url, opts) => {
-        calls.push({ url, body: JSON.parse(opts.body) });
-        return { ok: true, status: 200 } as any;
+      const results = await Promise.all(
+        Array.from({ length: 20 }, () => triggerSlowQueryAlert('Transaction', 'findMany', 400, 150))
+      );
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(results.filter((result) => result.outcome === 'delivered')).toHaveLength(1);
+      expect(results.filter((result) => result.outcome === 'suppressed')).toHaveLength(19);
+    });
+
+    it('does not let warning cooldown suppress a later critical alert', async () => {
+      process.env.QUERY_ALERT_TYPE = 'slack';
+      process.env.SLOW_QUERY_SLACK_WEBHOOK_URL = 'https://hooks.slack.test/query';
+      global.fetch = jest.fn().mockResolvedValue({ ok: true, status: 200 });
+
+      await triggerSlowQueryAlert('User', 'findUnique', 60, 50, { severity: 'warning' });
+      await triggerSlowQueryAlert('User', 'findUnique', 200, 50, { severity: 'critical' });
+
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('reports non-2xx alert responses as delivery failures', async () => {
+      process.env.QUERY_ALERT_TYPE = 'slack';
+      process.env.SLOW_QUERY_SLACK_WEBHOOK_URL = 'https://hooks.slack.test/query';
+      global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 503 });
+
+      const result = await triggerSlowQueryAlert('User', 'findUnique', 120, 50);
+
+      expect(result).toEqual({ outcome: 'delivery_failed', channels: [] });
+    });
+
+    it('sends both channels with critical PagerDuty severity and a dedup key', async () => {
+      process.env.QUERY_ALERT_TYPE = 'both';
+      process.env.SLOW_QUERY_SLACK_WEBHOOK_URL = 'https://hooks.slack.test/query';
+      process.env.SLOW_QUERY_PAGERDUTY_INTEGRATION_KEY = 'pd-key';
+      global.fetch = jest.fn().mockResolvedValue({ ok: true, status: 202 });
+
+      const result = await triggerSlowQueryAlert('Transaction', 'findMany', 600, 150, {
+        severity: 'critical',
+        source: 'prisma',
       });
 
-      // First alert
-      await triggerSlowQueryAlert('User', 'findUnique', 120, 50);
-      expect(calls.length).toBe(1);
+      expect(result.channels).toEqual(expect.arrayContaining(['slack', 'pagerduty']));
+      const pagerDutyCall = (global.fetch as jest.Mock).mock.calls.find(
+        ([url]) => url === 'https://events.pagerduty.com/v2/enqueue'
+      );
+      const body = JSON.parse(pagerDutyCall[1].body);
+      expect(body.payload.severity).toBe('critical');
+      expect(body.dedup_key).toMatch(/^yieldvault-slow-query-/);
+    });
+  });
 
-      // Second alert immediately (should be suppressed by cooldown)
-      await triggerSlowQueryAlert('User', 'findUnique', 130, 50);
-      expect(calls.length).toBe(1);
+  describe('distributed alert cooldown', () => {
+    it('uses one atomic Redis SET NX PX reservation', async () => {
+      const set = jest.fn().mockResolvedValueOnce('OK').mockResolvedValueOnce(null);
+      const store = new RedisAlertCooldownStore(
+        { set } as unknown as Redis,
+        new InMemoryAlertCooldownStore()
+      );
+
+      await expect(store.tryAcquire('slow-query:test', 1000)).resolves.toBe(true);
+      await expect(store.tryAcquire('slow-query:test', 1000)).resolves.toBe(false);
+      expect(set).toHaveBeenCalledWith('slow-query:test', '1', 'PX', 1000, 'NX');
+    });
+
+    it('falls back to process-local suppression when Redis is unavailable', async () => {
+      const set = jest.fn().mockRejectedValue(new Error('redis unavailable'));
+      const store = new RedisAlertCooldownStore(
+        { set } as unknown as Redis,
+        new InMemoryAlertCooldownStore()
+      );
+
+      await expect(store.tryAcquire('slow-query:test', 1000)).resolves.toBe(true);
+      await expect(store.tryAcquire('slow-query:test', 1000)).resolves.toBe(false);
+    });
+  });
+
+  describe('recordQueryPerformance()', () => {
+    it('records a budget breach metric and logs locally without external channels', async () => {
+      const before = await counterValue('BudgetMetricModel', 'findMany', 'prisma', 'critical');
+
+      const result = await recordQueryPerformance({
+        model: 'BudgetMetricModel',
+        action: 'findMany',
+        durationMs: 500,
+        source: 'prisma',
+      });
+
+      const after = await counterValue('BudgetMetricModel', 'findMany', 'prisma', 'critical');
+      expect(result).toMatchObject({ breached: true, severity: 'critical' });
+      expect(after - before).toBe(1);
+    });
+  });
+
+  describe('raw PostgreSQL integration', () => {
+    it.each([
+      ['SELECT 1', 'select'],
+      ['  -- comment\nUPDATE vault SET value = 1', 'update'],
+      ['/* report */ WITH rows AS (SELECT 1) SELECT * FROM rows', 'with'],
+      ['', 'unknown'],
+    ])('classifies %j as %s without exposing SQL text', (sql, expected) => {
+      expect(classifySqlAction(sql)).toBe(expected);
+    });
+
+    it('records raw queries routed through DatabaseManager', async () => {
+      process.env.QUERY_BUDGETS_JSON = JSON.stringify({ 'raw_replica.select': 0.001 });
+      const pool: IDatabasePool = {
+        query: jest.fn().mockResolvedValue({ rows: [{ value: 1 }] }),
+        end: jest.fn().mockResolvedValue(undefined),
+        isHealthy: jest.fn().mockResolvedValue(true),
+      };
+      const manager = new DatabaseManager(pool, pool);
+      const before = await counterValue('raw_replica', 'select', 'postgres', 'critical');
+
+      await manager.query('SELECT 1');
+      await new Promise((resolve) => setImmediate(resolve));
+
+      const after = await counterValue('raw_replica', 'select', 'postgres', 'critical');
+      expect(after - before).toBe(1);
     });
   });
 });
+
+async function counterValue(
+  model: string,
+  action: string,
+  source: string,
+  severity: string
+): Promise<number> {
+  const metric = await dbQueryBudgetBreachTotal.get();
+  return (
+    metric.values.find(
+      (value) =>
+        value.labels.model === model &&
+        value.labels.action === action &&
+        value.labels.source === source &&
+        value.labels.severity === severity
+    )?.value ?? 0
+  );
+}

--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -1,5 +1,6 @@
 import { logger } from './middleware/structuredLogging';
 import { Pool, PoolConfig } from 'pg';
+import { recordQueryPerformance } from './queryBudgets';
 
 /**
  * Interface for a database pool.
@@ -91,19 +92,19 @@ export class DatabaseManager {
 
     if (isReadQuery) {
       try {
-        return await this.replicaPool.query<T>(text, params);
+        return await this.executeWithBudget(this.replicaPool, 'raw_replica', text, params);
       } catch (error) {
         logger.log('warn', 'Read replica query failed, failing over to primary', {
           error: error instanceof Error ? error.message : String(error),
-          text,
+          action: classifySqlAction(text),
         });
         // Fallback to primary
-        return await this.primaryPool.query<T>(text, params);
+        return await this.executeWithBudget(this.primaryPool, 'raw_primary', text, params);
       }
     }
 
     // Write queries always go to primary
-    return await this.primaryPool.query<T>(text, params);
+    return await this.executeWithBudget(this.primaryPool, 'raw_primary', text, params);
   }
 
   /**
@@ -112,7 +113,7 @@ export class DatabaseManager {
    * Throws if the replica is unreachable.
    */
   async queryReplica<T = any>(text: string, params?: any[]): Promise<{ rows: T[] }> {
-    return await this.replicaPool.query<T>(text, params);
+    return await this.executeWithBudget(this.replicaPool, 'raw_replica', text, params);
   }
 
   /**
@@ -120,7 +121,7 @@ export class DatabaseManager {
    * Useful for reads that require the latest committed data (e.g. after a write).
    */
   async queryPrimary<T = any>(text: string, params?: any[]): Promise<{ rows: T[] }> {
-    return await this.primaryPool.query<T>(text, params);
+    return await this.executeWithBudget(this.primaryPool, 'raw_primary', text, params);
   }
 
   /**
@@ -151,6 +152,39 @@ export class DatabaseManager {
   private isReadQuery(text: string): boolean {
     const trimmed = text.trim().toLowerCase();
     return trimmed.startsWith('select') || trimmed.startsWith('with');
+  }
+
+  private async executeWithBudget<T>(
+    pool: IDatabasePool,
+    model: 'raw_primary' | 'raw_replica',
+    text: string,
+    params?: any[],
+  ): Promise<{ rows: T[] }> {
+    const startedAt = process.hrtime.bigint();
+    let failed = false;
+    try {
+      return await pool.query<T>(text, params);
+    } catch (error) {
+      failed = true;
+      throw error;
+    } finally {
+      const durationMs = Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+      void recordQueryPerformance({
+        model,
+        action: classifySqlAction(text),
+        durationMs,
+        source: 'postgres',
+        failed,
+      }).catch((error) => {
+        if (process.env.NODE_ENV !== 'test') {
+          logger.log('error', 'Failed to record PostgreSQL query performance', {
+            model,
+            action: classifySqlAction(text),
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      });
+    }
   }
 
   /**
@@ -197,6 +231,13 @@ function requireDatabaseUrl(): string {
 function parsePositiveInt(raw: string | undefined, fallback: number): number {
   const parsed = Number.parseInt(raw || '', 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function classifySqlAction(text: string): string {
+  const withoutLeadingComments = text
+    .replace(/^(?:\s|--[^\n]*(?:\n|$)|\/\*[\s\S]*?\*\/)*/u, '')
+    .trimStart();
+  return withoutLeadingComments.match(/^([A-Za-z]+)/)?.[1]?.toLowerCase() || 'unknown';
 }
 
 // Export a singleton instance

--- a/backend/src/metrics.ts
+++ b/backend/src/metrics.ts
@@ -37,9 +37,30 @@ export const activeConnections = new Gauge({
 
 export const dbQueryDuration = new Histogram({
   name: 'db_query_duration_seconds',
-  help: 'Histogram of Prisma query duration in seconds',
+  help: 'Histogram of database query duration in seconds',
   labelNames: ['model', 'action'],
   buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5],
+  registers: [register],
+});
+
+export const dbQueryBudgetMs = new Gauge({
+  name: 'db_query_budget_ms',
+  help: 'Configured database query performance budget in milliseconds',
+  labelNames: ['model', 'action'],
+  registers: [register],
+});
+
+export const dbQueryBudgetBreachTotal = new Counter({
+  name: 'db_query_budget_breach_total',
+  help: 'Total database queries that exceeded their performance budget',
+  labelNames: ['model', 'action', 'source', 'severity'],
+  registers: [register],
+});
+
+export const dbSlowQueryAlertTotal = new Counter({
+  name: 'db_slow_query_alert_total',
+  help: 'Slow-query alert outcomes after cooldown and delivery processing',
+  labelNames: ['model', 'action', 'severity', 'outcome'],
   registers: [register],
 });
 
@@ -95,6 +116,28 @@ export function observeDbQueryDuration(model: string, action: string, durationMs
     },
     durationMs / 1000,
   );
+}
+
+export function setDbQueryBudget(model: string, action: string, budgetMs: number): void {
+  dbQueryBudgetMs.set({ model, action }, budgetMs);
+}
+
+export function recordDbQueryBudgetBreach(
+  model: string,
+  action: string,
+  source: string,
+  severity: string,
+): void {
+  dbQueryBudgetBreachTotal.inc({ model, action, source, severity });
+}
+
+export function recordDbSlowQueryAlert(
+  model: string,
+  action: string,
+  severity: string,
+  outcome: string,
+): void {
+  dbSlowQueryAlertTotal.inc({ model, action, severity, outcome });
 }
 
 // --- Job Governance Metrics ---

--- a/backend/src/prismaClient.ts
+++ b/backend/src/prismaClient.ts
@@ -9,11 +9,10 @@
 
 import { PrismaClient } from '@prisma/client';
 import { logger } from './middleware/structuredLogging';
-import { observeDbQueryDuration } from './metrics';
+import { recordQueryPerformance } from './queryBudgets';
 
 let prismaClientInstance: PrismaClient | null = null;
 let queryInstrumentationAttached = false;
-const SLOW_QUERY_THRESHOLD_MS = parsePositiveInt(process.env.SLOW_QUERY_THRESHOLD_MS, 500);
 
 /**
  * Get or create the shared Prisma Client instance.
@@ -57,8 +56,6 @@ export function getPrismaClient(): PrismaClient {
   return prismaClientInstance as PrismaClient;
 }
 
-import { getQueryBudget, triggerSlowQueryAlert } from './queryBudgets';
-
 function attachQueryInstrumentation(client: PrismaClient): void {
   if (queryInstrumentationAttached) {
     return;
@@ -74,29 +71,18 @@ function attachQueryInstrumentation(client: PrismaClient): void {
       const model = params.model || 'raw';
       const action = params.action || 'unknown';
 
-      observeDbQueryDuration(model, action, elapsedMs);
-
-      const budgetMs = getQueryBudget(model, action);
-      if (elapsedMs >= budgetMs) {
-        logger.log('warn', 'Prisma query exceeded performance budget', {
+      void recordQueryPerformance({
+        model,
+        action,
+        durationMs: elapsedMs,
+        source: 'prisma',
+      }).catch((err) => {
+        logger.log('error', 'Failed to record Prisma query performance', {
+          error: err instanceof Error ? err.message : String(err),
           model,
           action,
-          durationMs: Math.round(elapsedMs * 100) / 100,
-          budgetMs,
         });
-
-        void triggerSlowQueryAlert(model, action, elapsedMs, budgetMs).catch((err) => {
-          logger.log('error', 'Failed to trigger slow query alert', {
-            error: err instanceof Error ? err.message : String(err),
-          });
-        });
-      } else if (elapsedMs >= SLOW_QUERY_THRESHOLD_MS) {
-        logger.log('warn', 'Slow Prisma query detected', {
-          model,
-          action,
-          durationMs: Math.round(elapsedMs * 100) / 100,
-        });
-      }
+      });
     }
   });
 
@@ -108,15 +94,6 @@ function attachQueryInstrumentation(client: PrismaClient): void {
   });
 
   queryInstrumentationAttached = true;
-}
-
-function parsePositiveInt(raw: string | undefined, fallback: number): number {
-  const parsed = parseInt(raw || '', 10);
-  if (Number.isNaN(parsed) || parsed <= 0) {
-    return fallback;
-  }
-
-  return parsed;
 }
 
 /**

--- a/backend/src/queryBudgets.ts
+++ b/backend/src/queryBudgets.ts
@@ -1,12 +1,28 @@
-import { logger } from './middleware/structuredLogging';
+/**
+ * Query performance budgets and slow-query alerting (Issue #1050).
+ *
+ * All database entry points report through this module so budget evaluation,
+ * metrics, structured logs, severity, and alert cooldowns stay consistent.
+ */
 
-// Default budget thresholds in milliseconds
+import crypto from 'crypto';
+import Redis from 'ioredis';
+import { logger } from './middleware/structuredLogging';
+import {
+  observeDbQueryDuration,
+  recordDbQueryBudgetBreach,
+  recordDbSlowQueryAlert,
+  setDbQueryBudget,
+} from './metrics';
+
 export const DEFAULT_READ_QUERY_BUDGET_MS = 100;
 export const DEFAULT_WRITE_QUERY_BUDGET_MS = 200;
+export const DEFAULT_ALERT_COOLDOWN_MS = 15 * 60 * 1000;
+export const DEFAULT_ALERT_TIMEOUT_MS = 5000;
+export const DEFAULT_CRITICAL_MULTIPLIER = 3;
 
-// Specific query budgets by model and action
-// Format: "Model.action"
-export const QUERY_BUDGETS: Record<string, number> = {
+/** Built-in budgets for known hot paths. `QUERY_BUDGETS_JSON` can override them. */
+export const QUERY_BUDGETS: Readonly<Record<string, number>> = Object.freeze({
   'User.findUnique': 50,
   'VaultState.findUnique': 50,
   'SharePriceSnapshot.create': 150,
@@ -14,128 +30,398 @@ export const QUERY_BUDGETS: Record<string, number> = {
   'Referral.findUnique': 50,
   'WebhookEndpoint.findMany': 100,
   'WebhookDelivery.findMany': 150,
-};
+});
 
-// Cooldown tracker to prevent alert spamming (default: 15 minutes)
-const getAlertCooldownMs = (): number =>
-  parseInt(process.env.SLOW_QUERY_ALERT_COOLDOWN_MS || '900000', 10);
+const READ_ACTIONS = new Set([
+  'findUnique',
+  'findFirst',
+  'findMany',
+  'count',
+  'queryRaw',
+  'aggregate',
+  'groupBy',
+  'select',
+  'with',
+  'show',
+  'explain',
+]);
 
-const lastAlertTimes = new Map<string, number>();
+export type QueryPerformanceSource = 'prisma' | 'postgres';
+export type QueryBreachSeverity = 'warning' | 'critical';
+export type SlowQueryAlertOutcome = 'delivered' | 'logged' | 'suppressed' | 'delivery_failed';
 
-/**
- * Resolves the performance budget for a Prisma query in milliseconds.
- */
-export function getQueryBudget(model: string, action: string): number {
-  const key = `${model}.${action}`;
-  if (QUERY_BUDGETS[key] !== undefined) {
-    return QUERY_BUDGETS[key];
+export interface QueryPerformanceSample {
+  model: string;
+  action: string;
+  durationMs: number;
+  source: QueryPerformanceSource;
+  failed?: boolean;
+}
+
+export interface QueryPerformanceEvaluation extends QueryPerformanceSample {
+  budgetMs: number;
+  ratio: number;
+  breached: boolean;
+  severity: QueryBreachSeverity;
+}
+
+export interface SlowQueryAlertResult {
+  outcome: SlowQueryAlertOutcome;
+  channels: Array<'slack' | 'pagerduty'>;
+}
+
+interface AlertCooldownStore {
+  tryAcquire(key: string, ttlMs: number): Promise<boolean>;
+  clear(): void;
+}
+
+export class InMemoryAlertCooldownStore implements AlertCooldownStore {
+  private readonly expiresAtByKey = new Map<string, number>();
+
+  async tryAcquire(key: string, ttlMs: number): Promise<boolean> {
+    const now = Date.now();
+    const expiresAt = this.expiresAtByKey.get(key) ?? 0;
+    if (expiresAt > now) return false;
+    this.expiresAtByKey.set(key, now + ttlMs);
+    return true;
   }
 
-  // Classify read vs write actions
-  const isRead = [
-    'findUnique',
-    'findFirst',
-    'findMany',
-    'count',
-    'queryRaw',
-    'aggregate',
-    'groupBy',
-  ].includes(action);
+  clear(): void {
+    this.expiresAtByKey.clear();
+  }
+}
 
-  return isRead ? DEFAULT_READ_QUERY_BUDGET_MS : DEFAULT_WRITE_QUERY_BUDGET_MS;
+export class RedisAlertCooldownStore implements AlertCooldownStore {
+  constructor(
+    private readonly redis: Redis,
+    private readonly fallback: InMemoryAlertCooldownStore
+  ) {}
+
+  async tryAcquire(key: string, ttlMs: number): Promise<boolean> {
+    try {
+      const result = await this.redis.set(key, '1', 'PX', ttlMs, 'NX');
+      return result === 'OK';
+    } catch (error) {
+      logger.log('warn', 'Redis slow-query cooldown unavailable; using local fallback', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return this.fallback.tryAcquire(key, ttlMs);
+    }
+  }
+
+  clear(): void {
+    this.fallback.clear();
+  }
+}
+
+const localCooldownStore = new InMemoryAlertCooldownStore();
+let redisCooldownStore: RedisAlertCooldownStore | null = null;
+let redisCooldownUrl: string | null = null;
+let budgetOverrideCacheRaw: string | undefined;
+let budgetOverrideCache: Record<string, number> = {};
+
+function parsePositiveNumber(raw: string | undefined, fallback: number): number {
+  const value = Number(raw);
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function readBudgetOverrides(): Record<string, number> {
+  const raw = process.env.QUERY_BUDGETS_JSON;
+  if (raw === budgetOverrideCacheRaw) return budgetOverrideCache;
+
+  budgetOverrideCacheRaw = raw;
+  budgetOverrideCache = {};
+  if (!raw) return budgetOverrideCache;
+
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error('expected a JSON object');
+    }
+
+    for (const [key, value] of Object.entries(parsed)) {
+      if (
+        /^[A-Za-z][A-Za-z0-9_]{0,63}\.[A-Za-z][A-Za-z0-9_]{0,63}$/.test(key) &&
+        typeof value === 'number' &&
+        Number.isFinite(value) &&
+        value > 0
+      ) {
+        budgetOverrideCache[key] = value;
+      } else {
+        logger.log('warn', 'Ignoring invalid query budget override', { key });
+      }
+    }
+  } catch (error) {
+    logger.log('error', 'Ignoring malformed QUERY_BUDGETS_JSON', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  return budgetOverrideCache;
+}
+
+function normalizeLabel(value: string, fallback: string): string {
+  const normalized = value
+    .trim()
+    .replace(/[^A-Za-z0-9_]/g, '_')
+    .slice(0, 64);
+  return normalized || fallback;
+}
+
+function getCooldownStore(): AlertCooldownStore {
+  const redisUrl = process.env.REDIS_URL;
+  if (!redisUrl) return localCooldownStore;
+  if (redisCooldownStore && redisCooldownUrl === redisUrl) return redisCooldownStore;
+
+  const redis = new Redis(redisUrl, {
+    lazyConnect: true,
+    // Queue the first atomic reservation while a lazy connection is being
+    // established; retries remain bounded so Redis outages fall back quickly.
+    enableOfflineQueue: true,
+    connectTimeout: parsePositiveNumber(process.env.REDIS_CONNECT_TIMEOUT_MS, 2000),
+    maxRetriesPerRequest: 1,
+  });
+  redis.on('error', (error) => {
+    logger.log('error', 'Redis slow-query cooldown error', { error: error.message });
+  });
+  redisCooldownUrl = redisUrl;
+  redisCooldownStore = new RedisAlertCooldownStore(redis, localCooldownStore);
+  return redisCooldownStore;
 }
 
 /**
- * Triggers an alert when a query exceeds its performance budget.
+ * Resolves an exact model/action override, then a built-in budget, then the
+ * configured read/write default.
+ */
+export function getQueryBudget(model: string, action: string): number {
+  const key = `${model}.${action}`;
+  const overrides = readBudgetOverrides();
+  if (overrides[key] !== undefined) return overrides[key];
+  if (QUERY_BUDGETS[key] !== undefined) return QUERY_BUDGETS[key];
+
+  return READ_ACTIONS.has(action)
+    ? parsePositiveNumber(process.env.QUERY_READ_BUDGET_MS, DEFAULT_READ_QUERY_BUDGET_MS)
+    : parsePositiveNumber(process.env.QUERY_WRITE_BUDGET_MS, DEFAULT_WRITE_QUERY_BUDGET_MS);
+}
+
+export function evaluateQueryPerformance(
+  sample: QueryPerformanceSample
+): QueryPerformanceEvaluation {
+  const model = normalizeLabel(sample.model, 'unknown');
+  const action = normalizeLabel(sample.action, 'unknown');
+  const durationMs =
+    Number.isFinite(sample.durationMs) && sample.durationMs >= 0 ? sample.durationMs : 0;
+  const budgetMs = getQueryBudget(model, action);
+  const ratio = budgetMs > 0 ? durationMs / budgetMs : 0;
+  const criticalMultiplier = parsePositiveNumber(
+    process.env.SLOW_QUERY_CRITICAL_MULTIPLIER,
+    DEFAULT_CRITICAL_MULTIPLIER
+  );
+
+  return {
+    ...sample,
+    model,
+    action,
+    durationMs,
+    budgetMs,
+    ratio,
+    breached: durationMs >= budgetMs,
+    severity: ratio >= criticalMultiplier ? 'critical' : 'warning',
+  };
+}
+
+/**
+ * Records query latency and emits a cooldown-aware alert for budget breaches.
+ * Callers intentionally do not await this function on request paths.
+ */
+export async function recordQueryPerformance(
+  sample: QueryPerformanceSample
+): Promise<QueryPerformanceEvaluation> {
+  const evaluation = evaluateQueryPerformance(sample);
+  const { model, action, source, durationMs, budgetMs, ratio, severity, breached } = evaluation;
+
+  observeDbQueryDuration(model, action, durationMs);
+  setDbQueryBudget(model, action, budgetMs);
+  if (!breached) return evaluation;
+
+  recordDbQueryBudgetBreach(model, action, source, severity);
+  // Some Jest suites intentionally leave background jobs running after their
+  // assertions. Avoid writing through Jest's closed console while preserving
+  // metrics and direct alert-delivery tests.
+  if (process.env.NODE_ENV !== 'test') {
+    logger.log(severity === 'critical' ? 'error' : 'warn', 'Database query exceeded budget', {
+      model,
+      action,
+      source,
+      durationMs: Math.round(durationMs * 100) / 100,
+      budgetMs,
+      ratio: Math.round(ratio * 100) / 100,
+      severity,
+      failed: sample.failed === true,
+    });
+  }
+
+  try {
+    await triggerSlowQueryAlert(model, action, durationMs, budgetMs, {
+      severity,
+      source,
+      failed: sample.failed === true,
+    });
+  } catch (error) {
+    logger.log('error', 'Unexpected slow-query alert failure', {
+      model,
+      action,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  return evaluation;
+}
+
+async function postJson(url: string, body: unknown): Promise<void> {
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(),
+    parsePositiveNumber(process.env.SLOW_QUERY_ALERT_TIMEOUT_MS, DEFAULT_ALERT_TIMEOUT_MS)
+  );
+
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      throw new Error(`alert endpoint returned HTTP ${response.status}`);
+    }
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * Emits one external alert per query key and cooldown window. Redis makes the
+ * cooldown shared across replicas; if it is unavailable, local suppression
+ * still prevents an alert storm from a single process.
  */
 export async function triggerSlowQueryAlert(
   model: string,
   action: string,
   durationMs: number,
   budgetMs: number,
-): Promise<void> {
-  const key = `${model}.${action}`;
-  const now = Date.now();
-  const lastAlert = lastAlertTimes.get(key) || 0;
-  const cooldownMs = getAlertCooldownMs();
+  details: {
+    severity?: QueryBreachSeverity;
+    source?: QueryPerformanceSource;
+    failed?: boolean;
+  } = {}
+): Promise<SlowQueryAlertResult> {
+  const severity = details.severity ?? 'warning';
+  const cooldownMs = parsePositiveNumber(
+    process.env.SLOW_QUERY_ALERT_COOLDOWN_MS,
+    DEFAULT_ALERT_COOLDOWN_MS
+  );
+  const queryKey = `${model}.${action}`;
+  const keyHash = crypto
+    .createHash('sha256')
+    .update(`${queryKey}:${severity}`)
+    .digest('hex')
+    .slice(0, 24);
+  const acquired = await getCooldownStore().tryAcquire(
+    `slow-query-alert:v1:${keyHash}`,
+    cooldownMs
+  );
 
-  if (now - lastAlert < cooldownMs) {
-    // Cooldown active, skip alerting
-    return;
+  if (!acquired) {
+    recordDbSlowQueryAlert(model, action, severity, 'suppressed');
+    return { outcome: 'suppressed', channels: [] };
   }
 
-  lastAlertTimes.set(key, now);
-
-  logger.log('error', `Slow query alert: ${key} exceeded budget`, {
-    model,
-    action,
-    durationMs: Math.round(durationMs * 100) / 100,
-    budgetMs,
-  });
-
-  // Send alert to external channels if configured
-  const alertType = process.env.ALERT_TYPE || 'slack';
-  const slackUrl = process.env.SLACK_WEBHOOK_URL;
-  const pagerDutyKey = process.env.PAGERDUTY_INTEGRATION_KEY;
-
-  const alertPromises: Promise<unknown>[] = [];
+  const alertType = process.env.QUERY_ALERT_TYPE || process.env.ALERT_TYPE || 'slack';
+  const slackUrl = process.env.SLOW_QUERY_SLACK_WEBHOOK_URL || process.env.SLACK_WEBHOOK_URL;
+  const pagerDutyKey =
+    process.env.SLOW_QUERY_PAGERDUTY_INTEGRATION_KEY || process.env.PAGERDUTY_INTEGRATION_KEY;
+  const deliveries: Array<Promise<'slack' | 'pagerduty'>> = [];
 
   if ((alertType === 'slack' || alertType === 'both') && slackUrl) {
-    alertPromises.push(
-      fetch(slackUrl, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          text: `🚨 Slow Database Query Alert: ${key}`,
-          attachments: [
-            {
-              color: 'danger',
-              fields: [
-                { title: 'Query', value: key, short: true },
-                { title: 'Duration', value: `${durationMs.toFixed(2)}ms`, short: true },
-                { title: 'Budget', value: `${budgetMs}ms`, short: true },
-                { title: 'Time', value: new Date().toISOString(), short: true },
-              ],
-            },
-          ],
-        }),
-      }).catch((err) =>
-        logger.log('error', 'Failed to send slow query Slack alert', {
-          error: err instanceof Error ? err.message : String(err),
-        }),
-      ),
+    deliveries.push(
+      postJson(slackUrl, {
+        text: `Slow Database Query Alert: ${queryKey}`,
+        attachments: [
+          {
+            color: severity === 'critical' ? 'danger' : 'warning',
+            fields: [
+              { title: 'Query', value: queryKey, short: true },
+              { title: 'Duration', value: `${durationMs.toFixed(2)}ms`, short: true },
+              { title: 'Budget', value: `${budgetMs}ms`, short: true },
+              { title: 'Severity', value: severity, short: true },
+              { title: 'Source', value: details.source ?? 'prisma', short: true },
+              { title: 'Failed', value: String(details.failed === true), short: true },
+            ],
+          },
+        ],
+      }).then(() => 'slack' as const)
     );
   }
 
   if ((alertType === 'pagerduty' || alertType === 'both') && pagerDutyKey) {
-    alertPromises.push(
-      fetch('https://events.pagerduty.com/v2/enqueue', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          routing_key: pagerDutyKey,
-          event_action: 'trigger',
-          payload: {
-            summary: `Slow Query: ${key} took ${durationMs.toFixed(2)}ms (budget: ${budgetMs}ms)`,
-            source: 'yieldvault-backend',
-            severity: 'warning',
-            component: 'database',
-            group: 'performance',
-            class: 'slow-query',
-            custom_details: { model, action, durationMs, budgetMs },
+    deliveries.push(
+      postJson('https://events.pagerduty.com/v2/enqueue', {
+        routing_key: pagerDutyKey,
+        event_action: 'trigger',
+        dedup_key: `yieldvault-slow-query-${keyHash}`,
+        payload: {
+          summary: `Slow Query: ${queryKey} took ${durationMs.toFixed(2)}ms (budget: ${budgetMs}ms)`,
+          source: 'yieldvault-backend',
+          severity,
+          component: 'database',
+          group: 'performance',
+          class: 'slow-query',
+          custom_details: {
+            model,
+            action,
+            durationMs,
+            budgetMs,
+            source: details.source ?? 'prisma',
+            failed: details.failed === true,
           },
-        }),
-      }).catch((err) =>
-        logger.log('error', 'Failed to send slow query PagerDuty alert', {
-          error: err instanceof Error ? err.message : String(err),
-        }),
-      ),
+        },
+      }).then(() => 'pagerduty' as const)
     );
   }
 
-  await Promise.all(alertPromises);
+  if (deliveries.length === 0) {
+    recordDbSlowQueryAlert(model, action, severity, 'logged');
+    return { outcome: 'logged', channels: [] };
+  }
+
+  const settled = await Promise.allSettled(deliveries);
+  const channels = settled
+    .filter(
+      (result): result is PromiseFulfilledResult<'slack' | 'pagerduty'> =>
+        result.status === 'fulfilled'
+    )
+    .map((result) => result.value);
+  const failures = settled.filter((result) => result.status === 'rejected');
+
+  for (const failure of failures) {
+    logger.log('error', 'Failed to deliver slow-query alert', {
+      query: queryKey,
+      error:
+        failure.status === 'rejected' && failure.reason instanceof Error
+          ? failure.reason.message
+          : String(failure),
+    });
+  }
+
+  const outcome: SlowQueryAlertOutcome = channels.length > 0 ? 'delivered' : 'delivery_failed';
+  recordDbSlowQueryAlert(model, action, severity, outcome);
+  return { outcome, channels };
 }
 
 export function resetAlertCooldowns(): void {
-  lastAlertTimes.clear();
+  localCooldownStore.clear();
+  redisCooldownStore?.clear();
+  budgetOverrideCacheRaw = undefined;
+  budgetOverrideCache = {};
 }

--- a/docs/ENV_VARIABLE_MATRIX.md
+++ b/docs/ENV_VARIABLE_MATRIX.md
@@ -70,8 +70,15 @@ Complete reference for all environment variables across the YieldVault RWA stack
 | `PRISMA_QUERY_TIMEOUT_MS` | `5000` | ⬜ optional | Prisma per-query timeout (ms) | `backend/src/prisma.ts` |
 | `PRISMA_TX_MAX_WAIT_MS` | `5000` | ⬜ optional | Prisma transaction max wait (ms) | `backend/.env.example` |
 | `PRISMA_TX_TIMEOUT_MS` | `10000` | ⬜ optional | Prisma transaction timeout (ms) | `backend/.env.example` |
-| `SLOW_QUERY_THRESHOLD_MS` | `500` | ⬜ optional | Slow query warning threshold (ms) | `backend/src/prismaClient.ts` |
+| `QUERY_READ_BUDGET_MS` | `100` | ⬜ optional | Default budget for read queries (ms) | `backend/src/queryBudgets.ts` |
+| `QUERY_WRITE_BUDGET_MS` | `200` | ⬜ optional | Default budget for write queries (ms) | `backend/src/queryBudgets.ts` |
+| `QUERY_BUDGETS_JSON` | built-in hot-path budgets | ⬜ optional | JSON map of exact `Model.action` budget overrides | `backend/src/queryBudgets.ts` |
+| `SLOW_QUERY_CRITICAL_MULTIPLIER` | `3` | ⬜ optional | Budget multiple that escalates a breach to critical | `backend/src/queryBudgets.ts` |
 | `SLOW_QUERY_ALERT_COOLDOWN_MS` | `900000` (15 min) | ⬜ optional | Cooldown between slow query alerts | `backend/src/queryBudgets.ts` |
+| `SLOW_QUERY_ALERT_TIMEOUT_MS` | `5000` | ⬜ optional | Slack/PagerDuty delivery timeout (ms) | `backend/src/queryBudgets.ts` |
+| `QUERY_ALERT_TYPE` | `ALERT_TYPE` / `slack` | ⬜ optional | Slow-query alert channels: `slack`, `pagerduty`, or `both` | `backend/src/queryBudgets.ts` |
+| `SLOW_QUERY_SLACK_WEBHOOK_URL` | `SLACK_WEBHOOK_URL` | ⬜ optional | Dedicated slow-query Slack webhook | `backend/src/queryBudgets.ts` |
+| `SLOW_QUERY_PAGERDUTY_INTEGRATION_KEY` | `PAGERDUTY_INTEGRATION_KEY` | ⬜ optional | Dedicated slow-query PagerDuty key | `backend/src/queryBudgets.ts` |
 
 ---
 

--- a/docs/MONITORING_OBSERVABILITY.md
+++ b/docs/MONITORING_OBSERVABILITY.md
@@ -81,7 +81,10 @@ sum(rate(http_request_count[5m])) by (route)
 
 | Metric                      | Type      | Labels            | What it measures                           |
 | --------------------------- | --------- | ----------------- | ------------------------------------------ |
-| `db_query_duration_seconds` | Histogram | `model`, `action` | Prisma query duration; buckets at 5 ms–5 s |
+| `db_query_duration_seconds` | Histogram | `model`, `action` | Prisma and raw PostgreSQL query duration; buckets at 5 ms–5 s |
+| `db_query_budget_ms` | Gauge | `model`, `action` | Active performance budget for each observed query |
+| `db_query_budget_breach_total` | Counter | `model`, `action`, `source`, `severity` | Queries exceeding budget |
+| `db_slow_query_alert_total` | Counter | `model`, `action`, `severity`, `outcome` | Delivered, logged, suppressed, or failed alerts |
 
 **Key derived query:**
 
@@ -90,7 +93,16 @@ sum(rate(http_request_count[5m])) by (route)
 histogram_quantile(0.95,
   sum(rate(db_query_duration_seconds_bucket[5m])) by (le, model, action)
 )
+
+# Budget breaches by severity
+sum(rate(db_query_budget_breach_total[5m])) by (model, action, severity)
+
+# Alert delivery failures
+sum(increase(db_slow_query_alert_total{outcome="delivery_failed"}[15m]))
 ```
+
+See [Query Performance Budgets and Slow-Query Alerts](../backend/docs/QUERY_PERFORMANCE_BUDGETS.md)
+for configuration, alert routing, and the operator response procedure.
 
 ### 1.3 Cache Metrics
 


### PR DESCRIPTION
## Summary

- add configurable latency budgets for Prisma model/action pairs and raw database queries
- classify warning and critical budget breaches and expose normalized performance metrics
- deliver deduplicated slow-query alerts through Slack and PagerDuty
- coordinate alert cooldowns through atomic Redis reservations with a safe local fallback
- document budget overrides, alert configuration, dashboards, and operational guidance

## Why

Database latency needs explicit service-level thresholds and actionable alerts. The previous instrumentation did not consistently evaluate queries against configurable budgets or prevent concurrent replicas from emitting duplicate notifications.

## Validation

- `npm test -- --runInBand src/__tests__/queryBudgets.test.ts` — 20 tests passed
- scoped ESLint — zero errors (15 existing type-safety warnings)
- `git diff --check upstream/main...HEAD` — passed

Closes #1050