### PR TITLE
Persist wallet alias mappings

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -246,6 +246,19 @@ When bumping snapshots intentionally:
 2. Run `npm run snapshots:write` and commit `schema-snapshots/*.json`
 3. Align OpenAPI annotations and run `npm run generate:openapi`
 
+### Wallet Alias Persistence
+
+Wallet alias identity groups are persisted in Prisma and loaded into the
+`walletAliasService` cache on startup. New aliases registered through auth or
+`/api/v1/wallet-aliases/link` survive backend restarts and continue to resolve
+for referral attribution.
+
+Environments that relied on the previous in-memory-only alias registry do not
+have a durable source to backfill from after a restart. If those aliases matter,
+export or re-register the live mappings before deploying/restarting; otherwise
+the persistent tables will start empty and only new registrations will be
+preserved.
+
 ## Issues Addressed
 
 ### Issue #145: Rate Limiting

--- a/backend/prisma/migrations/20260729000000_add_wallet_alias_persistence/migration.sql
+++ b/backend/prisma/migrations/20260729000000_add_wallet_alias_persistence/migration.sql
@@ -1,0 +1,37 @@
+-- Persist wallet alias identity groups so provider aliases survive process restarts.
+
+CREATE TABLE "WalletCanonicalIdentity" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+
+CREATE TABLE "WalletAlias" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "canonicalId" TEXT NOT NULL,
+    "alias" TEXT NOT NULL,
+    "source" TEXT NOT NULL,
+    "aliasKey" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "WalletAlias_canonicalId_fkey" FOREIGN KEY ("canonicalId") REFERENCES "WalletCanonicalIdentity" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "WalletAliasSource" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "source" TEXT NOT NULL,
+    "displayName" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+
+CREATE INDEX "WalletCanonicalIdentity_createdAt_idx" ON "WalletCanonicalIdentity"("createdAt");
+
+CREATE UNIQUE INDEX "WalletAlias_aliasKey_key" ON "WalletAlias"("aliasKey");
+CREATE INDEX "WalletAlias_canonicalId_idx" ON "WalletAlias"("canonicalId");
+CREATE INDEX "WalletAlias_source_idx" ON "WalletAlias"("source");
+CREATE INDEX "WalletAlias_createdAt_idx" ON "WalletAlias"("createdAt");
+
+CREATE UNIQUE INDEX "WalletAliasSource_source_key" ON "WalletAliasSource"("source");
+CREATE INDEX "WalletAliasSource_source_idx" ON "WalletAliasSource"("source");
+CREATE INDEX "WalletAliasSource_createdAt_idx" ON "WalletAliasSource"("createdAt");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -78,6 +78,43 @@ model ReferralCode {
   @@index([ownerAddress])
 }
 
+model WalletCanonicalIdentity {
+  id        String   @id
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  aliases WalletAlias[]
+
+  @@index([createdAt])
+}
+
+model WalletAlias {
+  id          String   @id @default(uuid())
+  canonicalId String
+  alias       String
+  source      String
+  aliasKey    String   @unique
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  canonical WalletCanonicalIdentity @relation(fields: [canonicalId], references: [id], onDelete: Cascade)
+
+  @@index([canonicalId])
+  @@index([source])
+  @@index([createdAt])
+}
+
+model WalletAliasSource {
+  id          String   @id @default(uuid())
+  source      String   @unique
+  displayName String?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@index([source])
+  @@index([createdAt])
+}
+
 model AdminAuditLog {
   id         String   @id
   action     String

--- a/backend/src/__tests__/referral.test.ts
+++ b/backend/src/__tests__/referral.test.ts
@@ -2,6 +2,7 @@ import request from 'supertest';
 import app from '../index';
 import { getPrismaClient, disconnectPrismaClient } from '../prismaClient';
 import { referralService } from '../referralService';
+import { walletAliasMappingService } from '../walletAliasService';
 import { VALID_TEST_WALLET, SECOND_TEST_WALLET, THIRD_TEST_WALLET } from './setup';
 
 // Use the centralized Prisma Client instance
@@ -20,6 +21,7 @@ describe('Referral System Integration', () => {
     await prisma.referral.deleteMany();
     await prisma.referralCode.deleteMany();
     await prisma.transaction.deleteMany();
+    await walletAliasMappingService.resetForTests();
 
     // Setup referral code
     await referralService.createReferralCode(referrerWallet, referralCode);
@@ -155,6 +157,39 @@ describe('Referral System Integration', () => {
       
       expect(response.body.total_reward_earned).toBe('0.000001');
       expect(response.body.total_reward_earned).toMatch(/^\d+\.\d{6}$/);
+    });
+  });
+
+  describe('Persisted wallet alias referral attribution', () => {
+    it('uses persisted canonical wallet aliases after cache hydration', async () => {
+      const prisma = getPrisma();
+      await prisma.referral.deleteMany();
+      await prisma.referralCode.deleteMany();
+      await prisma.transaction.deleteMany();
+      await walletAliasMappingService.resetForTests();
+
+      const persistedReferralCode = 'ALIAS2026';
+      await referralService.createReferralCode(referrerWallet, persistedReferralCode);
+      await walletAliasMappingService.linkProviderIdentity(
+        referredWallet,
+        'stellar',
+        'wallet-connect-referred',
+        'walletconnect',
+      );
+
+      await walletAliasMappingService.loadFromDatabase(true);
+      await referralService.recordDeposit(referredWallet.toLowerCase(), persistedReferralCode);
+
+      const referral = await prisma.referral.findUnique({
+        where: { referredAddress: referredWallet },
+      });
+
+      expect(referral).toBeDefined();
+      expect(referral?.referrerAddress).toBe(referrerWallet);
+      expect(referral?.firstDepositAt).not.toBeNull();
+      expect(await walletAliasMappingService.resolveCanonicalWallet('wallet-connect-referred', 'walletconnect')).toBe(
+        referredWallet,
+      );
     });
   });
 });

--- a/backend/src/__tests__/walletAliasEndpoints.test.ts
+++ b/backend/src/__tests__/walletAliasEndpoints.test.ts
@@ -1,10 +1,22 @@
 import request from 'supertest';
 import app from '../index';
+import { registerApiKey } from '../middleware/apiKeyAuth';
+import { disconnectPrismaClient } from '../prismaClient';
+import { walletAliasMappingService } from '../walletAliasService';
 import { VALID_TEST_WALLET, SECOND_TEST_WALLET } from './setup';
 
 describe('Wallet alias API endpoints', () => {
   const stellarWallet = VALID_TEST_WALLET;
   const providerAlias = 'wallet-connect-test-alias';
+  const authHeader = { Authorization: `ApiKey ${process.env.ADMIN_API_KEY || 'test-admin-key'}` };
+
+  beforeEach(async () => {
+    await walletAliasMappingService.resetForTests();
+  });
+
+  afterAll(async () => {
+    await disconnectPrismaClient();
+  });
 
   it('POST /api/v1/wallet-aliases/link links provider aliases to a canonical identity', async () => {
     const res = await request(app)
@@ -59,21 +71,87 @@ describe('Wallet alias API endpoints', () => {
     expect(res.body.aliases).toEqual(expect.arrayContaining([stellarWallet, providerAlias]));
     expect(res.body.sources).toEqual(expect.arrayContaining(['stellar', 'walletconnect']));
   });
+
+  it('GET /admin/wallet-aliases lists persisted identity groups', async () => {
+    const linked = await request(app)
+      .post('/api/v1/wallet-aliases/link')
+      .send({
+        primaryAlias: stellarWallet,
+        primarySource: 'stellar',
+        linkedAlias: providerAlias,
+        linkedSource: 'walletconnect',
+      });
+
+    const res = await request(app).get('/admin/wallet-aliases').set(authHeader);
+
+    expect(res.status).toBe(200);
+    expect(res.body.count).toBe(1);
+    expect(res.body.groups[0].canonicalId).toBe(linked.body.canonicalId);
+    expect(res.body.groups[0].aliases).toEqual(expect.arrayContaining([stellarWallet, providerAlias]));
+  });
+
+  it('DELETE /admin/wallet-aliases/:canonicalId deletes an identity group', async () => {
+    const linked = await request(app)
+      .post('/api/v1/wallet-aliases/link')
+      .send({
+        primaryAlias: stellarWallet,
+        primarySource: 'stellar',
+        linkedAlias: providerAlias,
+        linkedSource: 'walletconnect',
+      });
+
+    const deleted = await request(app)
+      .delete(`/admin/wallet-aliases/${linked.body.canonicalId}`)
+      .set(authHeader);
+
+    expect(deleted.status).toBe(200);
+    expect(deleted.body.aliasesDeleted).toBe(2);
+
+    const resolved = await request(app)
+      .get('/api/v1/wallet-aliases/resolve')
+      .query({ alias: providerAlias, source: 'walletconnect' });
+
+    expect(resolved.status).toBe(404);
+  });
+
+  it('DELETE /admin/wallet-aliases/:canonicalId rejects viewer API keys', async () => {
+    registerApiKey('wallet-alias-viewer-key', { role: 'viewer' });
+    const linked = await request(app)
+      .post('/api/v1/wallet-aliases/link')
+      .send({
+        primaryAlias: stellarWallet,
+        primarySource: 'stellar',
+        linkedAlias: providerAlias,
+        linkedSource: 'walletconnect',
+      });
+
+    const res = await request(app)
+      .delete(`/admin/wallet-aliases/${linked.body.canonicalId}`)
+      .set('Authorization', 'ApiKey wallet-alias-viewer-key');
+
+    expect(res.status).toBe(403);
+  });
 });
 
 describe('Auth login wallet alias integration', () => {
+  const loginWallet = 'GBJAACGKIIH72M5FOGVJGLARM43HC7JYE5DMMVQWZI5UUCC6YNUA37EH';
+
+  beforeEach(async () => {
+    await walletAliasMappingService.resetForTests();
+  });
+
   it('registers provider aliases during login and returns canonical wallet metadata', async () => {
     const res = await request(app)
       .post('/api/v1/auth/login')
       .send({
-        walletAddress: VALID_TEST_WALLET,
+        walletAddress: loginWallet,
         source: 'stellar',
         providerAlias: 'lobstr-session-alias',
         providerSource: 'lobstr',
       });
 
     expect(res.status).toBe(200);
-    expect(res.body.canonicalWallet).toBe(VALID_TEST_WALLET);
+    expect(res.body.canonicalWallet).toBe(loginWallet);
     expect(res.body.canonicalId).toMatch(/^wallet-alias:/);
     expect(res.body.accessToken).toBeDefined();
   });

--- a/backend/src/__tests__/walletAliasService.test.ts
+++ b/backend/src/__tests__/walletAliasService.test.ts
@@ -1,71 +1,106 @@
+import { getPrismaClient, disconnectPrismaClient } from '../prismaClient';
 import { WalletAliasMappingService } from '../walletAliasService';
 import { VALID_TEST_WALLET, SECOND_TEST_WALLET } from './setup';
 
 describe('WalletAliasMappingService', () => {
-  it('normalizes casing and whitespace for a single provider alias', () => {
-    const service = new WalletAliasMappingService();
+  const service = new WalletAliasMappingService();
 
-    const mapping = service.registerAlias(`  ${VALID_TEST_WALLET.toLowerCase()}  `, 'stellar');
+  beforeEach(async () => {
+    await service.resetForTests();
+  });
+
+  afterAll(async () => {
+    await disconnectPrismaClient();
+  });
+
+  it('normalizes casing and whitespace for a single provider alias', async () => {
+    const mapping = await service.registerAlias(`  ${VALID_TEST_WALLET.toLowerCase()}  `, 'stellar');
 
     expect(mapping.canonicalId).toMatch(/^wallet-alias:/);
     expect(mapping.aliases).toEqual([VALID_TEST_WALLET]);
     expect(mapping.sources).toEqual(['stellar']);
-    expect(service.resolveAlias(VALID_TEST_WALLET.toLowerCase(), 'stellar')?.canonicalId).toBe(mapping.canonicalId);
+    expect((await service.resolveAlias(VALID_TEST_WALLET.toLowerCase(), 'stellar'))?.canonicalId).toBe(mapping.canonicalId);
   });
 
-  it('links aliases from different providers to the same canonical identity', () => {
-    const service = new WalletAliasMappingService();
-
-    const first = service.registerAlias(VALID_TEST_WALLET, 'stellar');
-    const second = service.registerAlias('wallet-connect-alias', 'walletconnect', first.canonicalId);
+  it('links aliases from different providers to the same canonical identity', async () => {
+    const first = await service.registerAlias(VALID_TEST_WALLET, 'stellar');
+    const second = await service.registerAlias('wallet-connect-alias', 'walletconnect', first.canonicalId);
 
     expect(second.canonicalId).toBe(first.canonicalId);
     expect(second.aliases).toEqual(expect.arrayContaining([VALID_TEST_WALLET, 'wallet-connect-alias']));
     expect(second.sources).toEqual(expect.arrayContaining(['stellar', 'walletconnect']));
-    expect(service.resolveAlias('wallet-connect-alias', 'walletconnect')?.canonicalId).toBe(first.canonicalId);
+    expect((await service.resolveAlias('wallet-connect-alias', 'walletconnect'))?.canonicalId).toBe(first.canonicalId);
   });
 
-  it('preserves a canonical identity when a previously linked alias is registered again', () => {
-    const service = new WalletAliasMappingService();
-
-    const first = service.registerAlias('wallet-connect-alias', 'walletconnect');
-    const second = service.registerAlias('WALLET-CONNECT-ALIAS', 'walletconnect');
+  it('preserves a canonical identity when a previously linked alias is registered again', async () => {
+    const first = await service.registerAlias('wallet-connect-alias', 'walletconnect');
+    const second = await service.registerAlias('WALLET-CONNECT-ALIAS', 'walletconnect');
 
     expect(second.canonicalId).toBe(first.canonicalId);
-    expect(service.getIdentityLinks(first.canonicalId)?.aliases).toEqual(['wallet-connect-alias']);
-    expect(service.getIdentityLinks(first.canonicalId)?.sources).toEqual(['walletconnect']);
+    expect((await service.getIdentityLinks(first.canonicalId))?.aliases).toEqual(['wallet-connect-alias']);
+    expect((await service.getIdentityLinks(first.canonicalId))?.sources).toEqual(['walletconnect']);
   });
 
-  it('normalizes provider names across formatting variants to the same identity', () => {
-    const service = new WalletAliasMappingService();
-
-    const first = service.registerAlias('wallet-connect-alias', 'Wallet Connect');
-    const second = service.registerAlias('wallet-connect-alias', 'wallet-connect');
+  it('normalizes provider names across formatting variants to the same identity', async () => {
+    const first = await service.registerAlias('wallet-connect-alias', 'Wallet Connect');
+    const second = await service.registerAlias('wallet-connect-alias', 'wallet-connect');
 
     expect(first.canonicalId).toBe(second.canonicalId);
-    expect(service.getIdentityLinks(first.canonicalId)?.sources).toEqual(['walletconnect']);
+    expect((await service.getIdentityLinks(first.canonicalId))?.sources).toEqual(['walletconnect']);
   });
 
-  it('resolves linked provider aliases to the canonical Stellar wallet', () => {
-    const service = new WalletAliasMappingService();
-
-    service.linkProviderIdentity(
+  it('resolves linked provider aliases to the canonical Stellar wallet', async () => {
+    await service.linkProviderIdentity(
       VALID_TEST_WALLET,
       'stellar',
       'wallet-connect-alias',
       'walletconnect',
     );
 
-    expect(service.resolveCanonicalWallet('wallet-connect-alias', 'walletconnect')).toBe(
+    expect(await service.resolveCanonicalWallet('wallet-connect-alias', 'walletconnect')).toBe(
       VALID_TEST_WALLET,
     );
     expect(
-      service.areSameIdentity(
+      await service.areSameIdentity(
         VALID_TEST_WALLET,
         'stellar',
         'wallet-connect-alias',
         'walletconnect',
       ),
     ).toBe(true);
+  });
+
+  it('hydrates persisted aliases into a fresh service instance', async () => {
+    const first = await service.linkProviderIdentity(
+      VALID_TEST_WALLET,
+      'stellar',
+      'wallet-connect-alias',
+      'walletconnect',
+    );
+
+    const freshService = new WalletAliasMappingService();
+    await freshService.loadFromDatabase();
+
+    expect((await freshService.resolveAlias('wallet-connect-alias', 'walletconnect'))?.canonicalId).toBe(
+      first.canonicalId,
+    );
+    expect(await freshService.resolveCanonicalWallet('wallet-connect-alias', 'walletconnect')).toBe(
+      VALID_TEST_WALLET,
+    );
+  });
+
+  it('persists merge behavior when an alias moves between canonical groups', async () => {
+    const first = await service.registerAlias('wallet-connect-alias', 'walletconnect');
+    const second = await service.registerAlias(SECOND_TEST_WALLET, 'stellar');
+    const merged = await service.registerAlias('wallet-connect-alias', 'walletconnect', second.canonicalId);
+
+    expect(merged.canonicalId).toBe(second.canonicalId);
+    expect(await service.getIdentityLinks(first.canonicalId)).toBeNull();
+    expect((await service.resolveAlias('wallet-connect-alias', 'walletconnect'))?.canonicalId).toBe(second.canonicalId);
+
+    const prisma = getPrismaClient();
+    await expect(
+      prisma.walletCanonicalIdentity.findUnique({ where: { id: first.canonicalId } }),
+    ).resolves.toBeNull();
   });
 });

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -619,7 +619,7 @@ export async function loginHandler(req: Request, res: Response): Promise<void> {
 
   const normalizedAddress = normalizeWalletAddress(walletAddress.trim());
   const identitySource = typeof source === 'string' && source.trim() ? source : 'stellar';
-  const mapping = walletAliasMappingService.registerAlias(normalizedAddress, identitySource);
+  const mapping = await walletAliasMappingService.registerAlias(normalizedAddress, identitySource);
 
   if (
     typeof providerAlias === 'string' &&
@@ -627,10 +627,10 @@ export async function loginHandler(req: Request, res: Response): Promise<void> {
     typeof providerSource === 'string' &&
     providerSource.trim()
   ) {
-    walletAliasMappingService.registerAlias(providerAlias, providerSource, mapping.canonicalId);
+    await walletAliasMappingService.registerAlias(providerAlias, providerSource, mapping.canonicalId);
   }
 
-  const canonicalWallet = walletAliasMappingService.resolveCanonicalWallet(
+  const canonicalWallet = await walletAliasMappingService.resolveCanonicalWallet(
     normalizedAddress,
     identitySource,
   );

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -85,6 +85,7 @@ import { GracefulShutdownHandler } from './gracefulShutdown';
 import { db } from './database';
 import vaultRouter from './vaultEndpoints';
 import walletAliasRouter from './walletAliasEndpoints';
+import { walletAliasMappingService } from './walletAliasService';
 import transactionRouter from './transactionEndpoints';
 import {
   buildPortfolioHoldingsResponse,
@@ -227,6 +228,12 @@ const cacheVaultMetricsTtl = parseInt(process.env.CACHE_TTL_MS || process.env.CA
 
 // Configure logger
 logger.configure(logLevel);
+
+void walletAliasMappingService.loadFromDatabase().catch((error) => {
+  logger.log('error', 'Failed to warm wallet alias cache', {
+    error: error instanceof Error ? error.message : String(error),
+  });
+});
 
 // Health check cache to track dependency status
 const cache = new NodeCache({ stdTTL: 30 });
@@ -1928,6 +1935,63 @@ app.get('/admin/allowlist', validateApiKey, (_req: Request, res: Response) => {
     addresses: listAddresses(),
     count: allowlistSize(),
     enabled: process.env.ALLOWLIST_ENABLED !== 'false',
+  });
+});
+
+/**
+ * GET /admin/wallet-aliases
+ * Lists persisted wallet alias identity groups.
+ * Requires API key authentication.
+ */
+app.get('/admin/wallet-aliases', validateApiKey, async (_req: Request, res: Response) => {
+  const groups = await walletAliasMappingService.listIdentityLinks();
+  res.json({
+    groups,
+    count: groups.length,
+  });
+});
+
+/**
+ * DELETE /admin/wallet-aliases/:canonicalId
+ * Deletes a canonical wallet alias group and all linked aliases.
+ * Requires API key authentication.
+ */
+app.delete('/admin/wallet-aliases/:canonicalId', validateApiKey, async (req: Request, res: Response) => {
+  const { canonicalId } = req.params;
+  const existing = await walletAliasMappingService.getIdentityLinks(canonicalId);
+
+  if (!existing) {
+    res.status(404).json({
+      error: 'Not Found',
+      status: 404,
+      message: 'Canonical identity not found',
+    });
+    return;
+  }
+
+  const deleted = await walletAliasMappingService.deleteIdentityGroup(canonicalId);
+  if (!deleted) {
+    res.status(404).json({
+      error: 'Not Found',
+      status: 404,
+      message: 'Canonical identity not found',
+    });
+    return;
+  }
+
+  const actor = resolveActingAdminAddress(req);
+  void recordAdminAuditLog(req, 'wallet-alias.delete', 200, {
+    actor,
+    canonicalId,
+    aliases: existing.aliases,
+    sources: existing.sources,
+  });
+
+  res.status(200).json({
+    message: 'Wallet alias group deleted',
+    canonicalId,
+    aliasesDeleted: existing.aliases.length,
+    sources: existing.sources,
   });
 });
 

--- a/backend/src/middleware/rbac.ts
+++ b/backend/src/middleware/rbac.ts
@@ -91,6 +91,7 @@ const ADMIN_ROUTE_RULES: RouteRule[] = [
   { methods: ['POST'], pattern: /^\/admin\/cache\/invalidate$/, permission: Permission.CONFIG_WRITE },
   { methods: ['DELETE'], pattern: /^\/admin\/cache$/, permission: Permission.CONFIG_WRITE },
   { methods: ['POST'], pattern: /^\/admin\/withdrawal-limits\/override$/, permission: Permission.CONFIG_WRITE },
+  { methods: ['DELETE'], pattern: /^\/admin\/wallet-aliases\/[^/]+$/, permission: Permission.CONFIG_WRITE },
 
   // Allowlist
   { methods: ['POST'], pattern: /^\/admin\/allowlist\/add$/, permission: Permission.ALLOWLIST_WRITE },

--- a/backend/src/referralService.ts
+++ b/backend/src/referralService.ts
@@ -23,7 +23,7 @@ export class ReferralService {
    */
   async recordDeposit(walletAddress: string, referralCode?: string): Promise<void> {
     const prisma = getPrisma();
-    const normalizedReferred = walletAliasMappingService.resolveCanonicalWallet(
+    const normalizedReferred = await walletAliasMappingService.resolveCanonicalWallet(
       walletAddress,
       'stellar',
     );

--- a/backend/src/walletAliasEndpoints.ts
+++ b/backend/src/walletAliasEndpoints.ts
@@ -13,7 +13,7 @@ router.post(
   '/link',
   readsLimiter,
   validate({ body: WalletAliasLinkSchema }),
-  (req: Request, res: Response) => {
+  async (req: Request, res: Response) => {
     const { primaryAlias, primarySource, linkedAlias, linkedSource } = req.body as {
       primaryAlias: string;
       primarySource: string;
@@ -22,9 +22,13 @@ router.post(
     };
 
     try {
-      const mapping = walletAliasMappingService.linkProviderIdentity(
+      const mapping = await walletAliasMappingService.linkProviderIdentity(
         primaryAlias,
         primarySource,
+        linkedAlias,
+        linkedSource,
+      );
+      const canonicalWallet = await walletAliasMappingService.resolveCanonicalWallet(
         linkedAlias,
         linkedSource,
       );
@@ -33,10 +37,7 @@ router.post(
         canonicalId: mapping.canonicalId,
         aliases: mapping.aliases,
         sources: mapping.sources,
-        canonicalWallet: walletAliasMappingService.resolveCanonicalWallet(
-          linkedAlias,
-          linkedSource,
-        ),
+        canonicalWallet,
       });
     } catch (err) {
       res.status(400).json({
@@ -56,9 +57,9 @@ router.get(
   '/resolve',
   readsLimiter,
   validate({ query: WalletAliasResolveQuerySchema }),
-  (req: Request, res: Response) => {
+  async (req: Request, res: Response) => {
     const { alias, source } = req.query as { alias: string; source: string };
-    const mapping = walletAliasMappingService.resolveAlias(alias, source);
+    const mapping = await walletAliasMappingService.resolveAlias(alias, source);
 
     if (!mapping) {
       res.status(404).json({
@@ -69,9 +70,11 @@ router.get(
       return;
     }
 
+    const canonicalWallet = await walletAliasMappingService.resolveCanonicalWallet(alias, source);
+
     res.status(200).json({
       ...mapping,
-      canonicalWallet: walletAliasMappingService.resolveCanonicalWallet(alias, source),
+      canonicalWallet,
     });
   },
 );
@@ -80,8 +83,8 @@ router.get(
  * GET /api/v1/wallet-aliases/:canonicalId
  * Returns all aliases linked to a canonical identity.
  */
-router.get('/:canonicalId', readsLimiter, (req: Request, res: Response) => {
-  const mapping = walletAliasMappingService.getIdentityLinks(req.params.canonicalId);
+router.get('/:canonicalId', readsLimiter, async (req: Request, res: Response) => {
+  const mapping = await walletAliasMappingService.getIdentityLinks(req.params.canonicalId);
 
   if (!mapping) {
     res.status(404).json({

--- a/backend/src/walletAliasService.ts
+++ b/backend/src/walletAliasService.ts
@@ -1,3 +1,5 @@
+import { PrismaClient } from '@prisma/client';
+import { getPrismaClient } from './prismaClient';
 import { isValidStellarAddress, normalizeWalletAddress } from './walletUtils';
 
 export interface WalletAliasIdentifier {
@@ -11,14 +13,38 @@ export interface WalletAliasMapping {
   sources: string[];
 }
 
+type PrismaTransaction = Parameters<Parameters<PrismaClient['$transaction']>[0]>[0];
+type PrismaExecutor = PrismaClient | PrismaTransaction;
+
 export class WalletAliasMappingService {
   private aliasToCanonical = new Map<string, string>();
   private aliasMetadata = new Map<string, { alias: string; source: string }>();
   private canonicalToAliases = new Map<string, Set<string>>();
   private canonicalToSources = new Map<string, Set<string>>();
   private canonicalIdCounter = 0;
+  private hydrated = false;
+  private hydrationPromise: Promise<void> | null = null;
 
-  registerAlias(alias: string, source: string, canonicalId?: string): WalletAliasMapping {
+  constructor(private readonly prismaProvider: () => PrismaClient = getPrismaClient) {}
+
+  async loadFromDatabase(force = false): Promise<void> {
+    if (this.hydrated && !force) {
+      return;
+    }
+
+    if (this.hydrationPromise && !force) {
+      return this.hydrationPromise;
+    }
+
+    this.hydrationPromise = this.loadFromDatabaseInternal();
+    try {
+      await this.hydrationPromise;
+    } finally {
+      this.hydrationPromise = null;
+    }
+  }
+
+  async registerAlias(alias: string, source: string, canonicalId?: string): Promise<WalletAliasMapping> {
     const normalizedSource = this.normalizeSource(source);
     const normalizedAlias = this.normalizeAlias(alias, normalizedSource);
 
@@ -30,23 +56,53 @@ export class WalletAliasMappingService {
       throw new Error('Source value is required');
     }
 
+    await this.loadFromDatabase();
+
     const aliasKey = this.buildAliasKey(normalizedAlias, normalizedSource);
-    const existingCanonicalId = this.aliasToCanonical.get(aliasKey);
-    const targetCanonicalId = canonicalId || existingCanonicalId || this.createCanonicalId();
+    const prisma = this.prismaProvider();
+    const result = await prisma.$transaction(async (tx) => {
+      await tx.walletAliasSource.upsert({
+        where: { source: normalizedSource },
+        create: { source: normalizedSource },
+        update: {},
+      });
 
-    if (existingCanonicalId && existingCanonicalId !== targetCanonicalId) {
-      this.mergeCanonicalMappings(existingCanonicalId, targetCanonicalId);
-    }
+      const existing = await tx.walletAlias.findUnique({ where: { aliasKey } });
+      const targetCanonicalId = canonicalId || existing?.canonicalId || await this.createCanonicalId(tx);
 
-    this.aliasToCanonical.set(aliasKey, targetCanonicalId);
-    this.aliasMetadata.set(aliasKey, { alias: normalizedAlias, source: normalizedSource });
+      await tx.walletCanonicalIdentity.upsert({
+        where: { id: targetCanonicalId },
+        create: { id: targetCanonicalId },
+        update: {},
+      });
 
-    this.ensureCanonicalEntry(targetCanonicalId, normalizedAlias, normalizedSource);
+      if (existing && existing.canonicalId !== targetCanonicalId) {
+        await this.mergeCanonicalMappingsInDatabase(existing.canonicalId, targetCanonicalId, tx);
+      }
 
-    return this.getIdentityLinks(targetCanonicalId) || this.createEmptyMapping(targetCanonicalId);
+      await tx.walletAlias.upsert({
+        where: { aliasKey },
+        create: {
+          canonicalId: targetCanonicalId,
+          alias: normalizedAlias,
+          source: normalizedSource,
+          aliasKey,
+        },
+        update: {
+          canonicalId: targetCanonicalId,
+          alias: normalizedAlias,
+          source: normalizedSource,
+        },
+      });
+
+      return this.getIdentityLinksFromDatabase(targetCanonicalId, tx);
+    });
+
+    await this.loadFromDatabase(true);
+    return result || this.createEmptyMapping(canonicalId || '');
   }
 
-  resolveAlias(alias: string, source: string): WalletAliasMapping | null {
+  async resolveAlias(alias: string, source: string): Promise<WalletAliasMapping | null> {
     const normalizedSource = this.normalizeSource(source);
     const normalizedAlias = this.normalizeAlias(alias, normalizedSource);
 
@@ -54,16 +110,177 @@ export class WalletAliasMappingService {
       return null;
     }
 
-    const canonicalId = this.aliasToCanonical.get(this.buildAliasKey(normalizedAlias, normalizedSource));
+    await this.loadFromDatabase();
 
-    if (!canonicalId) {
+    const aliasKey = this.buildAliasKey(normalizedAlias, normalizedSource);
+    const cachedCanonicalId = this.aliasToCanonical.get(aliasKey);
+    if (cachedCanonicalId) {
+      return this.getIdentityLinksFromCache(cachedCanonicalId);
+    }
+
+    const row = await this.prismaProvider().walletAlias.findUnique({ where: { aliasKey } });
+    if (!row) {
       return null;
     }
 
-    return this.getIdentityLinks(canonicalId);
+    await this.loadFromDatabase(true);
+    return this.getIdentityLinksFromCache(row.canonicalId);
   }
 
-  getIdentityLinks(canonicalId: string): WalletAliasMapping | null {
+  async getIdentityLinks(canonicalId: string): Promise<WalletAliasMapping | null> {
+    await this.loadFromDatabase();
+
+    const cached = this.getIdentityLinksFromCache(canonicalId);
+    if (cached) {
+      return cached;
+    }
+
+    const mapping = await this.getIdentityLinksFromDatabase(canonicalId, this.prismaProvider());
+    if (!mapping) {
+      return null;
+    }
+
+    await this.loadFromDatabase(true);
+    return this.getIdentityLinksFromCache(canonicalId);
+  }
+
+  async listIdentityLinks(): Promise<WalletAliasMapping[]> {
+    await this.loadFromDatabase();
+
+    return Array.from(this.canonicalToAliases.keys())
+      .sort()
+      .map((canonicalId) => this.getIdentityLinksFromCache(canonicalId))
+      .filter((mapping): mapping is WalletAliasMapping => Boolean(mapping));
+  }
+
+  async deleteIdentityGroup(canonicalId: string): Promise<boolean> {
+    await this.loadFromDatabase();
+
+    const existing = await this.prismaProvider().walletCanonicalIdentity.findUnique({
+      where: { id: canonicalId },
+    });
+
+    if (!existing) {
+      return false;
+    }
+
+    await this.prismaProvider().walletCanonicalIdentity.delete({
+      where: { id: canonicalId },
+    });
+    await this.loadFromDatabase(true);
+
+    return true;
+  }
+
+  /**
+   * Links a provider-specific alias to an existing canonical identity.
+   */
+  async linkProviderIdentity(
+    primaryAlias: string,
+    primarySource: string,
+    linkedAlias: string,
+    linkedSource: string,
+  ): Promise<WalletAliasMapping> {
+    const primary = await this.registerAlias(primaryAlias, primarySource);
+    return this.registerAlias(linkedAlias, linkedSource, primary.canonicalId);
+  }
+
+  /**
+   * Resolves any provider alias to the canonical Stellar wallet when one exists
+   * in the identity group. Prevents duplicate records for the same user across
+   * wallet providers.
+   */
+  async resolveCanonicalWallet(alias: string, source: string): Promise<string> {
+    const normalizedSource = this.normalizeSource(source);
+    const normalizedAlias = this.normalizeAlias(alias, normalizedSource);
+
+    if (!normalizedAlias) {
+      return '';
+    }
+
+    if (isValidStellarAddress(normalizedAlias)) {
+      const stellar = normalizeWalletAddress(normalizedAlias);
+      const existing = await this.resolveAlias(stellar, 'stellar');
+      if (!existing) {
+        await this.registerAlias(stellar, 'stellar');
+      }
+      return stellar;
+    }
+
+    const mapping = await this.resolveAlias(normalizedAlias, normalizedSource);
+    if (!mapping) {
+      await this.registerAlias(normalizedAlias, normalizedSource);
+      return normalizedAlias;
+    }
+
+    const stellarAlias = mapping.aliases.find((entry) => isValidStellarAddress(entry));
+    return stellarAlias ? normalizeWalletAddress(stellarAlias) : normalizedAlias;
+  }
+
+  /**
+   * Returns true when two aliases refer to the same canonical identity.
+   */
+  async areSameIdentity(aliasA: string, sourceA: string, aliasB: string, sourceB: string): Promise<boolean> {
+    const mappingA = await this.resolveAlias(aliasA, sourceA);
+    const mappingB = await this.resolveAlias(aliasB, sourceB);
+
+    if (!mappingA || !mappingB) {
+      return false;
+    }
+
+    return mappingA.canonicalId === mappingB.canonicalId;
+  }
+
+  async resetForTests(): Promise<void> {
+    this.clearCache();
+    this.hydrated = false;
+    this.hydrationPromise = null;
+
+    const prisma = this.prismaProvider();
+    await prisma.walletAlias.deleteMany();
+    await prisma.walletAliasSource.deleteMany();
+    await prisma.walletCanonicalIdentity.deleteMany();
+  }
+
+  private async loadFromDatabaseInternal(): Promise<void> {
+    const rows = await this.prismaProvider().walletAlias.findMany({
+      orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+    });
+
+    this.clearCache();
+
+    for (const row of rows) {
+      this.addAliasToCache(row.canonicalId, row.alias, row.source);
+      this.canonicalIdCounter = Math.max(
+        this.canonicalIdCounter,
+        this.parseCanonicalIdCounter(row.canonicalId),
+      );
+    }
+
+    this.hydrated = true;
+  }
+
+  private async getIdentityLinksFromDatabase(
+    canonicalId: string,
+    prisma: PrismaExecutor,
+  ): Promise<WalletAliasMapping | null> {
+    const rows = await prisma.walletAlias.findMany({
+      where: { canonicalId },
+      orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+    });
+
+    if (rows.length === 0) {
+      return null;
+    }
+
+    return {
+      canonicalId,
+      aliases: Array.from(new Set(rows.map((row) => row.alias))),
+      sources: Array.from(new Set(rows.map((row) => row.source))),
+    };
+  }
+
+  private getIdentityLinksFromCache(canonicalId: string): WalletAliasMapping | null {
     const aliases = this.canonicalToAliases.get(canonicalId);
     const sources = this.canonicalToSources.get(canonicalId);
 
@@ -78,66 +295,11 @@ export class WalletAliasMappingService {
     };
   }
 
-  /**
-   * Links a provider-specific alias to an existing canonical identity.
-   */
-  linkProviderIdentity(
-    primaryAlias: string,
-    primarySource: string,
-    linkedAlias: string,
-    linkedSource: string,
-  ): WalletAliasMapping {
-    const primary = this.registerAlias(primaryAlias, primarySource);
-    return this.registerAlias(linkedAlias, linkedSource, primary.canonicalId);
-  }
+  private addAliasToCache(canonicalId: string, alias: string, source: string): void {
+    const aliasKey = this.buildAliasKey(alias, source);
+    this.aliasToCanonical.set(aliasKey, canonicalId);
+    this.aliasMetadata.set(aliasKey, { alias, source });
 
-  /**
-   * Resolves any provider alias to the canonical Stellar wallet when one exists
-   * in the identity group. Prevents duplicate records for the same user across
-   * wallet providers.
-   */
-  resolveCanonicalWallet(alias: string, source: string): string {
-    const normalizedSource = this.normalizeSource(source);
-    const normalizedAlias = this.normalizeAlias(alias, normalizedSource);
-
-    if (!normalizedAlias) {
-      return '';
-    }
-
-    if (isValidStellarAddress(normalizedAlias)) {
-      const stellar = normalizeWalletAddress(normalizedAlias);
-      const existing = this.resolveAlias(stellar, 'stellar');
-      if (!existing) {
-        this.registerAlias(stellar, 'stellar');
-      }
-      return stellar;
-    }
-
-    const mapping = this.resolveAlias(normalizedAlias, normalizedSource);
-    if (!mapping) {
-      this.registerAlias(normalizedAlias, normalizedSource);
-      return normalizedAlias;
-    }
-
-    const stellarAlias = mapping.aliases.find((entry) => isValidStellarAddress(entry));
-    return stellarAlias ? normalizeWalletAddress(stellarAlias) : normalizedAlias;
-  }
-
-  /**
-   * Returns true when two aliases refer to the same canonical identity.
-   */
-  areSameIdentity(aliasA: string, sourceA: string, aliasB: string, sourceB: string): boolean {
-    const mappingA = this.resolveAlias(aliasA, sourceA);
-    const mappingB = this.resolveAlias(aliasB, sourceB);
-
-    if (!mappingA || !mappingB) {
-      return false;
-    }
-
-    return mappingA.canonicalId === mappingB.canonicalId;
-  }
-
-  private ensureCanonicalEntry(canonicalId: string, alias: string, source: string): void {
     const aliases = this.canonicalToAliases.get(canonicalId) || new Set<string>();
     const sources = this.canonicalToSources.get(canonicalId) || new Set<string>();
 
@@ -148,35 +310,19 @@ export class WalletAliasMappingService {
     this.canonicalToSources.set(canonicalId, sources);
   }
 
-  private mergeCanonicalMappings(existingCanonicalId: string, targetCanonicalId: string): void {
-    const aliases = this.canonicalToAliases.get(existingCanonicalId);
-    const sources = this.canonicalToSources.get(existingCanonicalId);
+  private async mergeCanonicalMappingsInDatabase(
+    existingCanonicalId: string,
+    targetCanonicalId: string,
+    tx: PrismaTransaction,
+  ): Promise<void> {
+    await tx.walletAlias.updateMany({
+      where: { canonicalId: existingCanonicalId },
+      data: { canonicalId: targetCanonicalId },
+    });
 
-    if (aliases) {
-      for (const alias of aliases) {
-        for (const source of sources || []) {
-          const aliasKey = this.buildAliasKey(alias, source);
-          this.aliasToCanonical.set(aliasKey, targetCanonicalId);
-          this.aliasMetadata.set(aliasKey, { alias, source });
-        }
-      }
-    }
-
-    const mergedAliases = this.canonicalToAliases.get(targetCanonicalId) || new Set<string>();
-    const mergedSources = this.canonicalToSources.get(targetCanonicalId) || new Set<string>();
-
-    for (const alias of aliases || []) {
-      mergedAliases.add(alias);
-    }
-
-    for (const source of sources || []) {
-      mergedSources.add(source);
-    }
-
-    this.canonicalToAliases.set(targetCanonicalId, mergedAliases);
-    this.canonicalToSources.set(targetCanonicalId, mergedSources);
-    this.canonicalToAliases.delete(existingCanonicalId);
-    this.canonicalToSources.delete(existingCanonicalId);
+    await tx.walletCanonicalIdentity.deleteMany({
+      where: { id: existingCanonicalId },
+    });
   }
 
   private normalizeAlias(alias: string, source?: string): string {
@@ -207,9 +353,24 @@ export class WalletAliasMappingService {
     return `${source}:${alias}`;
   }
 
-  private createCanonicalId(): string {
-    this.canonicalIdCounter += 1;
-    return `wallet-alias:${this.canonicalIdCounter}`;
+  private async createCanonicalId(tx: PrismaTransaction): Promise<string> {
+    while (true) {
+      this.canonicalIdCounter += 1;
+      const id = `wallet-alias:${this.canonicalIdCounter}`;
+      const existing = await tx.walletCanonicalIdentity.findUnique({ where: { id } });
+      if (!existing) {
+        return id;
+      }
+    }
+  }
+
+  private parseCanonicalIdCounter(canonicalId: string): number {
+    const match = canonicalId.match(/^wallet-alias:(\d+)$/);
+    if (!match) {
+      return 0;
+    }
+
+    return Number.parseInt(match[1], 10) || 0;
   }
 
   private isStellarAddress(alias: string): boolean {
@@ -222,6 +383,14 @@ export class WalletAliasMappingService {
       aliases: [],
       sources: [],
     };
+  }
+
+  private clearCache(): void {
+    this.aliasToCanonical.clear();
+    this.aliasMetadata.clear();
+    this.canonicalToAliases.clear();
+    this.canonicalToSources.clear();
+    this.canonicalIdCounter = 0;
   }
 }
 


### PR DESCRIPTION
### Goal
Persist wallet alias identity groups so alias registrations survive backend restarts and referral attribution continues to resolve canonical wallets.

Closes #859

### Changes
- Add Prisma-backed canonical wallet identity, alias, and source tables.
- Convert wallet alias registration/resolution to DB-backed async operations with cache hydration.
- Add admin alias group list/delete endpoints with existing API-key/RBAC protection.
- Update auth, wallet alias, and referral flows to await canonical alias resolution.
- Document migration behavior for environments with prior in-memory-only aliases.

### Testing
- Passed: cd backend && npx prisma validate --schema prisma/schema.prisma
- Passed: cd backend && npm test -- --runInBand walletAliasService.test.ts walletAliasEndpoints.test.ts
