### PR TITLE
Backend: introduce soft-delete and audit trails for critical entities

### DIFF
--- a/backend/docs/CRITICAL_ENTITY_LIFECYCLE.md
+++ b/backend/docs/CRITICAL_ENTITY_LIFECYCLE.md
@@ -1,0 +1,105 @@
+# Critical Entity Soft Deletion and Audit Trail
+
+Issue #1047 protects critical control-plane records from accidental,
+unaudited hard deletion.
+
+## Scope
+
+The audited lifecycle service covers:
+
+- `Tenant`
+- persisted `ApiKey`
+
+Existing `WebhookEndpoint` deletion remains a soft delete with
+`deletedAt`/`deletedBy` and admin audit logging. `ScopedAdminToken` uses
+revocation rather than deletion. Generic Prisma hard deletes are blocked
+outside tests for all four entity types and for `CriticalEntityAuditEvent`.
+
+Financial records (`Transaction`, vault state, share-price snapshots, and
+reconciliation history) are deliberately excluded. They remain immutable and
+follow the regulatory retention policy rather than a reversible application
+delete workflow.
+
+## Invariants
+
+1. Delete and restore operations require a non-empty actor and reason.
+2. State changes and `CriticalEntityAuditEvent` creation occur in one database
+   transaction.
+3. Conditional `updateMany` predicates make retries idempotent and prevent two
+   concurrent requests from producing duplicate lifecycle events.
+4. Deleting a tenant atomically disables and soft-deletes all of its active API
+   keys.
+5. Restoring a tenant does not restore credentials. Each API key requires a
+   separate audited restore after the tenant is active.
+6. Authentication rejects keys whose key record or parent tenant is deleted.
+7. Audit metadata never includes plaintext credentials or stored key hashes.
+8. Audit rows are append-only. Generic Prisma `delete`/`deleteMany` operations
+   against protected models throw outside the test environment.
+
+Raw SQL bypasses Prisma safeguards and must not be used for lifecycle changes.
+Retention cleanup that eventually hard-deletes records must use a dedicated,
+reviewed maintenance path after the documented grace period.
+
+## Service API
+
+Use `src/criticalEntityLifecycle.ts`:
+
+```ts
+await softDeleteTenant('tenant-id', {
+  actor: 'admin@example.com',
+  reason: 'Customer account closed',
+});
+
+await restoreTenant('tenant-id', {
+  actor: 'security-admin@example.com',
+  reason: 'Closure reversed after verification',
+});
+
+await softDeleteApiKey('api-key-id', {
+  actor: 'security-admin@example.com',
+  reason: 'Credential compromised',
+});
+```
+
+The result status is one of:
+
+- `changed`
+- `not_found`
+- `already_deleted`
+- `not_deleted`
+- `parent_deleted`
+
+Treat statuses other than `changed` as no-op outcomes; they never create a
+duplicate audit event.
+
+## Audit review
+
+`listCriticalEntityAuditTrail` supports entity type, entity ID, and action
+filters. Results are newest-first and capped at 500 records per call.
+
+An audit record contains:
+
+- entity type and ID
+- `soft_delete` or `restore`
+- attributable actor
+- required reason
+- non-sensitive operation metadata
+- database-generated timestamp
+
+Retain `CriticalEntityAuditEvent` records for seven years with other security
+audit data. They must not be changed or removed through application CRUD.
+
+## Deployment
+
+1. Back up the database.
+2. Apply migration
+   `20260729000000_add_critical_entity_soft_delete`.
+3. Confirm the new nullable columns and audit table exist.
+4. Delete a non-production API key through the lifecycle service.
+5. Verify authentication fails immediately.
+6. Verify exactly one `CriticalEntityAuditEvent` exists.
+7. Restore the key and verify a second audit event is appended.
+
+Rollback should restore application code first. The nullable columns and audit
+table are backward-compatible and should be retained until their data has been
+archived and a separate destructive migration is approved.

--- a/backend/prisma/migrations/20260729000000_add_critical_entity_soft_delete/migration.sql
+++ b/backend/prisma/migrations/20260729000000_add_critical_entity_soft_delete/migration.sql
@@ -1,0 +1,62 @@
+-- Issue #1047: soft deletion and immutable lifecycle audits for critical
+-- control-plane entities. Financial history remains immutable and is not
+-- covered by this reversible deletion mechanism.
+-- migration-safety: allow-not-null-add
+-- migration-safety: allow-nonconcurrent-indexes
+-- The added columns are nullable. The NOT NULL detector otherwise scans into
+-- the later CREATE TABLE statement. SQLite does not support CONCURRENTLY.
+
+-- Tenant and ApiKey existed in schema.prisma before they were represented in
+-- the migration history. Establish their baseline shape on clean databases;
+-- existing managed databases treat these statements as no-ops.
+CREATE TABLE IF NOT EXISTS "Tenant" (
+  "id"        TEXT     NOT NULL PRIMARY KEY,
+  "name"      TEXT     NOT NULL,
+  "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "Tenant_name_key" ON "Tenant"("name");
+CREATE INDEX IF NOT EXISTS "Tenant_name_idx" ON "Tenant"("name");
+
+CREATE TABLE IF NOT EXISTS "ApiKey" (
+  "id"        TEXT     NOT NULL PRIMARY KEY,
+  "tenantId"  TEXT     NOT NULL,
+  "hashedKey" TEXT     NOT NULL,
+  "role"      TEXT     NOT NULL,
+  "scopes"    TEXT     NOT NULL DEFAULT '[]',
+  "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "expiresAt" DATETIME,
+  "isActive"  BOOLEAN  NOT NULL DEFAULT true,
+  CONSTRAINT "ApiKey_tenantId_fkey"
+    FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "ApiKey_hashedKey_key" ON "ApiKey"("hashedKey");
+CREATE INDEX IF NOT EXISTS "ApiKey_tenantId_idx" ON "ApiKey"("tenantId");
+CREATE INDEX IF NOT EXISTS "ApiKey_role_idx" ON "ApiKey"("role");
+
+ALTER TABLE "Tenant" ADD COLUMN "deletedAt" DATETIME;
+ALTER TABLE "Tenant" ADD COLUMN "deletedBy" TEXT;
+ALTER TABLE "Tenant" ADD COLUMN "deletionReason" TEXT;
+
+ALTER TABLE "ApiKey" ADD COLUMN "deletedAt" DATETIME;
+ALTER TABLE "ApiKey" ADD COLUMN "deletedBy" TEXT;
+ALTER TABLE "ApiKey" ADD COLUMN "deletionReason" TEXT;
+
+CREATE TABLE "CriticalEntityAuditEvent" (
+  "id"         TEXT     NOT NULL PRIMARY KEY,
+  "entityType" TEXT     NOT NULL,
+  "entityId"   TEXT     NOT NULL,
+  "action"     TEXT     NOT NULL,
+  "actor"      TEXT     NOT NULL,
+  "reason"     TEXT     NOT NULL,
+  "metadata"   TEXT     NOT NULL DEFAULT '{}',
+  "createdAt"  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX "Tenant_deletedAt_idx" ON "Tenant"("deletedAt");
+CREATE INDEX "ApiKey_tenantId_deletedAt_idx" ON "ApiKey"("tenantId", "deletedAt");
+CREATE INDEX "ApiKey_deletedAt_idx" ON "ApiKey"("deletedAt");
+CREATE INDEX "CriticalEntityAuditEvent_entityType_entityId_createdAt_idx"
+  ON "CriticalEntityAuditEvent"("entityType", "entityId", "createdAt");
+CREATE INDEX "CriticalEntityAuditEvent_action_idx" ON "CriticalEntityAuditEvent"("action");
+CREATE INDEX "CriticalEntityAuditEvent_actor_idx" ON "CriticalEntityAuditEvent"("actor");
+CREATE INDEX "CriticalEntityAuditEvent_createdAt_idx" ON "CriticalEntityAuditEvent"("createdAt");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -437,29 +437,57 @@ model ScopedAdminTokenRotationEvent {
 
 // Tenant model – represents a customer/organization
 model Tenant {
-  id        String   @id @default(uuid())
-  name      String   @unique
-  createdAt DateTime @default(now())
+  id             String    @id @default(uuid())
+  name           String    @unique
+  createdAt      DateTime  @default(now())
+  deletedAt      DateTime?
+  deletedBy      String?
+  deletionReason String?
   // Relations
-  apiKeys   ApiKey[]
+  apiKeys        ApiKey[]
+
   @@index([name])
+  @@index([deletedAt])
 }
 
 // API key model – scoped per tenant with role and scopes
 model ApiKey {
-  id         String   @id @default(uuid())
-  tenantId   String
-  hashedKey  String   @unique
-  role       String
-  scopes     String   @default("[]")
-  createdAt  DateTime @default(now())
-  expiresAt  DateTime?
-  isActive   Boolean  @default(true)
+  id             String    @id @default(uuid())
+  tenantId       String
+  hashedKey      String    @unique
+  role           String
+  scopes         String    @default("[]")
+  createdAt      DateTime  @default(now())
+  expiresAt      DateTime?
+  isActive       Boolean   @default(true)
+  deletedAt      DateTime?
+  deletedBy      String?
+  deletionReason String?
 
-  tenant     Tenant   @relation(fields: [tenantId], references: [id])
+  tenant Tenant @relation(fields: [tenantId], references: [id])
 
   @@index([tenantId])
+  @@index([tenantId, deletedAt])
   @@index([role])
+  @@index([deletedAt])
+}
+
+/// Immutable lifecycle history for critical control-plane entities.
+/// Application code may append records but must never update or delete them.
+model CriticalEntityAuditEvent {
+  id         String   @id @default(uuid())
+  entityType String
+  entityId   String
+  action     String
+  actor      String
+  reason     String
+  metadata   String   @default("{}")
+  createdAt  DateTime @default(now())
+
+  @@index([entityType, entityId, createdAt])
+  @@index([action])
+  @@index([actor])
+  @@index([createdAt])
 }
 
 // Durable write-ahead audit log for admin configuration changes (Issue #707).

--- a/backend/src/__tests__/apiKeySoftDeleteAuth.test.ts
+++ b/backend/src/__tests__/apiKeySoftDeleteAuth.test.ts
@@ -1,0 +1,40 @@
+import { isPersistedApiKeyUsable } from '../middleware/apiKeyAuth';
+
+describe('persisted API key soft-delete authentication (Issue #1047)', () => {
+  it('rejects a soft-deleted API key', () => {
+    expect(
+      isPersistedApiKeyUsable({
+        isActive: true,
+        deletedAt: new Date(),
+        tenant: { deletedAt: null },
+      })
+    ).toBe(false);
+  });
+
+  it('rejects an otherwise active key when its tenant is deleted', () => {
+    expect(
+      isPersistedApiKeyUsable({
+        isActive: true,
+        deletedAt: null,
+        tenant: { deletedAt: new Date() },
+      })
+    ).toBe(false);
+  });
+
+  it('accepts an active key only when its tenant is also active', () => {
+    expect(
+      isPersistedApiKeyUsable({
+        isActive: true,
+        deletedAt: null,
+        tenant: { deletedAt: null },
+      })
+    ).toBe(true);
+    expect(
+      isPersistedApiKeyUsable({
+        isActive: false,
+        deletedAt: null,
+        tenant: { deletedAt: null },
+      })
+    ).toBe(false);
+  });
+});

--- a/backend/src/__tests__/criticalEntityLifecycle.test.ts
+++ b/backend/src/__tests__/criticalEntityLifecycle.test.ts
@@ -1,0 +1,269 @@
+const mockTx = {
+  tenant: {
+    updateMany: jest.fn(),
+    findUnique: jest.fn(),
+    findFirst: jest.fn(),
+  },
+  apiKey: {
+    updateMany: jest.fn(),
+    findUnique: jest.fn(),
+    create: jest.fn(),
+  },
+  criticalEntityAuditEvent: {
+    create: jest.fn(),
+    findMany: jest.fn(),
+  },
+};
+
+const mockPrisma = {
+  $transaction: jest.fn(async (callback: (tx: typeof mockTx) => unknown) => callback(mockTx)),
+  criticalEntityAuditEvent: {
+    findMany: jest.fn(),
+  },
+};
+
+jest.mock('../prisma', () => ({ prisma: mockPrisma }));
+
+import {
+  listCriticalEntityAuditTrail,
+  restoreApiKey,
+  restoreTenant,
+  softDeleteApiKey,
+  softDeleteTenant,
+} from '../criticalEntityLifecycle';
+import { assertCriticalEntityMutationAllowed } from '../criticalEntityPolicy';
+import { createApiKey, rotateApiKey } from '../services/apiKeyService';
+
+describe('critical entity lifecycle (Issue #1047)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockTx.criticalEntityAuditEvent.create.mockResolvedValue({ id: 'audit-1' });
+  });
+
+  it('soft-deletes a tenant, disables its keys, and writes one atomic audit event', async () => {
+    mockTx.tenant.updateMany.mockResolvedValue({ count: 1 });
+    mockTx.apiKey.updateMany.mockResolvedValue({ count: 3 });
+
+    const result = await softDeleteTenant('tenant-1', {
+      actor: 'admin@example.com',
+      reason: 'Customer account closed',
+    });
+
+    expect(result).toEqual({
+      entityType: 'tenant',
+      entityId: 'tenant-1',
+      status: 'changed',
+      affectedApiKeys: 3,
+    });
+    expect(mockTx.tenant.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'tenant-1', deletedAt: null } })
+    );
+    expect(mockTx.apiKey.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { tenantId: 'tenant-1', deletedAt: null },
+        data: expect.objectContaining({ isActive: false }),
+      })
+    );
+    expect(mockTx.criticalEntityAuditEvent.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        entityType: 'tenant',
+        entityId: 'tenant-1',
+        action: 'soft_delete',
+        actor: 'admin@example.com',
+        metadata: '{"affectedApiKeys":3}',
+      }),
+    });
+  });
+
+  it('makes concurrent tenant deletion retries idempotent without duplicate audits', async () => {
+    mockTx.tenant.updateMany.mockResolvedValue({ count: 0 });
+    mockTx.tenant.findUnique.mockResolvedValue({ deletedAt: new Date() });
+
+    await expect(
+      softDeleteTenant('tenant-1', { actor: 'admin', reason: 'duplicate request' })
+    ).resolves.toMatchObject({ status: 'already_deleted' });
+
+    expect(mockTx.apiKey.updateMany).not.toHaveBeenCalled();
+    expect(mockTx.criticalEntityAuditEvent.create).not.toHaveBeenCalled();
+  });
+
+  it('restores a tenant without automatically restoring credentials', async () => {
+    mockTx.tenant.updateMany.mockResolvedValue({ count: 1 });
+
+    await expect(
+      restoreTenant('tenant-1', { actor: 'security-admin', reason: 'Closure reversed' })
+    ).resolves.toMatchObject({ status: 'changed' });
+
+    expect(mockTx.apiKey.updateMany).not.toHaveBeenCalled();
+    expect(mockTx.criticalEntityAuditEvent.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        action: 'restore',
+        metadata: '{"apiKeysRemainDisabled":true}',
+      }),
+    });
+  });
+
+  it('soft-deletes an API key without retaining its secret hash in the audit event', async () => {
+    mockTx.apiKey.updateMany.mockResolvedValue({ count: 1 });
+
+    await expect(
+      softDeleteApiKey('key-1', { actor: 'security-admin', reason: 'Credential compromised' })
+    ).resolves.toMatchObject({ status: 'changed' });
+
+    const auditData = mockTx.criticalEntityAuditEvent.create.mock.calls[0][0].data;
+    expect(JSON.stringify(auditData)).not.toContain('hashedKey');
+    expect(auditData).toMatchObject({
+      entityType: 'api_key',
+      entityId: 'key-1',
+      action: 'soft_delete',
+    });
+  });
+
+  it('does not restore an API key while its tenant is deleted', async () => {
+    mockTx.apiKey.findUnique.mockResolvedValue({
+      deletedAt: new Date(),
+      tenant: { deletedAt: new Date() },
+    });
+
+    await expect(
+      restoreApiKey('key-1', { actor: 'security-admin', reason: 'Requested restore' })
+    ).resolves.toMatchObject({ status: 'parent_deleted' });
+
+    expect(mockTx.apiKey.updateMany).not.toHaveBeenCalled();
+    expect(mockTx.criticalEntityAuditEvent.create).not.toHaveBeenCalled();
+  });
+
+  it('uses a conditional update when restoring an API key to close tenant deletion races', async () => {
+    mockTx.apiKey.findUnique.mockResolvedValue({
+      deletedAt: new Date(),
+      tenant: { deletedAt: null },
+    });
+    mockTx.apiKey.updateMany.mockResolvedValue({ count: 1 });
+
+    await expect(
+      restoreApiKey('key-1', { actor: 'security-admin', reason: 'Credential approved' })
+    ).resolves.toMatchObject({ status: 'changed' });
+
+    expect(mockTx.apiKey.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          id: 'key-1',
+          deletedAt: { not: null },
+          tenant: { deletedAt: null },
+        },
+        data: expect.objectContaining({ isActive: true, deletedAt: null }),
+      })
+    );
+  });
+
+  it('treats a concurrent API key restore as an idempotent no-op', async () => {
+    mockTx.apiKey.findUnique
+      .mockResolvedValueOnce({
+        deletedAt: new Date(),
+        tenant: { deletedAt: null },
+      })
+      .mockResolvedValueOnce({
+        deletedAt: null,
+        tenant: { deletedAt: null },
+      });
+    mockTx.apiKey.updateMany.mockResolvedValue({ count: 0 });
+
+    await expect(
+      restoreApiKey('key-1', { actor: 'security-admin', reason: 'Credential approved' })
+    ).resolves.toMatchObject({ status: 'not_deleted' });
+    expect(mockTx.criticalEntityAuditEvent.create).not.toHaveBeenCalled();
+  });
+
+  it('requires attributable actors and reasons', async () => {
+    await expect(softDeleteApiKey('key-1', { actor: ' ', reason: 'reason' })).rejects.toThrow(
+      'actor is required'
+    );
+    await expect(softDeleteApiKey('key-1', { actor: 'admin', reason: ' ' })).rejects.toThrow(
+      'reason is required'
+    );
+    expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('returns bounded, parsed immutable audit history', async () => {
+    mockPrisma.criticalEntityAuditEvent.findMany.mockResolvedValue([
+      {
+        id: 'audit-1',
+        entityType: 'tenant',
+        entityId: 'tenant-1',
+        action: 'soft_delete',
+        actor: 'admin',
+        reason: 'closed',
+        metadata: '{"affectedApiKeys":2}',
+        createdAt: new Date('2026-07-29T12:00:00.000Z'),
+      },
+    ]);
+
+    await expect(
+      listCriticalEntityAuditTrail({ entityType: 'tenant', entityId: 'tenant-1', limit: 9999 })
+    ).resolves.toEqual([
+      expect.objectContaining({
+        metadata: { affectedApiKeys: 2 },
+        createdAt: '2026-07-29T12:00:00.000Z',
+      }),
+    ]);
+    expect(mockPrisma.criticalEntityAuditEvent.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ take: 500 })
+    );
+  });
+});
+
+describe('API key lifecycle enforcement', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('refuses to create credentials for a missing or deleted tenant', async () => {
+    mockTx.tenant.findFirst.mockResolvedValue(null);
+
+    await expect(createApiKey('deleted-tenant')).rejects.toThrow('missing or deleted tenant');
+    expect(mockTx.apiKey.create).not.toHaveBeenCalled();
+  });
+
+  it('uses a conditional update so rotation loses safely to tenant deletion', async () => {
+    mockTx.apiKey.updateMany.mockResolvedValue({ count: 0 });
+
+    await expect(rotateApiKey('key-1', 'replacement-secret')).resolves.toBeNull();
+    expect(mockTx.apiKey.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          id: 'key-1',
+          deletedAt: null,
+          tenant: { deletedAt: null },
+        },
+      })
+    );
+  });
+});
+
+describe('critical entity hard-delete policy', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  it('blocks generic hard deletes outside tests', () => {
+    process.env.NODE_ENV = 'production';
+    expect(() => assertCriticalEntityMutationAllowed('Tenant', 'delete')).toThrow(
+      'Hard delete blocked'
+    );
+    expect(() => assertCriticalEntityMutationAllowed('ApiKey', 'deleteMany')).toThrow(
+      'Hard delete blocked'
+    );
+    expect(() =>
+      assertCriticalEntityMutationAllowed('CriticalEntityAuditEvent', 'updateMany')
+    ).toThrow('immutable');
+  });
+
+  it('allows non-critical deletes and explicit test cleanup', () => {
+    process.env.NODE_ENV = 'production';
+    expect(() => assertCriticalEntityMutationAllowed('ExportJob', 'deleteMany')).not.toThrow();
+    process.env.NODE_ENV = 'test';
+    expect(() => assertCriticalEntityMutationAllowed('Tenant', 'deleteMany')).not.toThrow();
+  });
+});

--- a/backend/src/criticalEntityLifecycle.ts
+++ b/backend/src/criticalEntityLifecycle.ts
@@ -1,0 +1,333 @@
+/**
+ * Atomic soft-delete/restore operations and immutable audit history for
+ * critical control-plane entities (Issue #1047).
+ */
+
+import { prisma } from './prisma';
+
+export type CriticalEntityType = 'tenant' | 'api_key';
+export type CriticalEntityLifecycleAction = 'soft_delete' | 'restore';
+export type CriticalEntityLifecycleStatus =
+  | 'changed'
+  | 'not_found'
+  | 'already_deleted'
+  | 'not_deleted'
+  | 'parent_deleted';
+
+export interface CriticalEntityActorContext {
+  actor: string;
+  reason: string;
+}
+
+export interface CriticalEntityLifecycleResult {
+  entityType: CriticalEntityType;
+  entityId: string;
+  status: CriticalEntityLifecycleStatus;
+  affectedApiKeys?: number;
+}
+
+export interface CriticalEntityAuditRecord {
+  id: string;
+  entityType: CriticalEntityType;
+  entityId: string;
+  action: CriticalEntityLifecycleAction;
+  actor: string;
+  reason: string;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+}
+
+export interface CriticalEntityAuditFilters {
+  entityType?: CriticalEntityType;
+  entityId?: string;
+  action?: CriticalEntityLifecycleAction;
+  limit?: number;
+}
+
+function normalizeContext(context: CriticalEntityActorContext): CriticalEntityActorContext {
+  const actor = context.actor.trim();
+  const reason = context.reason.trim();
+  if (!actor || actor.length > 200) {
+    throw new Error('actor is required and must be at most 200 characters');
+  }
+  if (!reason || reason.length > 500) {
+    throw new Error('reason is required and must be at most 500 characters');
+  }
+  return { actor, reason };
+}
+
+function auditData(
+  entityType: CriticalEntityType,
+  entityId: string,
+  action: CriticalEntityLifecycleAction,
+  context: CriticalEntityActorContext,
+  metadata: Record<string, unknown> = {}
+) {
+  return {
+    entityType,
+    entityId,
+    action,
+    actor: context.actor,
+    reason: context.reason,
+    metadata: JSON.stringify(metadata),
+  };
+}
+
+/**
+ * Soft-deletes a tenant and atomically disables every active API key owned by
+ * it. Conditional updates make concurrent retries idempotent.
+ */
+export async function softDeleteTenant(
+  tenantId: string,
+  rawContext: CriticalEntityActorContext
+): Promise<CriticalEntityLifecycleResult> {
+  const context = normalizeContext(rawContext);
+  const now = new Date();
+
+  return prisma.$transaction(async (tx) => {
+    const tenantUpdate = await tx.tenant.updateMany({
+      where: { id: tenantId, deletedAt: null },
+      data: {
+        deletedAt: now,
+        deletedBy: context.actor,
+        deletionReason: context.reason,
+      },
+    });
+
+    if (tenantUpdate.count === 0) {
+      const tenant = await tx.tenant.findUnique({
+        where: { id: tenantId },
+        select: { deletedAt: true },
+      });
+      return {
+        entityType: 'tenant' as const,
+        entityId: tenantId,
+        status: tenant ? ('already_deleted' as const) : ('not_found' as const),
+      };
+    }
+
+    const apiKeyUpdate = await tx.apiKey.updateMany({
+      where: { tenantId, deletedAt: null },
+      data: {
+        isActive: false,
+        deletedAt: now,
+        deletedBy: context.actor,
+        deletionReason: `Tenant deleted: ${context.reason}`,
+      },
+    });
+
+    await tx.criticalEntityAuditEvent.create({
+      data: auditData('tenant', tenantId, 'soft_delete', context, {
+        affectedApiKeys: apiKeyUpdate.count,
+      }),
+    });
+
+    return {
+      entityType: 'tenant' as const,
+      entityId: tenantId,
+      status: 'changed' as const,
+      affectedApiKeys: apiKeyUpdate.count,
+    };
+  });
+}
+
+/**
+ * Restores a tenant. API keys remain disabled and require individual,
+ * explicitly audited restoration.
+ */
+export async function restoreTenant(
+  tenantId: string,
+  rawContext: CriticalEntityActorContext
+): Promise<CriticalEntityLifecycleResult> {
+  const context = normalizeContext(rawContext);
+
+  return prisma.$transaction(async (tx) => {
+    const tenantUpdate = await tx.tenant.updateMany({
+      where: { id: tenantId, deletedAt: { not: null } },
+      data: {
+        deletedAt: null,
+        deletedBy: null,
+        deletionReason: null,
+      },
+    });
+
+    if (tenantUpdate.count === 0) {
+      const tenant = await tx.tenant.findUnique({
+        where: { id: tenantId },
+        select: { deletedAt: true },
+      });
+      return {
+        entityType: 'tenant' as const,
+        entityId: tenantId,
+        status: tenant ? ('not_deleted' as const) : ('not_found' as const),
+      };
+    }
+
+    await tx.criticalEntityAuditEvent.create({
+      data: auditData('tenant', tenantId, 'restore', context, {
+        apiKeysRemainDisabled: true,
+      }),
+    });
+
+    return {
+      entityType: 'tenant' as const,
+      entityId: tenantId,
+      status: 'changed' as const,
+    };
+  });
+}
+
+export async function softDeleteApiKey(
+  apiKeyId: string,
+  rawContext: CriticalEntityActorContext
+): Promise<CriticalEntityLifecycleResult> {
+  const context = normalizeContext(rawContext);
+  const now = new Date();
+
+  return prisma.$transaction(async (tx) => {
+    const keyUpdate = await tx.apiKey.updateMany({
+      where: { id: apiKeyId, deletedAt: null },
+      data: {
+        isActive: false,
+        deletedAt: now,
+        deletedBy: context.actor,
+        deletionReason: context.reason,
+      },
+    });
+
+    if (keyUpdate.count === 0) {
+      const key = await tx.apiKey.findUnique({
+        where: { id: apiKeyId },
+        select: { deletedAt: true },
+      });
+      return {
+        entityType: 'api_key' as const,
+        entityId: apiKeyId,
+        status: key ? ('already_deleted' as const) : ('not_found' as const),
+      };
+    }
+
+    await tx.criticalEntityAuditEvent.create({
+      data: auditData('api_key', apiKeyId, 'soft_delete', context),
+    });
+
+    return {
+      entityType: 'api_key' as const,
+      entityId: apiKeyId,
+      status: 'changed' as const,
+    };
+  });
+}
+
+export async function restoreApiKey(
+  apiKeyId: string,
+  rawContext: CriticalEntityActorContext
+): Promise<CriticalEntityLifecycleResult> {
+  const context = normalizeContext(rawContext);
+
+  return prisma.$transaction(async (tx) => {
+    const key = await tx.apiKey.findUnique({
+      where: { id: apiKeyId },
+      select: {
+        deletedAt: true,
+        tenant: { select: { deletedAt: true } },
+      },
+    });
+
+    if (!key) {
+      return { entityType: 'api_key' as const, entityId: apiKeyId, status: 'not_found' as const };
+    }
+    if (!key.deletedAt) {
+      return { entityType: 'api_key' as const, entityId: apiKeyId, status: 'not_deleted' as const };
+    }
+    if (key.tenant.deletedAt) {
+      return {
+        entityType: 'api_key' as const,
+        entityId: apiKeyId,
+        status: 'parent_deleted' as const,
+      };
+    }
+
+    const keyUpdate = await tx.apiKey.updateMany({
+      where: {
+        id: apiKeyId,
+        deletedAt: { not: null },
+        tenant: { deletedAt: null },
+      },
+      data: {
+        isActive: true,
+        deletedAt: null,
+        deletedBy: null,
+        deletionReason: null,
+      },
+    });
+
+    if (keyUpdate.count === 0) {
+      const current = await tx.apiKey.findUnique({
+        where: { id: apiKeyId },
+        select: {
+          deletedAt: true,
+          tenant: { select: { deletedAt: true } },
+        },
+      });
+      let status: CriticalEntityLifecycleStatus = 'not_deleted';
+      if (!current) {
+        status = 'not_found';
+      } else if (current.deletedAt && current.tenant.deletedAt) {
+        status = 'parent_deleted';
+      }
+      return {
+        entityType: 'api_key' as const,
+        entityId: apiKeyId,
+        status,
+      };
+    }
+
+    await tx.criticalEntityAuditEvent.create({
+      data: auditData('api_key', apiKeyId, 'restore', context),
+    });
+
+    return {
+      entityType: 'api_key' as const,
+      entityId: apiKeyId,
+      status: 'changed' as const,
+    };
+  });
+}
+
+export async function listCriticalEntityAuditTrail(
+  filters: CriticalEntityAuditFilters = {}
+): Promise<CriticalEntityAuditRecord[]> {
+  const limit = Math.max(1, Math.min(filters.limit ?? 100, 500));
+  const rows = await prisma.criticalEntityAuditEvent.findMany({
+    where: {
+      ...(filters.entityType ? { entityType: filters.entityType } : {}),
+      ...(filters.entityId ? { entityId: filters.entityId } : {}),
+      ...(filters.action ? { action: filters.action } : {}),
+    },
+    orderBy: { createdAt: 'desc' },
+    take: limit,
+  });
+
+  return rows.map((row) => ({
+    id: row.id,
+    entityType: row.entityType as CriticalEntityType,
+    entityId: row.entityId,
+    action: row.action as CriticalEntityLifecycleAction,
+    actor: row.actor,
+    reason: row.reason,
+    metadata: parseMetadata(row.metadata),
+    createdAt: row.createdAt.toISOString(),
+  }));
+}
+
+function parseMetadata(raw: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}

--- a/backend/src/criticalEntityPolicy.ts
+++ b/backend/src/criticalEntityPolicy.ts
@@ -1,0 +1,37 @@
+/**
+ * Hard-delete guardrails for critical control-plane entities (Issue #1047).
+ *
+ * Lifecycle code must use conditional updates plus immutable audit events.
+ * Test cleanup is the only generic-delete exception.
+ */
+
+export const CRITICAL_ENTITY_MODELS = new Set([
+  'ApiKey',
+  'CriticalEntityAuditEvent',
+  'ScopedAdminToken',
+  'Tenant',
+  'WebhookEndpoint',
+]);
+
+export function assertCriticalEntityMutationAllowed(
+  model: string | undefined,
+  operation: string
+): void {
+  const mutatesImmutableAudit =
+    model === 'CriticalEntityAuditEvent' &&
+    ['delete', 'deleteMany', 'update', 'updateMany', 'upsert'].includes(operation);
+
+  if (
+    process.env.NODE_ENV !== 'test' &&
+    model &&
+    (mutatesImmutableAudit ||
+      (CRITICAL_ENTITY_MODELS.has(model) && (operation === 'delete' || operation === 'deleteMany')))
+  ) {
+    if (mutatesImmutableAudit) {
+      throw new Error('CriticalEntityAuditEvent is immutable; only create operations are allowed');
+    }
+    throw new Error(
+      `Hard delete blocked for critical entity ${model}; use its audited lifecycle service`
+    );
+  }
+}

--- a/backend/src/middleware/apiKeyAuth.ts
+++ b/backend/src/middleware/apiKeyAuth.ts
@@ -55,10 +55,22 @@ function parseScopes(raw: unknown): string[] {
   return [];
 }
 
+export interface PersistedApiKeyStatus {
+  isActive: boolean;
+  deletedAt?: Date | null;
+  tenant?: { deletedAt?: Date | null };
+}
+
+export function isPersistedApiKeyUsable(
+  apiKey: PersistedApiKeyStatus | null
+): apiKey is PersistedApiKeyStatus {
+  return Boolean(apiKey && apiKey.isActive && !apiKey.deletedAt && !apiKey.tenant?.deletedAt);
+}
+
 export async function validateApiKey(
   req: Request,
   res: Response,
-  next: NextFunction,
+  next: NextFunction
 ): Promise<void> {
   const authHeader = req.get?.('Authorization') || '';
   const match = authHeader.match(/^ApiKey\s+(.+)$/i);
@@ -71,24 +83,42 @@ export async function validateApiKey(
 
   // Try Prisma first; fall back to in-memory store when the table doesn't exist
   // (e.g. in tests with an un-migrated SQLite database).
-  let apiKey: { hashedKey: string; role: string; tenantId: string; scopes: unknown; isActive: boolean } | null = null;
+  let apiKey: {
+    hashedKey: string;
+    role: string;
+    tenantId: string;
+    scopes: unknown;
+    isActive: boolean;
+    deletedAt?: Date | null;
+    tenant?: { deletedAt?: Date | null };
+  } | null = null;
   try {
-    apiKey = await prisma.apiKey.findUnique({ where: { hashedKey: hashed } });
+    apiKey = await prisma.apiKey.findUnique({
+      where: { hashedKey: hashed },
+      include: { tenant: { select: { deletedAt: true } } },
+    });
   } catch (err) {
     // Only fall back when the ApiKey table hasn't been created (tests / fresh DB).
     const isMissingTable =
       err instanceof Error &&
       (err.message.includes('does not exist in the current database') ||
-       (err as { code?: string }).code === 'P2021');
+        (err as { code?: string }).code === 'P2021');
     if (!isMissingTable) throw err;
   }
 
-  if (apiKey && apiKey.isActive) {
-    req.authApiKeyHash = apiKey.hashedKey;
-    req.authApiKeyRole = apiKey.role as ApiKeyRole;
-    req.authApiKeyTenantId = apiKey.tenantId;
-    req.authApiKeyScopes = parseScopes(apiKey.scopes);
-    next();
+  if (apiKey) {
+    if (isPersistedApiKeyUsable(apiKey)) {
+      req.authApiKeyHash = apiKey.hashedKey;
+      req.authApiKeyRole = apiKey.role as ApiKeyRole;
+      req.authApiKeyTenantId = apiKey.tenantId;
+      req.authApiKeyScopes = parseScopes(apiKey.scopes);
+      next();
+      return;
+    }
+
+    // A persisted-but-disabled credential must fail closed. Never let it fall
+    // through to the legacy in-memory store where an old duplicate could live.
+    res.status(401).json({ error: 'Unauthorized', message: 'Invalid API key' });
     return;
   }
 
@@ -112,7 +142,10 @@ export function hashApiKey(key: string): string {
 // Legacy helpers retained for compatibility – they operate on in‑memory map only.
 const IN_MEMORY_KEYS = new Map<string, ApiKeyMetadata>();
 
-export function registerApiKey(key: string, options?: { role?: ApiKeyRole; tenantId?: string; scopes?: string[] }): string {
+export function registerApiKey(
+  key: string,
+  options?: { role?: ApiKeyRole; tenantId?: string; scopes?: string[] }
+): string {
   const hash = hashApiKey(key);
   IN_MEMORY_KEYS.set(hash, {
     role: options?.role || 'admin',
@@ -132,7 +165,11 @@ export function revokeApiKey(hash: string): boolean {
   return IN_MEMORY_KEYS.delete(hash);
 }
 
-export function rotateApiKey(oldHash: string, newKey: string, options: { role?: ApiKeyRole; tenantId?: string; scopes?: string[] } = {}): string | null {
+export function rotateApiKey(
+  oldHash: string,
+  newKey: string,
+  options: { role?: ApiKeyRole; tenantId?: string; scopes?: string[] } = {}
+): string | null {
   const meta = IN_MEMORY_KEYS.get(oldHash);
   if (!meta) return null;
   IN_MEMORY_KEYS.delete(oldHash);

--- a/backend/src/prisma.ts
+++ b/backend/src/prisma.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from '@prisma/client';
+import { assertCriticalEntityMutationAllowed } from './criticalEntityPolicy';
 
 const QUERY_TIMEOUT_MS = parsePositiveInt(process.env.PRISMA_QUERY_TIMEOUT_MS, 5000);
 const POOL_MAX = parsePositiveInt(process.env.PRISMA_POOL_MAX, 10);
@@ -63,6 +64,7 @@ export const prisma = prismaClient.$extends({
   query: {
     $allModels: {
       async $allOperations({ model, operation, args, query }) {
+        assertCriticalEntityMutationAllowed(model, operation);
         return runWithTimeout(query(args), QUERY_TIMEOUT_MS, `${model}.${operation}`);
       },
     },

--- a/backend/src/prismaClient.ts
+++ b/backend/src/prismaClient.ts
@@ -8,6 +8,7 @@
  */
 
 import { PrismaClient } from '@prisma/client';
+import { assertCriticalEntityMutationAllowed } from './criticalEntityPolicy';
 import { logger } from './middleware/structuredLogging';
 import { observeDbQueryDuration } from './metrics';
 
@@ -65,6 +66,7 @@ function attachQueryInstrumentation(client: PrismaClient): void {
   }
 
   client.$use(async (params, next) => {
+    assertCriticalEntityMutationAllowed(params.model, params.action);
     const startedAt = process.hrtime.bigint();
 
     try {

--- a/backend/src/services/apiKeyService.ts
+++ b/backend/src/services/apiKeyService.ts
@@ -1,6 +1,11 @@
 import { prisma } from '../prisma';
 import crypto from 'crypto';
-import { ApiKeyRole } from '../middleware/apiKeyAuth';
+import type { ApiKeyRole } from '../middleware/apiKeyAuth';
+import {
+  restoreApiKey as restoreCriticalApiKey,
+  softDeleteApiKey,
+} from '../criticalEntityLifecycle';
+import type { CriticalEntityActorContext } from '../criticalEntityLifecycle';
 
 export interface ApiKeyRecord {
   id: string;
@@ -11,6 +16,9 @@ export interface ApiKeyRecord {
   createdAt: Date;
   expiresAt?: Date | null;
   isActive: boolean;
+  deletedAt?: Date | null;
+  deletedBy?: string | null;
+  deletionReason?: string | null;
 }
 
 function hashApiKey(key: string): string {
@@ -43,6 +51,9 @@ function toApiKeyRecord(r: {
   createdAt: Date;
   expiresAt: Date | null;
   isActive: boolean;
+  deletedAt: Date | null;
+  deletedBy: string | null;
+  deletionReason: string | null;
 }): ApiKeyRecord {
   return {
     id: r.id,
@@ -53,6 +64,9 @@ function toApiKeyRecord(r: {
     createdAt: r.createdAt,
     expiresAt: r.expiresAt ?? undefined,
     isActive: r.isActive,
+    deletedAt: r.deletedAt ?? undefined,
+    deletedBy: r.deletedBy ?? undefined,
+    deletionReason: r.deletionReason ?? undefined,
   };
 }
 
@@ -65,50 +79,99 @@ export async function createApiKey(
   const plainKey = crypto.randomBytes(32).toString('hex');
   const hashedKey = hashApiKey(plainKey);
   const now = new Date();
-  const expiresAt = expiresInDays ? new Date(now.getTime() + expiresInDays * 24 * 60 * 60 * 1000) : null;
+  const expiresAt = expiresInDays
+    ? new Date(now.getTime() + expiresInDays * 24 * 60 * 60 * 1000)
+    : null;
 
-  const record = await prisma.apiKey.create({
-    data: {
-      tenantId,
-      hashedKey,
-      role,
-      scopes: serializeScopes(scopes),
-      createdAt: now,
-      expiresAt,
-      isActive: true,
-    },
+  const record = await prisma.$transaction(async (tx) => {
+    const activeTenant = await tx.tenant.findFirst({
+      where: { id: tenantId, deletedAt: null },
+      select: { id: true },
+    });
+    if (!activeTenant) {
+      throw new Error('Cannot create an API key for a missing or deleted tenant');
+    }
+
+    return tx.apiKey.create({
+      data: {
+        tenantId,
+        hashedKey,
+        role,
+        scopes: serializeScopes(scopes),
+        createdAt: now,
+        expiresAt,
+        isActive: true,
+      },
+    });
   });
 
   return { plainKey, record: toApiKeyRecord(record) };
 }
 
 export async function getApiKeyByHashed(hashed: string): Promise<ApiKeyRecord | null> {
-  const record = await prisma.apiKey.findUnique({ where: { hashedKey: hashed } });
+  const record = await prisma.apiKey.findUnique({
+    where: { hashedKey: hashed },
+    include: { tenant: { select: { deletedAt: true } } },
+  });
   if (!record) return null;
-  if (!record.isActive) return null;
+  if (!record.isActive || record.deletedAt || record.tenant.deletedAt) return null;
   if (record.expiresAt && record.expiresAt < new Date()) return null;
   return toApiKeyRecord(record);
 }
 
-export async function revokeApiKey(id: string): Promise<boolean> {
-  const updated = await prisma.apiKey.update({
-    where: { id },
-    data: { isActive: false },
-  });
-  return !!updated;
+export async function revokeApiKey(
+  id: string,
+  context: CriticalEntityActorContext = {
+    actor: 'system',
+    reason: 'API key revoked',
+  }
+): Promise<boolean> {
+  const result = await softDeleteApiKey(id, context);
+  return result.status === 'changed';
 }
 
-export async function rotateApiKey(id: string, newPlainKey: string, newScopes?: string[]): Promise<ApiKeyRecord | null> {
+export async function restoreApiKey(
+  id: string,
+  context: CriticalEntityActorContext
+): Promise<boolean> {
+  const result = await restoreCriticalApiKey(id, context);
+  return result.status === 'changed';
+}
+
+export async function rotateApiKey(
+  id: string,
+  newPlainKey: string,
+  newScopes?: string[]
+): Promise<ApiKeyRecord | null> {
   const hashedKey = hashApiKey(newPlainKey);
   const updateData: Record<string, unknown> = {
     hashedKey,
   };
   if (newScopes) updateData.scopes = serializeScopes(newScopes);
-  const record = await prisma.apiKey.update({ where: { id }, data: updateData });
-  return toApiKeyRecord(record);
+  const record = await prisma.$transaction(async (tx) => {
+    const updated = await tx.apiKey.updateMany({
+      where: {
+        id,
+        deletedAt: null,
+        tenant: { deletedAt: null },
+      },
+      data: updateData,
+    });
+    if (updated.count === 0) return null;
+    return tx.apiKey.findUnique({ where: { id } });
+  });
+  return record ? toApiKeyRecord(record) : null;
 }
 
-export async function listApiKeys(tenantId: string): Promise<ApiKeyRecord[]> {
-  const records = await prisma.apiKey.findMany({ where: { tenantId } });
-  return records.map(r => toApiKeyRecord(r));
+export async function listApiKeys(
+  tenantId: string,
+  options: { includeDeleted?: boolean } = {}
+): Promise<ApiKeyRecord[]> {
+  const records = await prisma.apiKey.findMany({
+    where: {
+      tenantId,
+      ...(options.includeDeleted ? {} : { deletedAt: null }),
+    },
+  });
+  return records.map((r) => toApiKeyRecord(r));
 }

--- a/docs/DATA_RETENTION_DELETION_POLICY.md
+++ b/docs/DATA_RETENTION_DELETION_POLICY.md
@@ -1,6 +1,6 @@
 # Data Retention & Deletion Policy
 
-**Last Updated:** June 26, 2026
+**Last Updated:** July 29, 2026
 **Maintained By:** DevOps Team
 **Next Review:** September 26, 2026
 
@@ -26,6 +26,8 @@ This document defines the data retention periods, deletion workflows, and compli
 | **Admin Action Receipts** | `AdminActionReceipt` | 7 years | Non-repudiation & compliance | Hard delete after 7 years |
 | **Admin Impersonation** | `AdminImpersonationSession`, `AdminImpersonationLedgerEntry` | 3 years | Security monitoring; insider threat investigations | Hard delete after 3 years |
 | **API Key Audit** | `ApiKeyAuditEvent` | 3 years | Key usage tracking & abuse investigation | Hard delete after 3 years |
+| **Tenants and API Keys** | `Tenant`, `ApiKey` | Indefinite (active); deletion subject to contract and compliance policy | Access-control records and customer isolation | Audited soft-delete; hard delete only through approved retention cleanup |
+| **Critical Entity Lifecycle Audit** | `CriticalEntityAuditEvent` | 7 years | Reconstruction of tenant and credential deletion/restoration | Append-only; archive before retention cleanup |
 | **Export Jobs** | `ExportJob`, `BulkExportJob` | 90 days | Operational; cleanup to reduce DB size | Hard delete after 90 days |
 | **Event Processing** | `EventCursor`, `ProcessedEvent` | 30 days | Idempotency & replay; short-lived operational data | Hard delete after 30 days |
 | **Webhook Endpoints** | `WebhookEndpoint` | Indefinite (active); 90 days post-deletion | Webhook configuration; soft-delete with cleanup window | Soft-delete (`deletedAt`); hard delete after 90 days |
@@ -220,6 +222,12 @@ User Wallet Address
 ---
 
 ## Deletion Implementation Guidelines
+
+Critical control-plane entities must use the audited lifecycle service described
+in [Critical Entity Soft Deletion and Audit Trail](../backend/docs/CRITICAL_ENTITY_LIFECYCLE.md).
+Generic Prisma hard deletes are blocked outside tests. Tenant deletion
+atomically disables its API keys, and tenant restoration never restores those
+credentials automatically.
 
 ### Script Location
 


### PR DESCRIPTION
## Summary

- add reusable soft-delete, restore, and audit-history lifecycle operations for critical entities
- persist deletion metadata and immutable audit records through a Prisma migration
- prevent soft-deleted API keys from authenticating or appearing in active-key queries
- enforce entity-specific lifecycle policy and transactional audit writes
- document retention, restoration, purge, and operational procedures

## Why

Critical records need recoverable deletion and a reliable history of destructive lifecycle actions. The prior hard-delete behavior could remove important state without consistent attribution, restoration support, or audit evidence.

## Validation

- `npm test -- --runInBand src/__tests__/criticalEntityLifecycle.test.ts src/__tests__/apiKeySoftDeleteAuth.test.ts` — 16 tests passed
- `npx prisma validate` — schema valid
- scoped ESLint — zero errors (4 existing type-safety warnings)
- `git diff --check upstream/main...HEAD` — passed

Closes #1047